### PR TITLE
Fix CI: drop uuid v14 override breaking Cypress and Lighthouse on Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Vue 3 + TypeScript portfolio website for [www.jeromefaria.com](https://www.jerom
 - **Frontend**: Vue 3 (Composition API), TypeScript (strict mode)
 - **Build**: Vite with SSG (Static Site Generation)
 - **Styling**: SCSS with BEM methodology
-- **Testing**: Vitest (98%+ coverage), Playwright E2E, axe-core accessibility
+- **Testing**: Vitest (98%+ coverage), Cypress E2E, axe-core accessibility
 - **CI/CD**: GitHub Actions with quality gates
 - **Performance**: Lighthouse CI with performance budgets
 
@@ -58,17 +58,17 @@ npm run test:coverage
 ### E2E Tests
 
 ```bash
-# Run E2E tests
+# Run E2E tests (defaults to Electron, headless)
 npm run test:e2e
 
-# Run with UI
-npm run test:e2e:ui
+# Run against Chrome
+npm run test:e2e:chrome
 
-# Run in headed mode (see browser)
-npm run test:e2e:headed
+# Run against Firefox
+npm run test:e2e:firefox
 
-# Debug mode
-npm run test:e2e:debug
+# Open the Cypress runner
+npm run test:e2e:open
 ```
 
 **E2E Test Coverage**:
@@ -114,8 +114,7 @@ npm run build
 # 3. Performance Audit
 npm run lighthouse
 
-# 4. E2E Tests (requires Playwright browsers)
-npx playwright install  # First time only
+# 4. E2E Tests (Cypress installs its own browser binary on first run)
 npm run test:e2e
 ```
 
@@ -157,16 +156,15 @@ Every push to `master` and pull request triggers a comprehensive CI pipeline wit
 - Performance budget enforcement
 
 ### E2E Tests
-- Cross-browser testing (Chromium, Firefox, WebKit)
-- Mobile device testing (Pixel 5, iPhone 12)
+- Cross-browser testing (Chrome, Firefox, Edge)
 - Accessibility testing with axe-core
-- Visual regression prevention
+- Hash navigation, accordion, lightbox, contact form, and navigation specs
 
-**Quality Gates**: All checks must pass before deployment. Deployment workflow only runs after successful CI completion.
+**Quality Gates**: All four CI jobs (Quality Checks, Build, Lighthouse, E2E) must pass for the CI workflow to be green. Deployment runs on its own workflow and gates on type-check, lint, unit tests with coverage, and the production build.
 
 ## Deployment
 
-The site automatically deploys to GitHub Pages via GitHub Actions when CI passes on `master`.
+The site deploys to GitHub Pages via GitHub Actions on push to `master` once the deploy workflow's pre-deploy checks and build succeed.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10973,17 +10973,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "homepage": "https://jeromefaria.com",
   "overrides": {
     "tmp": "^0.2.4",
-    "unhead": "^2.1.13",
-    "uuid": "^14.0.0"
+    "unhead": "^2.1.13"
   },
   "dependencies": {
     "vue": "^3.5.25",


### PR DESCRIPTION
## Summary

- Drops the `uuid: ^14.0.0` npm override added in `fc7db5a`. uuid v14 is ESM-only, but `@cypress/request` and `@lhci/cli` load it via `require('uuid')`, which throws `ERR_REQUIRE_ESM` on Node 20 — that's why every E2E browser matrix and the Lighthouse job started failing immediately on master, with no test name in the logs. With the override removed, npm resolves uuid back to v8.3.2 for those dev-only consumers.
- Refreshes the README to match the current setup: Cypress instead of Playwright in Tech Stack, real `test:e2e:*` script names, no more `npx playwright install`, accurate browser list, and updated Quality Gates / Deployment paragraphs reflecting the decoupled deploy workflow from #43.

The original audit advisory the override was trying to silence (`GHSA-w5hq-g745-h8pq`) only covers `uuid.v3/v5/v6` (named-UUID buffer bounds). This codebase never calls those, so the moderate warning on dev-only deps is a known false positive.

## Test plan

- [x] `npm ci` reinstalls cleanly with uuid 8.3.2 nested under `@cypress/request` and `@lhci/cli`
- [x] `node -e "require('@cypress/request/lib/auth.js')"` no longer throws `ERR_REQUIRE_ESM`
- [x] `npm run type-check`, `npm run lint`, `npm run test:coverage` (100% lines/statements/functions, 95.41% branches), `node scripts/check-coverage.js`, `npm run build` all pass locally
- [ ] CI run on this PR turns green (E2E + Lighthouse should both pass once the uuid resolution is fixed)

https://claude.ai/code/session_01ThXm8urosX8Wx71oqobE2x

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThXm8urosX8Wx71oqobE2x)_