### PR TITLE
Fix cover images staying invisible when already cached

### DIFF
--- a/src/components/BandcampPlayer.vue
+++ b/src/components/BandcampPlayer.vue
@@ -19,6 +19,7 @@ const props = defineProps({
 });
 
 const {
+  setImageRef,
   imageError,
   imageLoaded,
   webpSrc,
@@ -51,6 +52,7 @@ const handleIframeLoad = () => {
         type="image/webp"
       >
       <img
+        :ref="setImageRef"
         :src="coverImage"
         :alt="`${albumTitle} album cover`"
         loading="lazy"

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -27,6 +27,7 @@ const getCoverImage = (release: Release): string | undefined => {
 };
 
 const {
+  setImageRef,
   imageError,
   imageLoaded,
   webpSrc,
@@ -81,6 +82,7 @@ const isBandcampLink = computed(() => {
         >
         <img
           v-if="'coverImage' in release"
+          :ref="setImageRef"
           :src="release.coverImage"
           :alt="`${release.title} cover`"
           loading="lazy"
@@ -104,6 +106,7 @@ const isBandcampLink = computed(() => {
         >
         <img
           v-if="'coverImage' in release"
+          :ref="setImageRef"
           :src="release.coverImage"
           :alt="`${release.title} cover`"
           loading="lazy"

--- a/src/composables/useImageLoader.test.ts
+++ b/src/composables/useImageLoader.test.ts
@@ -150,4 +150,26 @@ describe('useImageLoader', () => {
       expect(loader.imageLoaded.value).toBe(false);
     });
   });
+
+  describe('setImageRef', () => {
+    it('stores an HTMLImageElement in imageRef', () => {
+      const { loader } = mountWithLoader(TEST_SRC_JPG);
+      const img = document.createElement('img');
+      loader.setImageRef(img);
+      expect(loader.imageRef.value).toBe(img);
+    });
+
+    it('resets imageRef to null when passed null', () => {
+      const { loader } = mountWithLoader(TEST_SRC_JPG);
+      loader.setImageRef(document.createElement('img'));
+      loader.setImageRef(null);
+      expect(loader.imageRef.value).toBeNull();
+    });
+
+    it('ignores non-image elements', () => {
+      const { loader } = mountWithLoader(TEST_SRC_JPG);
+      loader.setImageRef(document.createElement('div'));
+      expect(loader.imageRef.value).toBeNull();
+    });
+  });
 });

--- a/src/composables/useImageLoader.ts
+++ b/src/composables/useImageLoader.ts
@@ -1,8 +1,9 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { ComponentPublicInstance, ComputedRef, Ref } from 'vue';
 import { computed, nextTick, onMounted, ref } from 'vue';
 
 interface UseImageLoaderReturn {
   imageRef: Ref<HTMLImageElement | null>;
+  setImageRef: (el: Element | ComponentPublicInstance | null) => void;
   imageError: Ref<boolean>;
   imageLoaded: Ref<boolean>;
   webpSrc: ComputedRef<string | undefined>;
@@ -22,6 +23,13 @@ export const useImageLoader = (src: string): UseImageLoaderReturn => {
 
   const webpSrc = computed(() => src?.replace(/\.jpg$/, '.webp'));
 
+  // Callback ref: bound via `:ref` in templates so the composable owns the
+  // <img> element. Needed for the already-complete fast-path below to work
+  // when a cached image never re-fires `load` after hydration.
+  const setImageRef = (el: Element | ComponentPublicInstance | null): void => {
+    imageRef.value = el instanceof HTMLImageElement ? el : null;
+  };
+
   onMounted(async () => {
     await nextTick();
     if (imageRef.value?.complete && imageRef.value?.naturalHeight > 0) {
@@ -39,6 +47,7 @@ export const useImageLoader = (src: string): UseImageLoaderReturn => {
 
   return {
     imageRef,
+    setImageRef,
     imageError,
     imageLoaded,
     webpSrc,


### PR DESCRIPTION
## Description
Fixes a rendering bug where album/release cover images could render **invisible** (`opacity: 0`) on repeat visits or hard reloads. Audit Tier-1 finding #1.

## Root cause
The `image-reveal` effect starts at `opacity: 0` and only reveals when the `.is-loaded` class is applied, which is driven by the img's `@load` handler. For an **already-cached** image, the browser does not re-fire `load` after hydration, so `handleImageLoad` never runs and the cover stays hidden.

`useImageLoader` already had an `onMounted` fast-path that reveals when `imageRef.value?.complete && naturalHeight > 0` — but **no component ever bound `imageRef`**, so that path was dead code (only the unit test bound it).

## Changes
- `src/composables/useImageLoader.ts`: add a typed `setImageRef` callback ref (`(el) => imageRef.value = el instanceof HTMLImageElement ? el : null`). A callback ref (bound via `:ref`) is used rather than a plain `Ref` because a template-string ref on a composable-owned `Ref` isn't recognized by `vue-tsc`/`noUnusedLocals`, and a dynamic `:ref` to a `Ref` mis-types under template unwrapping.
- `src/components/ReleaseItem.vue` and `BandcampPlayer.vue`: bind `:ref="setImageRef"` on the cover `<img>`s so the already-complete fast-path runs.
- `src/composables/useImageLoader.test.ts`: add regression tests for `setImageRef` (stores img, resets on null, ignores non-image elements).

## Testing
- `npm run type-check`, `npm run lint` ✅
- `npm run test` ✅ — 208 passing (+3)
- `npm run build` ✅
- Manual: the fast-path now has a bound element; on a cached hard-reload the cover reveals immediately instead of staying transparent. (Hard to assert in happy-dom since it doesn't set real `complete`/`naturalHeight`; the composable contract is unit-tested and the binding is verified by type-check + build.)

## Risk
Low — additive callback ref; existing `@load`/`@error` paths unchanged; only affects the already-complete reveal case that was previously broken.