### PR TITLE
Fix invalid nested anchors in live-event titles

### DIFF
--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 
 import type { LightboxItem, LiveEvent, LiveImage, LiveVideo } from '@/types';
 import { formatEventDate } from '@/utils/dateFormatter';
+import { stripHtml } from '@/utils/formatters';
 
 const props = defineProps<{
   event: LiveEvent;
@@ -14,6 +15,18 @@ const emit = defineEmits<{
 }>();
 
 const formattedDate = computed(() => formatEventDate(props.event.date));
+
+// Some event titles embed a link (festival site or an internal /works ref).
+// Render the title as plain text (the deep-link permalink) and surface the
+// embedded link separately as a trailing icon, avoiding invalid nested anchors.
+const titleText = computed(() => stripHtml(props.event.title));
+
+const titleHref = computed(() => {
+  const match = props.event.title.match(/href="([^"]+)"/);
+  return match ? match[1] : null;
+});
+
+const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? ''));
 
 // Convert LiveImage to LightboxImage
 const convertImagesToLightbox = (images: LiveImage[]): LightboxItem[] => {
@@ -54,8 +67,21 @@ const convertVideosToLightbox = (videos: LiveVideo[]): LightboxItem[] => {
             class="event-title-link"
             :href="`#${event.id}`"
             @click.prevent="emit('update-hash', event.id)"
-            v-html="event.title"
-          />
+          >{{ titleText }}</a>
+          <a
+            v-if="titleHref && titleHrefIsExternal"
+            class="event-title-ref"
+            :href="titleHref"
+            target="_blank"
+            rel="noopener noreferrer"
+            :aria-label="`${titleText} website (opens in a new tab)`"
+          ><span aria-hidden="true">↗</span></a>
+          <RouterLink
+            v-else-if="titleHref"
+            class="event-title-ref"
+            :to="titleHref"
+            :aria-label="`View ${titleText}`"
+          ><span aria-hidden="true">↗</span></RouterLink>
         </strong>
       </p>
       <p class="event-meta">

--- a/src/styles/_pages.scss
+++ b/src/styles/_pages.scss
@@ -378,6 +378,24 @@
       outline-offset: 2px;
     }
   }
+
+  // Trailing icon linking to an embedded festival site / related work
+  .event-title-ref {
+    margin-left: $spacing-1;
+    color: var(--color-text-muted);
+    font-size: 0.85em;
+    text-decoration: none;
+    transition: opacity $transition-base;
+
+    &:hover {
+      opacity: $opacity-70;
+    }
+
+    &:focus-visible {
+      outline: 1px solid var(--color-border);
+      outline-offset: 2px;
+    }
+  }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description
Fixes invalid nested anchors (`<a>` inside `<a>`) in 10 live-event titles — audit Tier-1 finding #2, an accessibility/HTML-validity bug (WCAG 4.1.2 / 2.1.1).

## Root cause
`EventItem` renders the title with `v-html` **inside** the title's own permalink `<a href="#id">`. 10 titles in `live.ts` are themselves `<a>` markup (8 external festival/venue links, 2 internal `/works#aragao` refs), so the output is an anchor nested in an anchor. Browsers auto-close the outer anchor at the inner one, splitting one title into conflicting controls with undefined Tab order and activation.

## Approach (per design decision: "text + ↗ icon")
The title text becomes the plain-text deep-link permalink on **every** event; any embedded link is surfaced as a trailing icon **sibling** (never nested):
- **External** (festival/venue, 8): `↗` opens in a new tab with `rel="noopener noreferrer"` and a descriptive `aria-label` (e.g. "MADEIRADIG website (opens in a new tab)").
- **Internal** (`/works#aragao`, 2): a `RouterLink` → same-tab SPA navigation (a new tab would be wrong for an in-site ref), `aria-label="View Aragão"`.

The `↗` glyph is `aria-hidden`; the accessible name lives on the link.

## Changes
- `src/components/EventItem.vue`: derive `titleText` (`stripHtml`), `titleHref`, and `titleHrefIsExternal`; render text permalink + trailing external `<a>` / internal `<RouterLink>` instead of `v-html` inside the anchor.
- `src/styles/_pages.scss`: add subtle `.event-title-ref` icon styling (muted, hover/focus states, existing tokens).

## Testing
- `npm run type-check`, `npm run lint`, `npm run test` (205), `npm run build` — all ✅
- **Verified in rendered `dist/live.html`:** no anchor-inside-anchor remains; `madeiradig-2011` emits permalink + external ↗; `aragao-funchal` emits permalink + same-tab `/works#aragao`.

## Notes for review
- Deep-linking to any event still works via the `#hash` permalink and accordion; the title text remains the copy-able permalink.
- `EventItem` currently has no unit test — a component-level regression test (assert siblings, not nesting) fits better with the coverage PR (Tier-1 #4), where the component/view test harness will be set up.