### PR TITLE
Add grouped Dependabot config to reduce update-PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot configuration
+# Groups routine npm updates into a single weekly PR (instead of one PR per
+# package) to cut review noise. Major bumps stay ungrouped so breaking changes
+# get individual review. Also keeps GitHub Actions pinned versions current.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # One combined PR for all minor/patch npm updates (security and version).
+      npm-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description
Dependabot was opening **one PR per package** (8 were open simultaneously — #48–#61 — most already superseded by #60's `npm update`). This adds a `.github/dependabot.yml` that consolidates routine updates.

## Config
- **npm**, weekly:
  - `npm-minor-patch` — groups **all** minor/patch version updates into one PR.
  - `npm-security` — groups security updates into one PR.
  - Major bumps stay **ungrouped** → individual review (e.g. a Cypress 14→15 upgrade gets its own PR, not silently batched).
  - `open-pull-requests-limit: 5`.
- **github-actions**, weekly, grouped.

## Context / follow-ups
- The 7 redundant Dependabot PRs and the Cypress-major PR (#61) have been closed; `master` already carries equal-or-newer versions from #60.
- The remaining dev-only qs/uuid moderate advisories still want a **major Cypress (14→15) + Lighthouse CI** upgrade — that belongs in its own deliberate, E2E-validated PR, not an unvetted bump.

## Testing
- YAML validated; `version: 2` schema.
- No code change; CI runs on the unchanged tree.