### PR TITLE
Backfill unit tests for utils and key components

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run test:ui
 npm run test:coverage
 ```
 
-**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs — currently Lines 38%, Statements 37%, Functions 24%, Branches 24%.
+**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs — currently Lines 52%, Statements 51%, Functions 35%, Branches 40%.
 
 ### E2E Tests
 

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -17,10 +17,10 @@ const __dirname = dirname(__filename);
 // (composables/utils) is ~100%; views and components are being backfilled with
 // unit tests, so raise these numbers as coverage climbs.
 const THRESHOLDS = {
-  lines: 38,
-  statements: 37,
-  functions: 24,
-  branches: 24,
+  lines: 52,
+  statements: 51,
+  functions: 35,
+  branches: 40,
 };
 
 const COVERAGE_SUMMARY_PATH = join(__dirname, '../coverage/coverage-summary.json');

--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -1,0 +1,116 @@
+import { mount, RouterLinkStub } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import type { LiveEvent } from '@/types';
+
+import EventItem from './EventItem.vue';
+
+const mountEvent = (event: LiveEvent) =>
+  mount(EventItem, {
+    props: { event },
+    global: { stubs: { RouterLink: RouterLinkStub } },
+  });
+
+const plainEvent: LiveEvent = {
+  id: 'fim-de-emissao-45',
+  title: 'Fim de Emissão #45',
+  date: '2025-01-17',
+  venue: 'Desterro, Lisbon, Portugal',
+};
+
+const festivalEvent: LiveEvent = {
+  id: 'madeiradig-2011',
+  title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+  date: '2011-12-02',
+  venue: 'Casa das Mudas, Calheta, Portugal',
+};
+
+const internalRefEvent: LiveEvent = {
+  id: 'aragao-funchal',
+  title: '<a href="/works#aragao">Aragão</a>',
+  date: '2021-09-22',
+  venue: 'Teatro Municipal Baltazar Dias, Funchal, Portugal',
+};
+
+describe('EventItem', () => {
+  describe('title', () => {
+    it('renders the title as the deep-link permalink and emits update-hash on click', async () => {
+      const wrapper = mountEvent(plainEvent);
+      const link = wrapper.get('.event-title-link');
+
+      expect(link.text()).toBe('Fim de Emissão #45');
+      expect(link.attributes('href')).toBe('#fim-de-emissao-45');
+
+      await link.trigger('click');
+      expect(wrapper.emitted('update-hash')?.[0]).toEqual(['fim-de-emissao-45']);
+    });
+
+    it('shows no trailing reference icon for a plain-text title', () => {
+      const wrapper = mountEvent(plainEvent);
+      expect(wrapper.find('.event-title-ref').exists()).toBe(false);
+    });
+
+    it('renders the permalink as plain text (not a nested anchor) for a linked title', () => {
+      const wrapper = mountEvent(festivalEvent);
+      const permalink = wrapper.get('.event-title-link');
+
+      expect(permalink.text()).toBe('MADEIRADIG');
+      // The invalid-HTML regression: the permalink anchor must not wrap another anchor.
+      expect(permalink.element.querySelector('a')).toBeNull();
+    });
+
+    it('surfaces an external festival link as a new-tab sibling icon', () => {
+      const wrapper = mountEvent(festivalEvent);
+      const ref = wrapper.get('a.event-title-ref');
+
+      expect(ref.attributes('href')).toBe('https://digitalinberlin.eu/');
+      expect(ref.attributes('target')).toBe('_blank');
+      expect(ref.attributes('rel')).toBe('noopener noreferrer');
+      expect(ref.attributes('aria-label')).toBe('MADEIRADIG website (opens in a new tab)');
+    });
+
+    it('surfaces an internal /works reference as a same-tab RouterLink (no new tab)', () => {
+      const wrapper = mountEvent(internalRefEvent);
+      const routerLink = wrapper.findComponent(RouterLinkStub);
+
+      expect(routerLink.exists()).toBe(true);
+      expect(routerLink.props('to')).toBe('/works#aragao');
+      expect(routerLink.attributes('target')).toBeUndefined();
+      expect(wrapper.find('a.event-title-ref[target="_blank"]').exists()).toBe(false);
+    });
+  });
+
+  describe('media links', () => {
+    it('shows a "View photos" control when the event has images', () => {
+      const wrapper = mountEvent({
+        ...plainEvent,
+        images: [
+          { src: '/images/live/a-001.jpg', alt: 'A' },
+          { src: '/images/live/a-002.jpg', alt: 'B' },
+        ],
+      });
+      const button = wrapper.get('.event-photos-link button');
+      expect(button.text()).toBe('View photos');
+    });
+
+    it('emits open-lightbox with the converted images on click', async () => {
+      const wrapper = mountEvent({
+        ...plainEvent,
+        images: [{ src: '/images/live/a-001.jpg', alt: 'A', photographer: { name: 'Someone' } }],
+      });
+
+      await wrapper.get('.event-photos-link button').trigger('click');
+      const payload = wrapper.emitted('open-lightbox')?.[0];
+
+      expect(payload?.[1]).toBe(0);
+      expect(payload?.[0]).toEqual([
+        { type: 'image', src: '/images/live/a-001.jpg', alt: 'A', photographer: { name: 'Someone' } },
+      ]);
+    });
+
+    it('renders no media control when the event has neither images nor videos', () => {
+      const wrapper = mountEvent(plainEvent);
+      expect(wrapper.find('.event-photos-link').exists()).toBe(false);
+    });
+  });
+});

--- a/src/components/LightboxOverlay.test.ts
+++ b/src/components/LightboxOverlay.test.ts
@@ -1,0 +1,77 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+
+import type { LightboxItem } from '@/types';
+
+import LightboxOverlay from './LightboxOverlay.vue';
+
+const image: LightboxItem = { type: 'image', src: '/image.jpg', alt: 'Test image' };
+
+const mountOverlay = (props: Record<string, unknown> = {}) =>
+  mount(LightboxOverlay, {
+    attachTo: document.body,
+    props: {
+      isOpen: true,
+      currentItem: image,
+      currentIndex: 0,
+      totalItems: 1,
+      variant: 'compact',
+      ...props,
+    },
+  });
+
+describe('LightboxOverlay', () => {
+  describe('dialog semantics', () => {
+    it('renders as a modal dialog with an accessible name', () => {
+      const wrapper = mountOverlay();
+      const dialog = wrapper.get('.lightbox');
+
+      expect(dialog.attributes('role')).toBe('dialog');
+      expect(dialog.attributes('aria-modal')).toBe('true');
+      expect(dialog.attributes('aria-label')).toBe('Image viewer');
+
+      wrapper.unmount();
+    });
+
+    it('reflects position in the accessible name for multi-item galleries', () => {
+      const wrapper = mountOverlay({ currentIndex: 1, totalItems: 3 });
+
+      expect(wrapper.get('.lightbox').attributes('aria-label')).toBe('Image 2 of 3');
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('focus management', () => {
+    it('moves focus into the dialog on open', async () => {
+      const wrapper = mountOverlay();
+      await nextTick();
+      await nextTick();
+
+      expect(document.activeElement).toBe(wrapper.get('.lightbox').element);
+
+      wrapper.unmount();
+    });
+
+    it('wraps Tab from the last control back to the first', async () => {
+      const wrapper = mountOverlay({ currentIndex: 1, totalItems: 3 });
+      await nextTick();
+
+      const focusable = Array.from(
+        wrapper.get('.lightbox').element.querySelectorAll<HTMLElement>('button:not([disabled])'),
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      expect(first).toBeDefined();
+      expect(last).toBeDefined();
+      last?.focus();
+
+      await wrapper.get('.lightbox').trigger('keydown', { key: 'Tab' });
+
+      expect(document.activeElement).toBe(first);
+
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { updateHash } from './navigation';
+
+describe('updateHash', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('replaces the URL hash without adding a history entry', () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState').mockImplementation(() => undefined);
+
+    updateHash('madeiradig-2011');
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', '#madeiradig-2011');
+  });
+
+  it('does not use pushState (avoids polluting history)', () => {
+    const pushState = vi.spyOn(window.history, 'pushState').mockImplementation(() => undefined);
+    vi.spyOn(window.history, 'replaceState').mockImplementation(() => undefined);
+
+    updateHash('solo');
+
+    expect(pushState).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/schemaHelpers.test.ts
+++ b/src/utils/schemaHelpers.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LiveEvent } from '@/types/live';
+
+import { createItemListSchema, createMusicAlbumSchema, createMusicEventSchema } from './schemaHelpers';
+
+const baseEvent: LiveEvent = {
+  id: 'madeiradig-2011',
+  title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+  date: '2011-12-02',
+  venue: '<a href="https://example.com">Casa das Mudas</a>, Calheta, Portugal',
+};
+
+describe('createMusicEventSchema', () => {
+  it('strips HTML from the title for the schema name', () => {
+    const schema = createMusicEventSchema(baseEvent, 'Jerome Faria');
+    expect(schema.name).toBe('MADEIRADIG');
+  });
+
+  it('parses the venue into name, locality and country', () => {
+    const schema = createMusicEventSchema(baseEvent, 'Jerome Faria');
+    expect(schema.location).toEqual({
+      '@type': 'Place',
+      name: 'Casa das Mudas',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Calheta',
+        addressCountry: 'Portugal',
+      },
+    });
+  });
+
+  it('uses the event date as startDate when present', () => {
+    const schema = createMusicEventSchema(baseEvent, 'Jerome Faria', '2011');
+    expect(schema.startDate).toBe('2011-12-02');
+  });
+
+  it('falls back to the provided fallback date when the event has none', () => {
+    const schema = createMusicEventSchema({ ...baseEvent, date: '' }, 'Jerome Faria', '2011');
+    expect(schema.startDate).toBe('2011');
+  });
+
+  it('sets the performer name', () => {
+    const schema = createMusicEventSchema(baseEvent, 'Jerome Faria');
+    expect(schema.performer).toEqual({ '@type': 'Person', name: 'Jerome Faria' });
+  });
+});
+
+describe('createItemListSchema', () => {
+  it('wraps items with 1-indexed positions', () => {
+    const events = [
+      createMusicEventSchema(baseEvent, 'Jerome Faria'),
+      createMusicEventSchema({ ...baseEvent, id: 'second' }, 'Jerome Faria'),
+    ];
+    const list = createItemListSchema(events, 'Live', 'History');
+
+    expect(list['@context']).toBe('https://schema.org');
+    expect(list.numberOfItems).toBe(2);
+    expect(list.itemListElement.map(entry => entry.position)).toEqual([1, 2]);
+    expect(list.itemListElement[0].item).toBe(events[0]);
+  });
+
+  it('handles an empty list', () => {
+    const list = createItemListSchema([], 'Live', 'History');
+    expect(list.numberOfItems).toBe(0);
+    expect(list.itemListElement).toEqual([]);
+  });
+});
+
+describe('createMusicAlbumSchema', () => {
+  const artist = 'Jerome Faria';
+  const siteUrl = 'https://jeromefaria.com';
+
+  it('builds the core album fields', () => {
+    const schema = createMusicAlbumSchema(
+      { title: 'Overlapse', bandcampUrl: 'https://music.jeromefaria.com/album/overlapse', datePublished: '2012' },
+      artist,
+      siteUrl,
+    );
+    expect(schema).toMatchObject({
+      '@type': 'MusicAlbum',
+      name: 'Overlapse',
+      url: 'https://music.jeromefaria.com/album/overlapse',
+      datePublished: '2012',
+      byArtist: { '@type': 'Person', name: artist },
+    });
+  });
+
+  it('defaults url and datePublished to empty strings when missing', () => {
+    const schema = createMusicAlbumSchema({ title: 'Untitled' }, artist, siteUrl);
+    expect(schema.url).toBe('');
+    expect(schema.datePublished).toBe('');
+  });
+
+  it('prefixes the cover image with the site URL when present', () => {
+    const schema = createMusicAlbumSchema({ title: 'Overlapse', coverImage: '/images/overlapse.jpg' }, artist, siteUrl);
+    expect(schema.image).toBe('https://jeromefaria.com/images/overlapse.jpg');
+  });
+
+  it('omits the image when there is no cover', () => {
+    const schema = createMusicAlbumSchema({ title: 'Overlapse' }, artist, siteUrl);
+    expect(schema.image).toBeUndefined();
+  });
+
+  it('sets numTracks from a non-empty tracklist', () => {
+    const schema = createMusicAlbumSchema({ title: 'Overlapse', tracklist: ['A', 'B', 'C'] }, artist, siteUrl);
+    expect(schema.numTracks).toBe(3);
+  });
+
+  it('omits numTracks for an empty or missing tracklist', () => {
+    expect(createMusicAlbumSchema({ title: 'X', tracklist: [] }, artist, siteUrl).numTracks).toBeUndefined();
+    expect(createMusicAlbumSchema({ title: 'X' }, artist, siteUrl).numTracks).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description
First coverage **backfill** on top of the #65 instrumentation baseline (audit Tier-1 #4, "instrument + backfill"). Adds unit tests for the previously-untested util modules **and** the two key components touched by this batch, ratcheting the coverage floor up. Folded the component tests in here (rather than a second PR) so the coverage-floor edits don't conflict across PRs.

## Tests added
- **utils**
  - `schemaHelpers.test.ts` — `createMusicEventSchema` (title HTML stripped, venue parsed, date vs fallback, performer), `createItemListSchema` (1-indexed positions, empty list), `createMusicAlbumSchema` (core fields, url/date defaults, cover-image prefix, `numTracks`).
  - `navigation.test.ts` — `updateHash` uses `replaceState`, not `pushState`.
- **components**
  - `EventItem.test.ts` — title renders as the deep-link permalink + emits `update-hash`; **no-nested-anchor regression** (guards the #63 fix); external festival link → new-tab sibling icon (`rel`/`aria-label`); internal `/works#…` → same-tab `RouterLink`; media ("View photos") control + `open-lightbox` payload.
  - `LightboxOverlay.test.ts` — `role="dialog"` / `aria-modal` / position-aware `aria-label`; focus-in on open; Tab wraps last→first (guards the #64 fix).

## Coverage
```
             baseline   this PR
Lines        39.27%     52.97%    (floor 52)
Statements   38.37%     51.59%    (floor 51)
Functions    24.73%     36.31%    (floor 35)
Branches     25.70%     40.76%    (floor 40)
```
`EventItem.vue` ~92%, `LightboxOverlay.vue` ~84%.

## Testing
- `npm run test:coverage` (237 tests) + `node scripts/check-coverage.js` → passes at the new floor ✅
- `npm run type-check`, `npm run lint`, `npm run build` ✅

## Next backfill
`ReleaseItem`, `SiteHeader`/`SiteFooter`, and the views — each raising the floor further.