### PR TITLE
Backfill unit tests for SiteHeader, SiteFooter, ReleaseItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run test:ui
 npm run test:coverage
 ```
 
-**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs — currently Lines 52%, Statements 51%, Functions 35%, Branches 40%.
+**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs — currently Lines 62%, Statements 61%, Functions 48%, Branches 55%.
 
 ### E2E Tests
 

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -17,10 +17,10 @@ const __dirname = dirname(__filename);
 // (composables/utils) is ~100%; views and components are being backfilled with
 // unit tests, so raise these numbers as coverage climbs.
 const THRESHOLDS = {
-  lines: 52,
-  statements: 51,
-  functions: 35,
-  branches: 40,
+  lines: 62,
+  statements: 61,
+  functions: 48,
+  branches: 55,
 };
 
 const COVERAGE_SUMMARY_PATH = join(__dirname, '../coverage/coverage-summary.json');

--- a/src/components/ReleaseItem.test.ts
+++ b/src/components/ReleaseItem.test.ts
@@ -1,0 +1,122 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import type {
+  BandcampRelease,
+  CollaborationRelease,
+  ExternalRelease,
+  MasteringCredit,
+  PublicationRelease,
+  Release,
+} from '@/types';
+
+import BandcampPlayer from './BandcampPlayer.vue';
+import ReleaseItem from './ReleaseItem.vue';
+
+const mountRelease = (release: Release, textOnly = false) =>
+  mount(ReleaseItem, { props: { release, textOnly } });
+
+const bandcamp: BandcampRelease = {
+  id: 'overlapse',
+  title: 'Overlapse',
+  meta: 'Digital — BRØQN, 2012',
+  bandcampId: '1643026936',
+  coverImage: '/images/overlapse.jpg',
+  bandcampUrl: 'https://music.jeromefaria.com/album/overlapse',
+  tracklist: ['Attack', 'Sustain'],
+  credits: 'Music by Jerome Faria.',
+};
+
+const external: ExternalRelease = {
+  id: 'ect',
+  title: 'ECT',
+  meta: 'Digital — Test Tube, 2005',
+  coverImage: '/images/ect.jpg',
+  externalUrl: 'https://example.com/ect',
+  tracklist: ['Play'],
+  credits: 'Music by Jerome Faria.',
+};
+
+const staticCover: CollaborationRelease = {
+  id: 'depolarized',
+  title: 'Depolarized',
+  meta: 'Digital — BRØQN, 2012',
+  coverImage: '/images/depolarized.jpg',
+  credits: 'Music by Jerome Faria and Nelson P. Ferreira.',
+};
+
+const textOnlyRelease: MasteringCredit = {
+  id: 'master-open',
+  title: 'Open',
+  meta: 'Hugo Calcio, 2021',
+};
+
+describe('ReleaseItem', () => {
+  it('renders a Bandcamp player for a release with a bandcampId', () => {
+    const wrapper = mountRelease(bandcamp);
+    expect(wrapper.findComponent(BandcampPlayer).exists()).toBe(true);
+  });
+
+  it('renders an external-link cover for a release with an externalUrl', () => {
+    const wrapper = mountRelease(external);
+    const cover = wrapper.get('a.release-cover');
+    expect(cover.attributes('href')).toBe('https://example.com/ect');
+    expect(cover.attributes('target')).toBe('_blank');
+    expect(cover.attributes('rel')).toBe('noopener noreferrer');
+    expect(cover.find('img').attributes('src')).toBe('/images/ect.jpg');
+  });
+
+  it('renders a static (unlinked) cover when there is no player or link', () => {
+    const wrapper = mountRelease(staticCover);
+    expect(wrapper.find('.release-cover--static').exists()).toBe(true);
+    expect(wrapper.find('a.release-cover').exists()).toBe(false);
+  });
+
+  it('renders no cover for a release without an image', () => {
+    const wrapper = mountRelease(textOnlyRelease);
+    expect(wrapper.find('.release-cover').exists()).toBe(false);
+    expect(wrapper.get('.release-title-link').text()).toBe('Open');
+  });
+
+  it('emits update-hash when the title permalink is clicked', async () => {
+    const wrapper = mountRelease(textOnlyRelease);
+    await wrapper.get('.release-title-link').trigger('click');
+    expect(wrapper.emitted('update-hash')?.[0]).toEqual(['master-open']);
+  });
+
+  it('renders meta, tracklist and credits', () => {
+    const wrapper = mountRelease(bandcamp);
+    expect(wrapper.get('.release-meta').text()).toContain('BRØQN');
+    expect(wrapper.findAll('ol li')).toHaveLength(2);
+    expect(wrapper.get('.release-credits').text()).toContain('Jerome Faria');
+  });
+
+  it('applies the text-only modifier when requested', () => {
+    const wrapper = mountRelease(textOnlyRelease, true);
+    expect(wrapper.get('article').classes()).toContain('release--text-only');
+  });
+
+  it('emits open-lightbox with converted images from the gallery button', async () => {
+    const publication: PublicationRelease = {
+      id: 'glitch',
+      title: 'Glitch',
+      meta: 'Book, 2009',
+      coverImage: '/images/glitch.jpg',
+      externalUrl: 'https://example.com/glitch',
+      description: 'A book.',
+      credits: 'Editors.',
+      images: [
+        { src: '/images/publications/glitch-spread-01.jpg', alt: 'Spread 1' },
+        { src: '/images/publications/glitch-spread-02.jpg', alt: 'Spread 2' },
+      ],
+    };
+    const wrapper = mountRelease(publication);
+
+    await wrapper.get('.release-gallery-link button').trigger('click');
+    const payload = wrapper.emitted('open-lightbox')?.[0];
+
+    expect(payload?.[1]).toBe(0);
+    expect(payload?.[0]).toHaveLength(2);
+    expect((payload?.[0] as Array<{ src: string }>)[0].src).toBe('/images/publications/glitch-spread-01.jpg');
+  });
+});

--- a/src/components/SiteFooter.test.ts
+++ b/src/components/SiteFooter.test.ts
@@ -1,0 +1,48 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { createMemoryHistory, createRouter } from 'vue-router';
+
+import { navigation, siteConfig, social } from '@/data/navigation';
+
+import SiteFooter from './SiteFooter.vue';
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+});
+
+const mountFooter = async () => {
+  const wrapper = mount(SiteFooter, { global: { plugins: [router] } });
+  await router.isReady();
+  return wrapper;
+};
+
+describe('SiteFooter', () => {
+  it('renders a link for every nav item', async () => {
+    const wrapper = await mountFooter();
+    const navLinks = wrapper.findAll('.footer__nav a');
+    expect(navLinks).toHaveLength(navigation.length);
+    expect(navLinks.map(link => link.text())).toEqual(navigation.map(item => item.title));
+  });
+
+  it('renders social links as external, safely-relled anchors', async () => {
+    const wrapper = await mountFooter();
+    const links = wrapper.findAll('.social-links a');
+
+    expect(links).toHaveLength(social.length);
+    social.forEach((item, index) => {
+      const link = links[index];
+      expect(link?.attributes('href')).toBe(item.url);
+      expect(link?.attributes('target')).toBe('_blank');
+      expect(link?.attributes('rel')).toBe('noopener noreferrer');
+      expect(link?.attributes('aria-label')).toBe(`${siteConfig.author.name} on ${item.name}`);
+    });
+  });
+
+  it('shows the current year and author in the copyright', async () => {
+    const wrapper = await mountFooter();
+    const copyright = wrapper.get('.footer__copyright');
+    expect(copyright.text()).toContain(String(new Date().getFullYear()));
+    expect(copyright.text()).toContain(siteConfig.author.name);
+  });
+});

--- a/src/components/SiteHeader.test.ts
+++ b/src/components/SiteHeader.test.ts
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { createMemoryHistory, createRouter } from 'vue-router';
+
+import { navigation, siteConfig } from '@/data/navigation';
+
+import SiteHeader from './SiteHeader.vue';
+
+const makeRouter = () =>
+  createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/about', component: { template: '<div />' } },
+    ],
+  });
+
+const mountHeader = async () => {
+  const router = makeRouter();
+  router.push('/');
+  await router.isReady();
+  const wrapper = mount(SiteHeader, { global: { plugins: [router] } });
+  return { wrapper, router };
+};
+
+describe('SiteHeader', () => {
+  it('renders the site title and tagline', async () => {
+    const { wrapper } = await mountHeader();
+    expect(wrapper.get('.masthead-title').text()).toContain(siteConfig.title);
+    expect(wrapper.get('.masthead-tagline').text()).toBe(siteConfig.tagline);
+  });
+
+  it('renders a link for every nav item', async () => {
+    const { wrapper } = await mountHeader();
+    const links = wrapper.findAll('.nav__link');
+    expect(links.map(link => link.text())).toEqual(navigation.map(item => item.title));
+  });
+
+  it('toggles the menu open and closed, reflecting aria-expanded', async () => {
+    const { wrapper } = await mountHeader();
+    const toggle = wrapper.get('.nav-toggle');
+
+    expect(toggle.attributes('aria-expanded')).toBe('false');
+    expect(wrapper.find('.nav--open').exists()).toBe(false);
+
+    await toggle.trigger('click');
+    expect(toggle.attributes('aria-expanded')).toBe('true');
+    expect(wrapper.find('.nav--open').exists()).toBe(true);
+
+    await toggle.trigger('click');
+    expect(toggle.attributes('aria-expanded')).toBe('false');
+    expect(wrapper.find('.nav--open').exists()).toBe(false);
+  });
+
+  it('closes an open menu when the route changes', async () => {
+    const { wrapper, router } = await mountHeader();
+
+    await wrapper.get('.nav-toggle').trigger('click');
+    expect(wrapper.find('.nav--open').exists()).toBe(true);
+
+    await router.push('/about');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.nav--open').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description
Continues the coverage backfill (audit Tier-1 #4). Adds unit tests for the three remaining untested components and ratchets the floor up.

## Tests added
- **`SiteHeader.test.ts`** — title/tagline, a nav link per item, menu toggle open/close with `aria-expanded`, and close-on-route-change (via a memory router).
- **`SiteFooter.test.ts`** — nav links, external social links (`target`/`rel`/`aria-label`), current-year copyright.
- **`ReleaseItem.test.ts`** — Bandcamp-player / external-link-cover / static-cover / text-only variants, title permalink emit, and the gallery `open-lightbox` payload.

## Coverage
```
             before   this PR
Lines        52.97%   62.52%   (floor 62)
Statements   51.59%   62.10%   (floor 61)
Functions    36.31%   48.94%   (floor 48)
Branches     40.76%   56.02%   (floor 55)
```

## Testing
- `npm run test:coverage` (252 tests) + `node scripts/check-coverage.js` → passes at the new floor ✅
- `npm run type-check`, `npm run lint`, `npm run build` ✅

## Next
View backfill (`HomeView`, `WorksView`, `LiveView`, `PressView`, `ContactView`, `AboutView`, `NotFoundView`, `App`), then the Tier-2/3 correctness batch.