### PR TITLE
Backfill unit tests for all views

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run test:ui
 npm run test:coverage
 ```
 
-**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs — currently Lines 62%, Statements 61%, Functions 48%, Branches 55%.
+**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs — currently Lines 81%, Statements 80%, Functions 63%, Branches 70%.
 
 ### E2E Tests
 

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -17,10 +17,10 @@ const __dirname = dirname(__filename);
 // (composables/utils) is ~100%; views and components are being backfilled with
 // unit tests, so raise these numbers as coverage climbs.
 const THRESHOLDS = {
-  lines: 62,
-  statements: 61,
-  functions: 48,
-  branches: 55,
+  lines: 81,
+  statements: 80,
+  functions: 63,
+  branches: 70,
 };
 
 const COVERAGE_SUMMARY_PATH = join(__dirname, '../coverage/coverage-summary.json');

--- a/src/test-support/viewHarness.ts
+++ b/src/test-support/viewHarness.ts
@@ -1,0 +1,19 @@
+import { createHead } from '@unhead/vue/client';
+import { mount } from '@vue/test-utils';
+import type { Component } from 'vue';
+import { createMemoryHistory, createRouter } from 'vue-router';
+
+/**
+ * Mount a view component with the plugins it needs at runtime: a memory router
+ * (for `useRoute` / `RouterLink`) and an unhead instance (for `usePageHead`).
+ */
+export const mountView = async (component: Component, path = '/') => {
+  const head = createHead();
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+  });
+  router.push(path);
+  await router.isReady();
+  return mount(component, { global: { plugins: [router, head] } });
+};

--- a/src/views/AboutView.test.ts
+++ b/src/views/AboutView.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { aboutSections } from '@/data/about';
+import { mountView } from '@/test-support/viewHarness';
+
+import AboutView from './AboutView.vue';
+
+describe('AboutView', () => {
+  it('renders the short bio and the prose sections', async () => {
+    const wrapper = await mountView(AboutView, '/about');
+    expect(wrapper.find('.short-bio').exists()).toBe(true);
+
+    const proseCount = aboutSections.filter(section => !('type' in section) || !section.type).length;
+    expect(wrapper.findAll('.prose')).toHaveLength(proseCount);
+  });
+
+  it('renders a figure for every image across the image groups', async () => {
+    const wrapper = await mountView(AboutView, '/about');
+
+    const groups = aboutSections.filter((section): section is typeof section & { images: unknown[] } =>
+      'type' in section && section.type === 'image-group' && Array.isArray((section as { images?: unknown[] }).images));
+    const groupCount = groups.length;
+    const imageCount = groups.reduce((sum, group) => sum + group.images.length, 0);
+
+    expect(wrapper.findAll('.about-image-group')).toHaveLength(groupCount);
+    expect(wrapper.findAll('.about-image-group__image')).toHaveLength(imageCount);
+  });
+});

--- a/src/views/ContactView.test.ts
+++ b/src/views/ContactView.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { contactContent } from '@/data/contact';
+import { mountView } from '@/test-support/viewHarness';
+
+import ContactView from './ContactView.vue';
+
+describe('ContactView', () => {
+  it('posts to the configured form action', async () => {
+    const wrapper = await mountView(ContactView);
+    expect(wrapper.get('form.contact-form').attributes('action')).toBe(contactContent.form.action);
+  });
+
+  it('renders the name, email, subject and message fields', async () => {
+    const wrapper = await mountView(ContactView);
+    ['name', 'email', 'subject', 'message'].forEach(field => {
+      expect(wrapper.find(`#${field}`).exists()).toBe(true);
+    });
+  });
+
+  it('includes a hidden honeypot field for spam protection', async () => {
+    const wrapper = await mountView(ContactView);
+    const honeypot = wrapper.get('.contact-form__honeypot');
+    expect(honeypot.attributes('tabindex')).toBe('-1');
+    expect(honeypot.attributes('aria-label')).toBe('Leave this field empty');
+  });
+
+  it('shows the submit label from the content config', async () => {
+    const wrapper = await mountView(ContactView);
+    expect(wrapper.get('.contact-form__submit').text()).toBe(contactContent.form.submitText);
+  });
+});

--- a/src/views/HomeView.test.ts
+++ b/src/views/HomeView.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { mountView } from '@/test-support/viewHarness';
+
+import HomeView from './HomeView.vue';
+
+describe('HomeView', () => {
+  it('renders the hero with the background image', async () => {
+    const wrapper = await mountView(HomeView);
+    const hero = wrapper.get('.hero');
+    expect(hero.attributes('style')).toContain('/images/performance.jpg');
+  });
+
+  it('shows the loading indicator until the hero image loads', async () => {
+    const wrapper = await mountView(HomeView);
+    expect(wrapper.find('.hero__loading').exists()).toBe(true);
+    expect(wrapper.findAll('.hero__loading-dot')).toHaveLength(3);
+    expect(wrapper.get('.hero').classes()).not.toContain('hero--loaded');
+  });
+});

--- a/src/views/LiveView.test.ts
+++ b/src/views/LiveView.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import AccordionSection from '@/components/AccordionSection.vue';
+import EventItem from '@/components/EventItem.vue';
+import { liveData, liveYears } from '@/data/live';
+import { mountView } from '@/test-support/viewHarness';
+
+import LiveView from './LiveView.vue';
+
+describe('LiveView', () => {
+  it('renders an accordion section for every year', async () => {
+    const wrapper = await mountView(LiveView, '/live');
+    expect(wrapper.findAllComponents(AccordionSection)).toHaveLength(liveYears.length);
+  });
+
+  it('renders an event item for every performance', async () => {
+    const wrapper = await mountView(LiveView, '/live');
+    const totalEvents = Object.values(liveData).reduce((sum, year) => sum + year.items.length, 0);
+    expect(wrapper.findAllComponents(EventItem)).toHaveLength(totalEvents);
+  });
+});

--- a/src/views/NotFoundView.test.ts
+++ b/src/views/NotFoundView.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { navigation } from '@/data/navigation';
+import { mountView } from '@/test-support/viewHarness';
+
+import NotFoundView from './NotFoundView.vue';
+
+describe('NotFoundView', () => {
+  it('renders the not-found heading', async () => {
+    const wrapper = await mountView(NotFoundView, '/nope');
+    expect(wrapper.get('h1').text()).toBe('Page Not Found');
+  });
+
+  it('offers a Home link plus every nav destination', async () => {
+    const wrapper = await mountView(NotFoundView, '/nope');
+    const linkTexts = wrapper.findAll('.not-found-nav a').map(link => link.text());
+    expect(linkTexts).toContain('Home');
+    navigation.forEach(item => expect(linkTexts).toContain(item.title));
+  });
+});

--- a/src/views/PressView.test.ts
+++ b/src/views/PressView.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { pressQuotes } from '@/data/press';
+import { mountView } from '@/test-support/viewHarness';
+
+import PressView from './PressView.vue';
+
+describe('PressView', () => {
+  it('renders a blockquote for every press quote, keyed by id', async () => {
+    const wrapper = await mountView(PressView);
+    const quotes = wrapper.findAll('blockquote');
+    expect(quotes).toHaveLength(pressQuotes.length);
+    pressQuotes.forEach(quote => {
+      expect(wrapper.find(`#${quote.id}`).exists()).toBe(true);
+    });
+  });
+
+  it('links the source when a quote has a url, and shows plain text otherwise', async () => {
+    const wrapper = await mountView(PressView);
+
+    const withUrl = pressQuotes.find(quote => quote.url);
+    const withoutUrl = pressQuotes.find(quote => !quote.url);
+
+    if (withUrl) {
+      const link = wrapper.get(`#${withUrl.id} strong a`);
+      expect(link.attributes('href')).toBe(withUrl.url);
+      expect(link.attributes('target')).toBe('_blank');
+      expect(link.attributes('rel')).toBe('noopener noreferrer');
+    }
+    if (withoutUrl) {
+      expect(wrapper.find(`#${withoutUrl.id} strong a`).exists()).toBe(false);
+    }
+  });
+});

--- a/src/views/WorksView.test.ts
+++ b/src/views/WorksView.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import AccordionSection from '@/components/AccordionSection.vue';
+import ReleaseItem from '@/components/ReleaseItem.vue';
+import { worksData, worksSections } from '@/data/works';
+import { mountView } from '@/test-support/viewHarness';
+
+import WorksView from './WorksView.vue';
+
+describe('WorksView', () => {
+  it('renders an accordion section for every works category', async () => {
+    const wrapper = await mountView(WorksView, '/works');
+    expect(wrapper.findAllComponents(AccordionSection)).toHaveLength(worksSections.length);
+  });
+
+  it('renders a release item for every release across all sections', async () => {
+    const wrapper = await mountView(WorksView, '/works');
+    const totalReleases = Object.values(worksData).reduce((sum, section) => sum + section.items.length, 0);
+    expect(wrapper.findAllComponents(ReleaseItem)).toHaveLength(totalReleases);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         '**/*.test.ts',
         '**/types/**',
         'src/main.ts',
+        'src/test-support/**',
       ],
     },
   },


### PR DESCRIPTION
## Description
Continues the coverage backfill (audit Tier-1 #4). Adds unit tests for all seven views, via a shared `src/test-support/viewHarness.ts` that mounts a view with the router + unhead instance it needs at runtime (excluded from coverage as test infra).

## Tests added
- `HomeView` — hero background image + loading indicator (pre-load state).
- `AboutView` — short-bio + prose section counts, image-group / figure counts.
- `WorksView` — an accordion section per category, a `ReleaseItem` per release.
- `LiveView` — an accordion section per year, an `EventItem` per performance.
- `PressView` — a blockquote (with id) per quote, linked vs plain source.
- `ContactView` — form action, all fields, hidden honeypot, submit label.
- `NotFoundView` — heading + Home/nav links.

## Coverage
```
             before   this PR
Lines        62.52%   81.98%   (floor 81)
Statements   62.10%   81.05%   (floor 80)
Functions    48.94%   64.21%   (floor 63)
Branches     56.02%   71.28%   (floor 70)
```

## Testing
- `npm run test:coverage` (268 tests) + `node scripts/check-coverage.js` → passes at the new floor ✅
- `npm run type-check`, `npm run lint`, `npm run build` ✅

## Next
Remaining uncovered: `App.vue`, `router/`, `AccordionSection`. Then the Tier-2/3 correctness batch and tooling/cleanup, plus the visible-UX PRs left open for your review.