### PR TITLE
Fix Tier-2/3 correctness issues

### DIFF
--- a/scripts/async-css.js
+++ b/scripts/async-css.js
@@ -13,13 +13,15 @@ async function makeCSSAsync() {
       const filePath = join(distDir, file);
       let content = await readFile(filePath, 'utf-8');
 
-      // Transform CSS links to load asynchronously
-      // Critical CSS is already inlined in index.html template
-      content = content.replace(
-        /<link\s+rel="stylesheet"\s+crossorigin=""\s+href="([^"]+)">/g,
-        (match, href) =>
-          `<link rel="preload" as="style" href="${href}" onload="this.onload=null;this.rel='stylesheet'"><noscript><link rel="stylesheet" href="${href}"></noscript>`,
-      );
+      // Transform CSS links to load asynchronously.
+      // Critical CSS is already inlined in index.html template.
+      // Match any stylesheet <link> regardless of attribute order, so a change
+      // in how Vite emits the tag doesn't silently turn this into a no-op.
+      content = content.replace(/<link\b[^>]*\brel="stylesheet"[^>]*>/g, tag => {
+        const href = tag.match(/\bhref="([^"]+)"/)?.[1];
+        if (!href) return tag;
+        return `<link rel="preload" as="style" href="${href}" onload="this.onload=null;this.rel='stylesheet'"><noscript><link rel="stylesheet" href="${href}"></noscript>`;
+      });
 
       await writeFile(filePath, content, 'utf-8');
       console.log(`✓ Made CSS async in ${file}`);

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@ const processExternalLinks = () => {
 
   const links = main.querySelectorAll<HTMLAnchorElement>('a[href^="http"]:not([target])');
   links.forEach(link => {
-    if (!link.hostname.includes(window.location.hostname)) {
+    if (link.hostname !== window.location.hostname) {
       link.setAttribute('target', '_blank');
       link.setAttribute('rel', 'noopener noreferrer');
     }

--- a/src/composables/useAccordion.ts
+++ b/src/composables/useAccordion.ts
@@ -50,7 +50,8 @@ export const useAccordion = (
         if (element) {
           const scrollMargin = parseFloat(getComputedStyle(element).scrollMarginTop) || 0;
           const targetY = element.getBoundingClientRect().top + window.scrollY - scrollMargin;
-          window.scrollTo({ top: targetY, behavior: 'smooth' });
+          const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+          window.scrollTo({ top: targetY, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
         }
       }, TIMING.ACCORDION_ANIMATION);
     });

--- a/src/utils/imageStyles.ts
+++ b/src/utils/imageStyles.ts
@@ -1,23 +1,20 @@
+import type { CSSProperties } from 'vue';
+
 export interface ImageWithTransforms {
   position?: string;
   scale?: number;
   rotate?: number;
 }
 
-export interface ImageStyleObject {
-  objectPosition?: string;
-  transform?: string;
-}
-
 /**
  * Calculates CSS style object for image transformations
  * @param image - Image object with optional position, scale, rotate properties
- * @returns CSS style object
+ * @returns CSS style object usable directly as a Vue `:style` binding
  */
-export const getImageStyles = (image?: ImageWithTransforms): ImageStyleObject => {
+export const getImageStyles = (image?: ImageWithTransforms): CSSProperties => {
   if (!image) return {};
 
-  const styles: ImageStyleObject = {};
+  const styles: CSSProperties = {};
 
   // Object position (e.g., "center top", "50% 25%")
   if (image.position) {

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -97,7 +97,7 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
               <img
                 :src="image.src"
                 :alt="image.alt"
-                :style="getImageStyles(image) as any"
+                :style="getImageStyles(image)"
                 loading="lazy"
                 decoding="async"
               >

--- a/src/views/HomeView.test.ts
+++ b/src/views/HomeView.test.ts
@@ -1,10 +1,29 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { mountView } from '@/test-support/viewHarness';
 
 import HomeView from './HomeView.vue';
 
+interface FakeImage { onload: (() => void) | null; onerror: (() => void) | null }
+
+const created: FakeImage[] = [];
+const OriginalImage = window.Image;
+
+class MockImage implements FakeImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  set src(_value: string) { /* no-op: load is driven manually in tests */ }
+  constructor() {
+    created.push(this);
+  }
+}
+
 describe('HomeView', () => {
+  afterEach(() => {
+    window.Image = OriginalImage;
+    created.length = 0;
+  });
+
   it('renders the hero with the background image', async () => {
     const wrapper = await mountView(HomeView);
     const hero = wrapper.get('.hero');
@@ -16,5 +35,26 @@ describe('HomeView', () => {
     expect(wrapper.find('.hero__loading').exists()).toBe(true);
     expect(wrapper.findAll('.hero__loading-dot')).toHaveLength(3);
     expect(wrapper.get('.hero').classes()).not.toContain('hero--loaded');
+  });
+
+  it('reveals the hero once the image loads', async () => {
+    window.Image = MockImage as unknown as typeof Image;
+    const wrapper = await mountView(HomeView);
+
+    created[0]?.onload?.();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get('.hero').classes()).toContain('hero--loaded');
+    expect(wrapper.find('.hero__loading').exists()).toBe(false);
+  });
+
+  it('reveals the hero even if the image fails, so the loader never hangs', async () => {
+    window.Image = MockImage as unknown as typeof Image;
+    const wrapper = await mountView(HomeView);
+
+    created[0]?.onerror?.();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get('.hero').classes()).toContain('hero--loaded');
   });
 });

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -27,10 +27,14 @@ const heroImageSrc = '/images/performance.jpg';
 
 onMounted(() => {
   const img = new Image();
-  img.src = heroImageSrc;
   img.onload = () => {
     heroImageLoaded.value = true;
   };
+  // Reveal the hero even if the image fails, so the loader never spins forever.
+  img.onerror = () => {
+    heroImageLoaded.value = true;
+  };
+  img.src = heroImageSrc;
 });
 </script>
 

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -37,7 +37,7 @@ const eventSchemas = computed(() =>
   liveYears.flatMap(year => {
     const yearData = sortedLiveData.value[year];
     return (yearData?.items || []).map(event =>
-      createMusicEventSchema(event, siteConfig.author.name, year),
+      createMusicEventSchema(event, siteConfig.author.name, `${year}-01-01`),
     );
   }),
 );


### PR DESCRIPTION
## Description
Batch of pure-correctness fixes from the audit's Tier 2/3, grouped into one PR (no visible UI change). Each is small and low-risk.

## Fixes
- **HomeView** — hero preloader now handles `onerror` as well as `onload`, so a failed `/images/performance.jpg` reveals the hero instead of spinning the loader forever. (+ tests mocking `Image` for both paths.)
- **useAccordion** — hash-scroll honours `prefers-reduced-motion` (`'auto'` vs `'smooth'`), consistent with `AccordionSection`.
- **LiveView** — passes a valid ISO fallback (`${year}-01-01`) to `createMusicEventSchema` instead of a bare year (latent invalid `startDate`).
- **App.vue** — external-link detection uses strict hostname equality (`!==`) instead of substring `.includes()`, so subdomain links (e.g. `music.`/`blog.jeromefaria.com`) are correctly treated as external.
- **AboutView / imageStyles** — `getImageStyles` returns `CSSProperties`; drops the `:style="… as any"` cast.
- **async-css.js** — matches stylesheet `<link>`s regardless of attribute order, so a change in Vite's emitted markup can't silently turn the async-CSS transform into a no-op.

## Deliberately deferred
- **`parseVenue` length-branching** — a 1-part venue string is genuinely ambiguous (venue *name* like "Teatro Nacional" vs *country* like "Portugal"); length alone can't disambiguate, and changing it risks the common case. Left as a judgement call (or resolves itself when the 2026 TBC venues get real "Venue, City, Country" values).

## Testing
- `npm run type-check`, `npm run lint`, `npm run test` (270), `npm run test:coverage` + `check-coverage` (82.25%, floor 81) ✅
- `npm run build` ✅ — verified the async-css transform still applies to real `dist` HTML.