### PR TITLE
Enlarge lightbox controls to meet minimum target size

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -614,6 +614,9 @@
     background: none;
     border: none;
     padding: $spacing-1;
+    // Meet the WCAG 2.5.8 target-size minimum (24px); use a comfortable 44px.
+    min-width: 44px;
+    min-height: 44px;
     font-size: $font-size-base;
     color: var(--color-background);
     opacity: $opacity-50;


### PR DESCRIPTION
## Description
**Visible-UX change — left open for your review** (per the Hybrid autonomy policy). Audit Tier-3 finding.

The compact lightbox controls (`←` / `×` / `→`, `.lightbox__hint`) had a ~22px hit area (padding `$spacing-1` + glyph), under the WCAG **2.5.8** 24px minimum. This gives them a **44px** min target (the comfortable recommended size) without changing the glyphs.

## Design note
44px is the recommended tap target; if it feels too large for the compact overlay, dial `min-width`/`min-height` down to as low as `24px` and it still passes. That's your call — hence this PR is left for review, not auto-merged.

## Testing
- `npm run build` ✅ (SCSS compiles). CSS-only change; no logic/tests affected.