### PR TITLE
Add a screen-reader 'opens in a new tab' cue to external links

### DIFF
--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -163,7 +163,7 @@ onMounted(async () => {
           :href="photographer.url"
           target="_blank"
           rel="noopener noreferrer"
-        >{{ photographer.name }}</a>
+        >{{ photographer.name }}<span class="visually-hidden"> (opens in a new tab)</span></a>
         <span v-else>{{ photographer.name }}</span>
       </div>
     </div>

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -92,6 +92,7 @@ const isBandcampLink = computed(() => {
           @error="handleImageError"
         >
       </picture>
+      <span class="visually-hidden"> (opens in a new tab)</span>
     </a>
 
     <!-- Static Cover (no link) -->

--- a/src/components/SiteFooter.test.ts
+++ b/src/components/SiteFooter.test.ts
@@ -35,7 +35,7 @@ describe('SiteFooter', () => {
       expect(link?.attributes('href')).toBe(item.url);
       expect(link?.attributes('target')).toBe('_blank');
       expect(link?.attributes('rel')).toBe('noopener noreferrer');
-      expect(link?.attributes('aria-label')).toBe(`${siteConfig.author.name} on ${item.name}`);
+      expect(link?.attributes('aria-label')).toBe(`${siteConfig.author.name} on ${item.name} (opens in a new tab)`);
     });
   });
 

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -29,7 +29,7 @@ const currentYear = new Date().getFullYear();
             :href="item.url"
             target="_blank"
             rel="noopener noreferrer"
-            :aria-label="`${siteConfig.author.name} on ${item.name}`"
+            :aria-label="`${siteConfig.author.name} on ${item.name} (opens in a new tab)`"
           >
             {{ item.name }}
           </a>

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -35,7 +35,7 @@ useHashScroll(scrollToHash);
             :href="item.url"
             target="_blank"
             rel="noopener noreferrer"
-          >{{ item.source }}</a>
+          >{{ item.source }}<span class="visually-hidden"> (opens in a new tab)</span></a>
           <template v-else>{{ item.source }}</template>
         </strong>
       </blockquote>


### PR DESCRIPTION
## Description
**Visible-UX/a11y change — left open for your review** (Hybrid policy). Audit Tier-3 (WCAG 3.2.5 best practice).

External links that open in a new tab gave screen-reader users no warning. Adds the cue with no visual change:
- **SiteFooter** social links — appended to the existing `aria-label`.
- **PressView** source, **LightboxOverlay** photographer, **ReleaseItem** cover — a `visually-hidden` " (opens in a new tab)" note.
- `EventItem`'s festival link already carried this cue (unchanged).

## Testing
- `npm run type-check`, `npm run lint`, `npm run test:coverage` (+ updated SiteFooter aria-label assertion), `npm run build` — all ✅

## Note
Purely additive for assistive tech (no visual change), but grouped with the UX review batch since it changes announced link text. Safe to merge if you're happy with the wording.