### PR TITLE
Improve mobile-nav keyboard accessibility

### DIFF
--- a/src/components/SiteHeader.test.ts
+++ b/src/components/SiteHeader.test.ts
@@ -19,7 +19,7 @@ const mountHeader = async () => {
   const router = makeRouter();
   router.push('/');
   await router.isReady();
-  const wrapper = mount(SiteHeader, { global: { plugins: [router] } });
+  const wrapper = mount(SiteHeader, { global: { plugins: [router] }, attachTo: document.body });
   return { wrapper, router };
 };
 
@@ -62,5 +62,29 @@ describe('SiteHeader', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find('.nav--open').exists()).toBe(false);
+  });
+
+  it('associates the toggle with the nav via aria-controls', async () => {
+    const { wrapper } = await mountHeader();
+    expect(wrapper.get('.nav-toggle').attributes('aria-controls')).toBe('primary-nav');
+    expect(wrapper.get('nav').attributes('id')).toBe('primary-nav');
+  });
+
+  it('moves focus into the menu when opened', async () => {
+    const { wrapper } = await mountHeader();
+    await wrapper.get('.nav-toggle').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(document.activeElement).toBe(wrapper.get('.nav__link').element);
+  });
+
+  it('closes on Escape and returns focus to the toggle', async () => {
+    const { wrapper } = await mountHeader();
+    await wrapper.get('.nav-toggle').trigger('click');
+    expect(wrapper.find('.nav--open').exists()).toBe(true);
+
+    await wrapper.get('#primary-nav').trigger('keydown', { key: 'Escape' });
+
+    expect(wrapper.find('.nav--open').exists()).toBe(false);
+    expect(document.activeElement).toBe(wrapper.get('.nav-toggle').element);
   });
 });

--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { nextTick, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 
 import { navigation, siteConfig } from '@/data/navigation';
@@ -8,6 +8,8 @@ import { TIMING } from '@/utils/constants';
 const route = useRoute();
 const navOpen = ref(false);
 const navClosing = ref(false);
+const navToggle = ref<HTMLButtonElement | null>(null);
+const navMenu = ref<HTMLElement | null>(null);
 
 const closeNav = () => {
   navClosing.value = true;
@@ -17,8 +19,23 @@ const closeNav = () => {
   }, TIMING.NAV_ANIMATION);
 };
 
+const openNav = () => {
+  navOpen.value = true;
+  // Move focus into the menu once it's rendered so keyboard users land in it.
+  nextTick(() => {
+    navMenu.value?.querySelector<HTMLElement>('.nav__link')?.focus();
+  });
+};
+
 const toggleNav = () => {
-  navOpen.value ? closeNav() : navOpen.value = true;
+  navOpen.value ? closeNav() : openNav();
+};
+
+const handleNavKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && navOpen.value) {
+    closeNav();
+    navToggle.value?.focus();
+  }
 };
 
 watch(() => route.path, () => {
@@ -38,9 +55,11 @@ watch(() => route.path, () => {
 
       <div class="masthead-controls">
         <button
+          ref="navToggle"
           class="nav-toggle"
           type="button"
           aria-label="Toggle menu"
+          aria-controls="primary-nav"
           :aria-expanded="navOpen"
           @click="toggleNav"
         >
@@ -71,9 +90,12 @@ watch(() => route.path, () => {
       </div>
 
       <nav
+        id="primary-nav"
+        ref="navMenu"
         class="nav"
         :class="{ 'nav--open': navOpen, 'nav--closing': navClosing }"
         aria-label="Main navigation"
+        @keydown="handleNavKeydown"
       >
         <div class="nav__inner">
           <RouterLink


### PR DESCRIPTION
## Description
**Visible-UX/a11y change — left open for your review** (Hybrid policy). Audit Tier-2 (WCAG 4.1.2 / 2.4.3).

The mobile menu toggle exposed `aria-expanded` but nothing else. This adds:
- **`aria-controls`** on the toggle pointing at the nav (now `id="primary-nav"`).
- **Focus moves into the menu** (first link) when it opens.
- **Escape closes** the menu and **returns focus to the toggle**.

## Testing
- `npm run test` (273, +3 SiteHeader tests: aria-controls, focus-in, Escape) ✅
- `npm run type-check`, `npm run lint`, `npm run test:coverage` + `check-coverage`, `npm run build` — all ✅

## Note
No visual change; keyboard/SR behaviour only. Left for review since it changes interaction. A full focus-trap within the menu could be a follow-up, but focus-in + Escape covers the reported gaps.