### PR TITLE
Expose contact-form validation errors to assistive tech

### DIFF
--- a/src/composables/useContactForm.test.ts
+++ b/src/composables/useContactForm.test.ts
@@ -461,4 +461,22 @@ describe('useContactForm', () => {
       expect(mockEvent.preventDefault).toHaveBeenCalled();
     });
   });
+
+  describe('errors', () => {
+    it('produces a required-field message once a field is touched and empty', () => {
+      const wrapper = mount(createTestComponent(TEST_URL));
+      wrapper.vm.handleBlur('name');
+      expect(wrapper.vm.errors.name).toBe('Name is required');
+    });
+
+    it('clears the message once the field is filled', async () => {
+      const wrapper = mount(createTestComponent(TEST_URL));
+      wrapper.vm.handleBlur('email');
+      expect(wrapper.vm.errors.email).toBe('Email is required');
+
+      wrapper.vm.formData.email = 'a@b.com';
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.errors.email).toBe('');
+    });
+  });
 });

--- a/src/composables/useContactForm.ts
+++ b/src/composables/useContactForm.ts
@@ -21,6 +21,7 @@ interface UseContactFormReturn {
   showSuccess: Ref<boolean>;
   isFormValid: ComputedRef<boolean>;
   fieldInvalid: ComputedRef<FormState>;
+  errors: ComputedRef<Record<keyof FormState, string>>;
   handleBlur: (field: keyof FormState) => void;
   handleInput: () => void;
   handleSubmit: (event: Event) => Promise<void>;
@@ -63,6 +64,14 @@ export const useContactForm = (submitUrl: string): UseContactFormReturn => {
     name: touched.value.name && formData.value.name.trim() === '',
     email: touched.value.email && formData.value.email.trim() === '',
     message: touched.value.message && formData.value.message.trim() === '',
+  }));
+
+  const FIELD_LABELS: Record<keyof FormState, string> = { name: 'Name', email: 'Email', message: 'Message' };
+
+  const errors = computed<Record<keyof FormState, string>>(() => ({
+    name: fieldInvalid.value.name ? `${FIELD_LABELS.name} is required` : '',
+    email: fieldInvalid.value.email ? `${FIELD_LABELS.email} is required` : '',
+    message: fieldInvalid.value.message ? `${FIELD_LABELS.message} is required` : '',
   }));
 
   // Handlers
@@ -130,6 +139,7 @@ export const useContactForm = (submitUrl: string): UseContactFormReturn => {
     // Validation
     isFormValid,
     fieldInvalid,
+    errors,
     // Handlers
     handleBlur,
     handleInput,

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -423,6 +423,14 @@
     }
   }
 
+  // Per-field validation message (announced via role="alert")
+  &__error {
+    display: block;
+    margin-top: $spacing-2;
+    font-size: $font-size-xs;
+    color: var(--color-error, #c0392b);
+  }
+
   &__label {
     display: block;
     margin-bottom: $spacing-2;

--- a/src/views/ContactView.test.ts
+++ b/src/views/ContactView.test.ts
@@ -29,4 +29,20 @@ describe('ContactView', () => {
     const wrapper = await mountView(ContactView);
     expect(wrapper.get('.contact-form__submit').text()).toBe(contactContent.form.submitText);
   });
+
+  it('marks a required field invalid and exposes an announced error after blur', async () => {
+    const wrapper = await mountView(ContactView);
+    const name = wrapper.get('#name');
+
+    expect(name.attributes('aria-invalid')).toBe('false');
+
+    await name.trigger('blur');
+
+    expect(name.attributes('aria-invalid')).toBe('true');
+    expect(name.attributes('aria-describedby')).toBe('name-error');
+
+    const error = wrapper.get('#name-error');
+    expect(error.attributes('role')).toBe('alert');
+    expect(error.text()).toBe('Name is required');
+  });
 });

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -22,7 +22,7 @@ usePageHead({
   schema: contactSchema,
 });
 
-const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, handleBlur, handleInput, handleSubmit } =
+const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, errors, handleBlur, handleInput, handleSubmit } =
   useContactForm(contactContent.form.action);
 </script>
 
@@ -97,9 +97,17 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, handleBl
             :class="['contact-form__input', { 'contact-form__input--invalid': fieldInvalid.name }]"
             :autocomplete="contactContent.form.fields.name.autocomplete"
             :required="contactContent.form.fields.name.required"
+            :aria-invalid="fieldInvalid.name"
+            :aria-describedby="fieldInvalid.name ? 'name-error' : undefined"
             @input="handleInput"
             @blur="handleBlur('name')"
           >
+          <span
+            v-if="fieldInvalid.name"
+            id="name-error"
+            class="contact-form__error"
+            role="alert"
+          >{{ errors.name }}</span>
         </div>
 
         <!-- Email Field -->
@@ -122,9 +130,17 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, handleBl
             :class="['contact-form__input', { 'contact-form__input--invalid': fieldInvalid.email }]"
             :autocomplete="contactContent.form.fields.email.autocomplete"
             :required="contactContent.form.fields.email.required"
+            :aria-invalid="fieldInvalid.email"
+            :aria-describedby="fieldInvalid.email ? 'email-error' : undefined"
             @input="handleInput"
             @blur="handleBlur('email')"
           >
+          <span
+            v-if="fieldInvalid.email"
+            id="email-error"
+            class="contact-form__error"
+            role="alert"
+          >{{ errors.email }}</span>
           <!-- FormSubmit: use email as reply-to -->
           <input
             type="hidden"
@@ -171,9 +187,17 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, handleBl
             :class="['contact-form__textarea', { 'contact-form__textarea--invalid': fieldInvalid.message }]"
             :rows="contactContent.form.fields.message.rows"
             :required="contactContent.form.fields.message.required"
+            :aria-invalid="fieldInvalid.message"
+            :aria-describedby="fieldInvalid.message ? 'message-error' : undefined"
             @input="handleInput"
             @blur="handleBlur('message')"
           />
+          <span
+            v-if="fieldInvalid.message"
+            id="message-error"
+            class="contact-form__error"
+            role="alert"
+          >{{ errors.message }}</span>
         </div>
 
         <!-- Submit Button -->


### PR DESCRIPTION
## Description
**Visible-UX/a11y change — left open for your review** (Hybrid policy). Audit Tier-2 (WCAG 3.3.1 / 3.3.3 / 4.1.3).

Required fields previously only turned their border red on blur — nothing was announced, and a blind user had no idea which field failed or why. This adds:
- **`errors`** computed to `useContactForm` — per-field message ("Name is required", etc.).
- On each input/textarea: **`aria-invalid`** and **`aria-describedby`** pointing at the error.
- A visible **`role="alert"`** error message per field (`.contact-form__error`, styled with `var(--color-error, #c0392b)`).

## Testing
- `npm run test` (273, +3: `errors` computed, ContactView ARIA wiring) ✅
- `npm run type-check`, `npm run lint`, `npm run test:coverage` + `check-coverage`, `npm run build` — all ✅

## Design notes (your call)
- Error text uses `var(--color-error, #c0392b)` — define `--color-error` in the theme tokens if you want a specific light/dark red.
- Wording is "{Field} is required" (the only current validation). Adjust copy as you like.