### PR TITLE
Give each page a single heading and demote the masthead title

### DIFF
--- a/src/components/AccordionSection.vue
+++ b/src/components/AccordionSection.vue
@@ -57,16 +57,18 @@ const toggle = () => {
     ref="sectionRef"
     class="accordion-section"
   >
-    <button
-      :id="`${ID_PREFIX.TRIGGER}${id}`"
-      class="accordion-trigger"
-      type="button"
-      :aria-expanded="isExpanded"
-      :aria-controls="`${ID_PREFIX.CONTENT}${id}`"
-      @click="toggle"
-    >
-      {{ title }}
-    </button>
+    <h2 class="accordion-heading">
+      <button
+        :id="`${ID_PREFIX.TRIGGER}${id}`"
+        class="accordion-trigger"
+        type="button"
+        :aria-expanded="isExpanded"
+        :aria-controls="`${ID_PREFIX.CONTENT}${id}`"
+        @click="toggle"
+      >
+        {{ title }}
+      </button>
+    </h2>
     <div
       :id="`${ID_PREFIX.CONTENT}${id}`"
       ref="contentRef"

--- a/src/components/SiteHeader.test.ts
+++ b/src/components/SiteHeader.test.ts
@@ -87,4 +87,10 @@ describe('SiteHeader', () => {
     expect(wrapper.find('.nav--open').exists()).toBe(false);
     expect(document.activeElement).toBe(wrapper.get('.nav-toggle').element);
   });
+
+  it('renders the site title as branding, not a page heading', async () => {
+    const { wrapper } = await mountHeader();
+    expect(wrapper.get('.masthead-title').element.tagName).toBe('P');
+    expect(wrapper.find('h1').exists()).toBe(false);
+  });
 });

--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -46,12 +46,12 @@ watch(() => route.path, () => {
 <template>
   <header class="masthead">
     <div class="masthead-inner">
-      <h1 class="masthead-title">
+      <p class="masthead-title">
         <RouterLink to="/">
           {{ siteConfig.title }}
         </RouterLink>
         <span class="masthead-tagline">{{ siteConfig.tagline }}</span>
-      </h1>
+      </p>
 
       <div class="masthead-controls">
         <button

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -727,6 +727,12 @@
   }
 }
 
+// Semantic heading wrapper around the trigger button — no visual footprint
+.accordion-heading {
+  margin: 0;
+  font: inherit;
+}
+
 .accordion-trigger {
   display: flex;
   align-items: center;

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -60,6 +60,7 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
       class="page"
       data-page="about"
     >
+      <h1 class="visually-hidden">About</h1>
       <template
         v-for="(section, sectionIndex) in aboutSections"
         :key="section.id"

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -32,6 +32,7 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, errors, 
       class="page"
       data-page="contact"
     >
+      <h1 class="visually-hidden">Contact</h1>
       <!-- Introduction -->
       <div
         v-show="!showSuccess"

--- a/src/views/HomeView.test.ts
+++ b/src/views/HomeView.test.ts
@@ -57,4 +57,9 @@ describe('HomeView', () => {
 
     expect(wrapper.get('.hero').classes()).toContain('hero--loaded');
   });
+
+  it('has a visually-hidden page heading', async () => {
+    const wrapper = await mountView(HomeView);
+    expect(wrapper.get('h1.visually-hidden').text()).toContain('Jerome Faria');
+  });
 });

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -41,6 +41,7 @@ onMounted(() => {
 <template>
   <div class="container-wide">
     <div class="home">
+      <h1 class="visually-hidden">{{ siteConfig.title }} — {{ siteConfig.tagline }}</h1>
       <section
         class="hero"
         :class="{ 'hero--loaded': heroImageLoaded }"

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -72,6 +72,7 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
       class="page"
       data-page="live"
     >
+      <h1 class="visually-hidden">Live</h1>
       <AccordionSection
         v-for="year in liveYears"
         :id="year"

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -22,6 +22,7 @@ useHashScroll(scrollToHash);
       class="page"
       data-page="press"
     >
+      <h1 class="visually-hidden">Press</h1>
       <blockquote
         v-for="item in pressQuotes"
         :id="item.id"

--- a/src/views/WorksView.test.ts
+++ b/src/views/WorksView.test.ts
@@ -18,4 +18,10 @@ describe('WorksView', () => {
     const totalReleases = Object.values(worksData).reduce((sum, section) => sum + section.items.length, 0);
     expect(wrapper.findAllComponents(ReleaseItem)).toHaveLength(totalReleases);
   });
+
+  it('has a page heading and wraps each accordion trigger in a heading', async () => {
+    const wrapper = await mountView(WorksView, '/works');
+    expect(wrapper.get('h1.visually-hidden').text()).toBe('Works');
+    expect(wrapper.findAll('h2.accordion-heading .accordion-trigger')).toHaveLength(worksSections.length);
+  });
 });

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -94,6 +94,7 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
       class="page"
       data-page="works"
     >
+      <h1 class="visually-hidden">Works</h1>
       <AccordionSection
         v-for="sectionKey in worksSections"
         :id="sectionKey"


### PR DESCRIPTION
## Description
**Visible-structure change — left open for your review** (Hybrid policy). Audit Tier-2 (WCAG 1.3.1 / 2.4.6). You chose the "hidden h1 + demote masthead" approach.

The masthead site-title was the only `<h1>`, repeated on every page, so SR heading navigation just announced "Jerome Faria" everywhere and content pages had no heading.

## Changes (zero visual change — verified in `dist`)
- **`SiteHeader`**: masthead title `<h1>` → `<p class="masthead-title">`. Styling is class-based (`margin: 0`), so it looks identical.
- **Each view** gets one **visually-hidden `<h1>`** naming it (Home → identity, About/Works/Live/Press/Contact). NotFound already had a visible `<h1>`.
- **`AccordionSection`**: trigger wrapped in `<h2 class="accordion-heading">` (`margin: 0; font: inherit;` — no footprint) per the WAI-ARIA APG.

Result: exactly one `<h1>` per page + a proper `h1 → h2` outline; masthead is branding, not a heading.

## Testing
- `npm run test` (273, +3 guards: masthead-is-`<p>`/no-h1, Works page-h1 + accordion-in-h2, Home h1) ✅
- `npm run type-check`, `npm run lint`, `npm run test:coverage` + `check-coverage`, `npm run build` ✅
- Verified rendered `dist`: masthead `<p>`, per-page `<h1>`, accordion `<h2>`.

## ⚠️ Merge note
Both this PR and **#81 (mobile-nav)** touch `SiteHeader.vue` / `SiteHeader.test.ts` in different spots. Whichever merges second will need a trivial rebase (the changes don't overlap logically). Ping me and I'll rebase.