### PR TITLE
Model event venues as structured data instead of parsing strings

### DIFF
--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -15,21 +15,21 @@ const plainEvent: LiveEvent = {
   id: 'fim-de-emissao-45',
   title: 'Fim de Emissão #45',
   date: '2025-01-17',
-  venue: 'Desterro, Lisbon, Portugal',
+  venue: { name: 'Desterro', url: 'https://darc.pt', city: 'Lisbon', country: 'Portugal' },
 };
 
 const festivalEvent: LiveEvent = {
   id: 'madeiradig-2011',
   title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
   date: '2011-12-02',
-  venue: 'Casa das Mudas, Calheta, Portugal',
+  venue: { name: 'Casa das Mudas', city: 'Calheta', country: 'Portugal' },
 };
 
 const internalRefEvent: LiveEvent = {
   id: 'aragao-funchal',
   title: '<a href="/works#aragao">Aragão</a>',
   date: '2021-09-22',
-  venue: 'Teatro Municipal Baltazar Dias, Funchal, Portugal',
+  venue: { name: 'Teatro Municipal Baltazar Dias', city: 'Funchal', country: 'Portugal' },
 };
 
 describe('EventItem', () => {
@@ -111,6 +111,31 @@ describe('EventItem', () => {
     it('renders no media control when the event has neither images nor videos', () => {
       const wrapper = mountEvent(plainEvent);
       expect(wrapper.find('.event-photos-link').exists()).toBe(false);
+    });
+  });
+
+  describe('venue', () => {
+    it('renders a linked venue name with city and country', () => {
+      const wrapper = mountEvent(plainEvent);
+      const venue = wrapper.get('.event-venue');
+      const link = venue.get('a');
+      expect(link.attributes('href')).toBe('https://darc.pt');
+      expect(link.text()).toBe('Desterro');
+      expect(venue.text()).toBe('Desterro, Lisbon, Portugal');
+    });
+
+    it('renders an unlinked venue name when there is no url', () => {
+      const wrapper = mountEvent(festivalEvent);
+      const venue = wrapper.get('.event-venue');
+      expect(venue.find('a').exists()).toBe(false);
+      expect(venue.text()).toBe('Casa das Mudas, Calheta, Portugal');
+    });
+
+    it('renders a country-only (TBC) venue as plain text', () => {
+      const wrapper = mountEvent({ ...plainEvent, venue: { country: 'Portugal' } });
+      const venue = wrapper.get('.event-venue');
+      expect(venue.find('a').exists()).toBe(false);
+      expect(venue.text()).toBe('Portugal');
     });
   });
 });

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -28,6 +28,10 @@ const titleHref = computed(() => {
 
 const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? ''));
 
+// City + country suffix for the venue line (either may be absent for a TBC venue).
+const venueLocation = computed(() =>
+  [props.event.venue.city, props.event.venue.country].filter(Boolean).join(', '));
+
 // Convert LiveImage to LightboxImage
 const convertImagesToLightbox = (images: LiveImage[]): LightboxItem[] => {
   return images.map(img => {
@@ -89,7 +93,10 @@ const convertVideosToLightbox = (videos: LiveVideo[]): LightboxItem[] => {
           v-if="event.date"
           class="event-date"
         >{{ formattedDate }} · </span>
-        <span v-html="event.venue" />
+        <span class="event-venue"><template v-if="event.venue.name"><a
+          v-if="event.venue.url"
+          :href="event.venue.url"
+        >{{ event.venue.name }}</a><template v-else>{{ event.venue.name }}</template><template v-if="venueLocation">, </template></template>{{ venueLocation }}</span>
       </p>
       <p
         v-if="event.description"

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -11,14 +11,14 @@ export const liveData: LiveData = {
         id: 'tbc-2026-09-19',
         title: 'TBC',
         date: '2026-09-19',
-        venue: 'Portugal',
+        venue: { country: 'Portugal' },
         description: 'Solo performance.',
       },
       {
         id: 'tbc-2026-08-23',
         title: 'TBC',
         date: '2026-08-23',
-        venue: 'Portugal',
+        venue: { country: 'Portugal' },
         description: 'Solo performance.',
       },
     ],
@@ -31,7 +31,7 @@ export const liveData: LiveData = {
         id: 'showcase-casa-amarela',
         title: 'Showcase Casa Amarela',
         date: '2025-06-14',
-        venue: '<a href="https://www.instagram.com/cooperativamula/">Cooperativa Mula</a>, Barreiro, Portugal',
+        venue: { name: 'Cooperativa Mula', url: 'https://www.instagram.com/cooperativamula/', city: 'Barreiro', country: 'Portugal' },
         description: 'NOx (with <a href="https://cavernancia.bandcamp.com/">Pedro Roque</a>). With <a href="https://copodagua.bandcamp.com/">Copo d\'Água</a>, TiaAvô, Rebolation All-Stars.',
         images: [
           {
@@ -95,7 +95,7 @@ export const liveData: LiveData = {
         id: 'fim-de-emissao-45',
         title: 'Fim de Emissão #45',
         date: '2025-01-17',
-        venue: '<a href="https://darc.pt">Desterro</a>, Lisbon, Portugal',
+        venue: { name: 'Desterro', url: 'https://darc.pt', city: 'Lisbon', country: 'Portugal' },
         description: 'Solo performance. With Ai Feith, W.T.V.R.',
         images: [
           {
@@ -150,14 +150,14 @@ export const liveData: LiveData = {
         id: 'cca-no-desterro-august',
         title: 'CCA no Desterro',
         date: '2024-08-10',
-        venue: '<a href="https://darc.pt">Desterro</a>, Lisbon, Portugal',
+        venue: { name: 'Desterro', url: 'https://darc.pt', city: 'Lisbon', country: 'Portugal' },
         description: 'Solo performance. With <a href="https://mosskissingmusic.bandcamp.com/">Moss Kissing</a>, Rui Wentacid (DJ set).',
       },
       {
         id: 'cca-no-desterro',
         title: 'CCA no Desterro',
         date: '2024-05-02',
-        venue: '<a href="https://darc.pt">Desterro</a>, Lisbon, Portugal',
+        venue: { name: 'Desterro', url: 'https://darc.pt', city: 'Lisbon', country: 'Portugal' },
         description: 'NOx (with <a href="https://cavernancia.bandcamp.com/">Pedro Roque</a>). With <a href="https://copodagua.bandcamp.com/">Copo d\'Água</a>, <a href="https://soundcloud.com/djprivilegio">DJ Privilégio</a>, <a href="https://casaamarela.bandcamp.com/album/shimano">Gallo\'84</a>.',
         images: [
           {
@@ -247,7 +247,7 @@ export const liveData: LiveData = {
         id: 'amess-teatro-baltazar-dias',
         title: 'Performance with Amess',
         date: '2022-07-02',
-        venue: '<a href="https://www.teatromunicipal.pt/">Teatro Municipal Baltazar Dias</a>, Funchal, Portugal',
+        venue: { name: 'Teatro Municipal Baltazar Dias', url: 'https://www.teatromunicipal.pt/', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://www.instagram.com/amess.music/">Amess</a>.',
         images: [
           {
@@ -271,7 +271,7 @@ export const liveData: LiveData = {
         id: 'amess-museu-franco',
         title: 'Performance with Amess',
         date: '2022-03-18',
-        venue: '<a href="https://museus.madeira.gov.pt/DetalhesMuseu?museumId=3">Museu Henrique e Francisco Franco</a>, Funchal, Portugal',
+        venue: { name: 'Museu Henrique e Francisco Franco', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=3', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://www.instagram.com/amess.music/">Amess</a>.',
         images: [
           {
@@ -305,7 +305,7 @@ export const liveData: LiveData = {
         id: 'jejum-11',
         title: 'Jejum #11',
         date: '2022-03-05',
-        venue: '<a href="https://ruadasgaivotas6.pt/">Rua das Gaivotas 6</a>, Lisbon, Portugal',
+        venue: { name: 'Rua das Gaivotas 6', url: 'https://ruadasgaivotas6.pt/', city: 'Lisbon', country: 'Portugal' },
         images: [
           {
             src: '/images/live/jejum-11-001.jpg',
@@ -389,14 +389,14 @@ export const liveData: LiveData = {
         id: 'aragao-cartaxo',
         title: '<a href="/works#aragao">Aragão</a>',
         date: '2021-10-23',
-        venue: '<a href="https://www.cm-cartaxo.pt/servicos-municipais/cultura/equipamentos-culturais/item/49-centro-cultural-municipio-do-cartaxo">Centro Cultural do Cartaxo</a>, Cartaxo, Portugal',
+        venue: { name: 'Centro Cultural do Cartaxo', url: 'https://www.cm-cartaxo.pt/servicos-municipais/cultura/equipamentos-culturais/item/49-centro-cultural-municipio-do-cartaxo', city: 'Cartaxo', country: 'Portugal' },
         description: 'Theatre production. Live music & interpretation.',
       },
       {
         id: 'nariz-entupido',
         title: 'Nariz Entupido',
         date: '2021-10-22',
-        venue: '<a href="https://www.smup.pt/">SMUP</a>, Parede, Portugal',
+        venue: { name: 'SMUP', url: 'https://www.smup.pt/', city: 'Parede', country: 'Portugal' },
         description: 'Duo with <a href="https://cavernancia.bandcamp.com/">CAVERNANCIA</a>. <a href="https://thisco.bandcamp.com/">THISCO</a> / SPH anniversary celebration.',
         images: [
           {
@@ -425,7 +425,7 @@ export const liveData: LiveData = {
         id: 'aragao-funchal',
         title: '<a href="/works#aragao">Aragão</a>',
         date: '2021-09-22',
-        venue: '<a href="https://www.teatromunicipal.pt/">Teatro Municipal Baltazar Dias</a>, Funchal, Portugal',
+        venue: { name: 'Teatro Municipal Baltazar Dias', url: 'https://www.teatromunicipal.pt/', city: 'Funchal', country: 'Portugal' },
         description: 'Theatre production. Live music & interpretation.',
         images: [
           {
@@ -439,7 +439,7 @@ export const liveData: LiveData = {
         id: 'reviralho',
         title: 'Reviralho',
         date: '2021-08-20',
-        venue: 'Cais do Carvão, Funchal, Portugal',
+        venue: { name: 'Cais do Carvão', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://www.instagram.com/amess.music/">Amess</a>.',
       },
     ],
@@ -452,7 +452,7 @@ export const liveData: LiveData = {
         id: 'heineken-series',
         title: 'Heineken Series',
         date: '2015-09-18',
-        venue: '<a href="https://www.musicboxlisboa.com/">Musicbox</a>, Lisbon, Portugal',
+        venue: { name: 'Musicbox', url: 'https://www.musicboxlisboa.com/', city: 'Lisbon', country: 'Portugal' },
         description: 'With <a href="https://www.mmlxii.com/">William Basinski</a>, <a href="https://zigurartists.bandcamp.com/album/forgetting-is-a-liability">Mr. Herbert Quain</a>, <a href="https://www.viberate.com/artist/cruz-767/">Cruz</a>.',
         images: [
           {
@@ -511,7 +511,7 @@ export const liveData: LiveData = {
         id: 'fica-na-cidade',
         title: '<a href="https://www.visitfunchal.pt/pt/todos-os-eventos/280-fica-na-cidade.html">Fica na Cidade</a>',
         date: '2015-06-05',
-        venue: 'Praça de Colombo, Funchal, Portugal',
+        venue: { name: 'Praça de Colombo', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://trengosoundsystem.bandcamp.com/">Tren Go! Sound System</a>.',
         images: [
           {
@@ -531,21 +531,21 @@ export const liveData: LiveData = {
         id: 'cognitivopolis',
         title: 'Cognitivopolis',
         date: '2013-11-15',
-        venue: '<a href="https://www.pontadosol.com/">Estalagem da Ponta do Sol</a>, Ponta do Sol, Portugal',
+        venue: { name: 'Estalagem da Ponta do Sol', url: 'https://www.pontadosol.com/', city: 'Ponta do Sol', country: 'Portugal' },
         description: 'Solo performance. Festival about creativity, technology and science. With <a href="https://massimobanzi.com/">Massimo Banzi</a> (Arduino), <a href="https://davidrowan.com/">David Rowan</a> (Wired UK), Gian Giudice (CERN).',
       },
       {
         id: 'caligari-live-3',
         title: '<a href="https://www.pontadosol.com/l-concerts">Concertos L</a>: The Cabinet of Dr. Caligari',
         date: '2013-10-26',
-        venue: '<a href="https://www.pontadosol.com/">Estalagem da Ponta do Sol</a>, Ponta do Sol, Portugal',
+        venue: { name: 'Estalagem da Ponta do Sol', url: 'https://www.pontadosol.com/', city: 'Ponta do Sol', country: 'Portugal' },
         description: 'Live score for Robert Wiene\'s 1920 expressionist silent film. With <a href="https://nunoandtheend.bandcamp.com/">Nuno Filipe</a>.',
       },
       {
         id: 'caligari-live-2',
         title: 'The Cabinet of Dr. Caligari',
         date: '2013-09-13',
-        venue: 'Scat Music Club, Funchal, Portugal',
+        venue: { name: 'Scat Music Club', city: 'Funchal', country: 'Portugal' },
         description: 'Live score for Robert Wiene\'s 1920 expressionist silent film. With <a href="https://nunoandtheend.bandcamp.com/">Nuno Filipe</a>.',
         images: [
           {
@@ -559,7 +559,7 @@ export const liveData: LiveData = {
         id: 'caligari-live',
         title: 'Cidades Eletrónicas: The Cabinet of Dr. Caligari',
         date: '2013-05-11',
-        venue: '<a href="https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1">Casa das Mudas</a>, Calheta, Portugal',
+        venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'Premiere of live score for Robert Wiene\'s 1920 expressionist silent film. With <a href="https://nunoandtheend.bandcamp.com/">Nuno Filipe</a>.',
         images: [
           {
@@ -578,7 +578,7 @@ export const liveData: LiveData = {
         id: 'cine-qua-non',
         date: '2012-10-27',
         title: 'Cine Qua Non',
-        venue: '<a href="https://www.pontadosol.com/">Estalagem da Ponta do Sol</a>, Ponta do Sol, Portugal',
+        venue: { name: 'Estalagem da Ponta do Sol', url: 'https://www.pontadosol.com/', city: 'Ponta do Sol', country: 'Portugal' },
         description: 'Improvisation collective. Electronics, piano (<a href="https://nunoandtheend.bandcamp.com/">Nuno Filipe</a>), percussion (<a href="https://madeirajazzcollective.bandcamp.com/">Jorge Maggiore</a>) and visuals (Filipe Ferraz).',
         videos: [
           {
@@ -598,7 +598,7 @@ export const liveData: LiveData = {
         id: 'madeiradig-2011',
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
         date: '2011-12-02',
-        venue: '<a href="https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1">Casa das Mudas</a>, Calheta, Portugal',
+        venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'Duo with <a href="https://12k.com/">Taylor Deupree</a>. With <a href="https://sunblind.net/">Tim Hecker</a>, <a href="https://pointnever.com/">Oneohtrix Point Never</a>, <a href="https://ktl10.bandcamp.com/">KTL</a>, <a href="https://deafcenter.bandcamp.com/">Deaf Center</a>, <a href="https://www.leeranaldo.com/">Lee Ranaldo</a> & Manuel Mota, <a href="https://nadja.bandcamp.com/">Nadja</a>, <a href="https://akionda.net/">Aki Onda</a>.',
         images: [
           {
@@ -637,7 +637,7 @@ export const liveData: LiveData = {
         id: 'migractions-2011',
         title: 'Festival Migractions',
         date: '2011-05-23',
-        venue: '<a href="https://www.theatredelopprime.com/">Théâtre de L\'Opprimé</a>, Paris, France',
+        venue: { name: 'Théâtre de L\'Opprimé', url: 'https://www.theatredelopprime.com/', city: 'Paris', country: 'France' },
         description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>.',
         images: [
           {
@@ -662,7 +662,7 @@ export const liveData: LiveData = {
         id: 'olhares-de-outono-2010',
         date: '2010-11-27',
         title: 'Olhares de Outono',
-        venue: '<a href="https://passosmanuel.net/">Passos Manuel</a>, Porto, Portugal',
+        venue: { name: 'Passos Manuel', url: 'https://passosmanuel.net/', city: 'Porto', country: 'Portugal' },
         description: 'Artist talk and performance. With <a href="https://oval.bandcamp.com/">Oval</a>, <a href="https://simonfisherturner.bandcamp.com/">Simon Fisher Turner</a>, Paul Farrington, André Gonçalves.',
         images: [
           {
@@ -712,7 +712,7 @@ export const liveData: LiveData = {
         id: 'madeiradig-2009',
         date: '2009-12-04',
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
-        venue: '<a href="https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1">Casa das Mudas</a>, Calheta, Portugal',
+        venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>. With <a href="https://www.alvanoto.com/">Alva Noto</a>, <a href="https://murcof.com/">Murcof</a>, <a href="https://felixkubin.bandcamp.com/">Felix Kubin</a>, <a href="https://www.discogs.com/artist/31633-Christ">Christ.</a>, <a href="https://zavoloka.com/">Zavoloka</a> & <a href="https://laetitiamorais.com/">Laetitia Morais</a>, <a href="https://gigantiq.bandcamp.com/">Gigantiq</a>, <a href="http://www.jade-enterprises.at/">Jade</a>.',
         images: [
           {
@@ -758,7 +758,7 @@ export const liveData: LiveData = {
         id: 'eme-olhares-2009',
         title: 'EME.LL / Olhares de Outono',
         date: '2009-11-21',
-        venue: '<a href="https://www.tnsj.pt/en/edificios/mosteiro-de-sao-bento-da-vitoria/">Mosteiro São Bento da Vitória</a>, Porto, Portugal',
+        venue: { name: 'Mosteiro São Bento da Vitória', url: 'https://www.tnsj.pt/en/edificios/mosteiro-de-sao-bento-da-vitoria/', city: 'Porto', country: 'Portugal' },
         description: 'Resampling White Noise — 16-performer laptop meeting. With <a href="https://scannerdot.bandcamp.com/">Scanner</a>, <a href="https://at-c.org/">@c</a>, <a href="https://www.vitorjoaquim.pt/">Vitor Joaquim</a>, <a href="https://carlossantos.bandcamp.com/">Carlos Santos</a>, <a href="https://www.carvalhais.org/">Miguel Carvalhais</a>, <a href="http://pedrotudela.org/">Pedro Tudela</a>, Pedro Almeida, <a href="https://opcabpol.bandcamp.com/">João Ricardo</a>, <a href="https://ivanfranco.wordpress.com/">Ivan Franco</a>, <a href="https://nunomoita.bandcamp.com/">Nuno Moita</a>, <a href="https://www.andregoncalves.info/">André Gonçalves</a>, <a href="https://cronica.bandcamp.com/album/musicamorosa">The Beautiful Schizophonic</a>, Rui Costa, <a href="https://andre-sier.com/">André Sier</a>, <a href="https://blog.albagcorral.com/">Alba Corral</a>, <a href="https://laetitiamorais.com/">Laetitia Morais</a>, <a href="https://vimeo.com/hugoolim">Hugo Olim</a>.',
         images: [
           {
@@ -798,14 +798,14 @@ export const liveData: LiveData = {
         id: 'eme-madeira-2008',
         date: '2008-10-04',
         title: 'EME — Extensão Madeira',
-        venue: '<a href="https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1">Casa das Mudas</a>, Calheta, Portugal',
+        venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'With <a href="https://hauschka.bandcamp.com/">Hauschka</a>, <a href="https://thesightbelow.bandcamp.com/">The Sight Below</a>.',
       },
       {
         id: 'eme-2008',
         title: 'EME',
         date: '2008-10-01',
-        venue: '<a href="https://teatroiberico.org/">Teatro Ibérico</a>, Lisbon, Portugal',
+        venue: { name: 'Teatro Ibérico', url: 'https://teatroiberico.org/', city: 'Lisbon', country: 'Portugal' },
         description: 'With <a href="https://thesightbelow.bandcamp.com/">The Sight Below</a>, <a href="https://greghaines.bandcamp.com/">Greg Haines</a>, <a href="https://hauschka.bandcamp.com/">Hauschka</a>, <a href="https://frankbretschneider.bandcamp.com/">Frank Bretschneider</a>, <a href="https://soundcloud.com/sanso-xtro">Sanso-Xtro</a>, <a href="https://annatroisi.org/">Anna Troisi</a>, <a href="https://www.tinafrank.net/">Tina Frank</a>, <a href="https://carstengoertz.cc/">Carsten Goertz</a>, <a href="https://andre-sier.com/">André Sier</a>, <a href="https://www.andregoncalves.info/">André Gonçalves</a>, <a href="https://margaridagarcia.bandcamp.com/">Garcia</a>, Machas, <a href="https://davidmaranha.bandcamp.com/">Maranha</a> e <a href="https://manuelmota.bandcamp.com/">Mota</a>, Safe & Sound, <a href="https://cronica.bandcamp.com/album/musicamorosa">The Beautiful Schizophonic</a>.',
         images: [
           {
@@ -861,7 +861,7 @@ export const liveData: LiveData = {
         id: 'storung-2008',
         date: '2008-09-25',
         title: '<a href="https://ra.co/promoters/4519">Störung</a>',
-        venue: '<a href="https://farinera.org/">La Farinera del Clot</a>, Barcelona, Spain',
+        venue: { name: 'La Farinera del Clot', url: 'https://farinera.org/', city: 'Barcelona', country: 'Spain' },
         description: 'With <a href="https://kimcascone.bandcamp.com/">Kim Cascone</a>, <a href="https://www.franciscolopez.net/">Francisco López</a>, <a href="https://philippepetit.bandcamp.com/">Philippe Petit</a>, <a href="https://ritornell.bandcamp.com/">Ritornell</a>, Sébastien Roux, Tonne.',
         images: [
           {
@@ -891,7 +891,7 @@ export const liveData: LiveData = {
         id: 'stfu-porto',
         date: '2007-03-22',
         title: 'STFU Porto',
-        venue: '<a href="https://fabricadesom.org/">Fábrica do Som</a>, Porto, Portugal',
+        venue: { name: 'Fábrica do Som', url: 'https://fabricadesom.org/', city: 'Porto', country: 'Portugal' },
         description: 'With <a href="https://svartegreiner.bandcamp.com/">Svarte Greiner</a>, Pygar (<a href="https://vimeo.com/hugoolim">Hugo Olim</a> & <a href="https://opcabpol.bandcamp.com/">João Ricardo</a>), e:4c, CKZ, DeciBeats, Aenedra, Unknown Forces Of Everyday Life.',
         images: [
           {
@@ -915,7 +915,7 @@ export const liveData: LiveData = {
         id: 'madeiradig-2007',
         date: '2007-12-08',
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
-        venue: '<a href="https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1">Casa das Mudas</a>, Calheta, Portugal',
+        venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'With <a href="https://alogmusic.bandcamp.com/">Alog</a>, <a href="https://vladislavdelay.bandcamp.com/">Vladislav Delay</a>, <a href="https://ranslavin.com/">Ran Slavin</a>.',
         images: [
           {
@@ -980,7 +980,7 @@ export const liveData: LiveData = {
         id: 'madeiradig-2006',
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
         date: '2006-12-07',
-        venue: '<a href="https://madeira.rtp.pt/">RDP Auditorium</a>, Funchal, Portugal',
+        venue: { name: 'RDP Auditorium', url: 'https://madeira.rtp.pt/', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://phonophani.bandcamp.com/">Phonophani</a> & <a href="https://mariuswatz.com/">Marius Watz</a>, <a href="https://frankbretschneider.bandcamp.com/">Frank Bretschneider</a>.',
       },
     ],
@@ -993,7 +993,7 @@ export const liveData: LiveData = {
         id: 'madeiradig-2005',
         date: '2005-12-07',
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
-        venue: '<a href="https://madeira.rtp.pt/">RDP Auditorium</a>, Funchal, Portugal',
+        venue: { name: 'RDP Auditorium', url: 'https://madeira.rtp.pt/', city: 'Funchal', country: 'Portugal' },
         description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>. With <a href="https://www.fennesz.com/">Fennesz</a>, <a href="https://florianhecker.blogspot.com/">Florian Hecker</a>, <a href="https://at-c.org/">@c</a> & <a href="https://liaworks.com/">Lia</a>.',
         images: [
           {

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -17,11 +17,18 @@ export interface LiveVideo {
   platform: 'youtube' | 'vimeo';
 }
 
+export interface EventVenue {
+  name?: string;
+  url?: string;
+  city?: string;
+  country: string;
+}
+
 export interface LiveEvent {
   id: string;
   title: string;
   date: string;
-  venue: string;
+  venue: EventVenue;
   description?: string;
   images?: LiveImage[];
   videos?: LiveVideo[];

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractYear, parseVenue, stripHtml } from './formatters';
+import { extractYear, stripHtml } from './formatters';
 
 describe('formatters', () => {
   describe('stripHtml', () => {
@@ -51,96 +51,6 @@ describe('formatters', () => {
     it('should handle null/undefined gracefully', () => {
       expect(stripHtml(null as unknown as string)).toBe('');
       expect(stripHtml(undefined as unknown as string)).toBe('');
-    });
-  });
-
-  describe('parseVenue', () => {
-    it('should parse full venue format correctly', () => {
-      const venue = 'Teatro Nacional, Lisbon, Portugal';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: 'Teatro Nacional',
-        addressLocality: 'Lisbon',
-        addressCountry: 'Portugal',
-      });
-    });
-
-    it('should parse venue with two parts', () => {
-      const venue = 'Teatro Nacional, Lisbon';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: 'Teatro Nacional',
-        addressLocality: 'Lisbon',
-        addressCountry: '',
-      });
-    });
-
-    it('should parse venue with one part', () => {
-      const venue = 'Teatro Nacional';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: 'Teatro Nacional',
-        addressLocality: '',
-        addressCountry: '',
-      });
-    });
-
-    it('should trim whitespace from parts', () => {
-      const venue = '  Teatro Nacional  ,  Lisbon  ,  Portugal  ';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: 'Teatro Nacional',
-        addressLocality: 'Lisbon',
-        addressCountry: 'Portugal',
-      });
-    });
-
-    it('should handle empty string', () => {
-      const venue = '';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: '',
-        addressLocality: '',
-        addressCountry: '',
-      });
-    });
-
-    it('should strip HTML from venue string', () => {
-      const venue = '<strong>Teatro Nacional</strong>, <em>Lisbon</em>, Portugal';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: 'Teatro Nacional',
-        addressLocality: 'Lisbon',
-        addressCountry: 'Portugal',
-      });
-    });
-
-    it('should handle venue with HTML and commas in name', () => {
-      const venue = '<a href="#">Venue, Inc.</a>, New York, USA';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: 'Venue',
-        addressLocality: 'Inc.',
-        addressCountry: 'New York',
-      });
-    });
-
-    it('should handle extra commas', () => {
-      const venue = 'Teatro Nacional, Lisbon, Portugal, Europe';
-      const result = parseVenue(venue);
-
-      expect(result).toEqual({
-        name: 'Teatro Nacional',
-        addressLocality: 'Lisbon',
-        addressCountry: 'Portugal',
-      });
     });
   });
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -5,27 +5,6 @@
  */
 export const stripHtml = (html: string): string => html?.replace(/<[^>]*>/g, '') || '';
 
-export interface ParsedVenue {
-  name: string;
-  addressLocality: string;
-  addressCountry: string;
-}
-
-/**
- * Parse a venue string into structured address components
- * @param venue - Venue string (e.g., "Venue Name, City, Country")
- * @returns Parsed venue with name, addressLocality, addressCountry
- */
-export const parseVenue = (venue: string): ParsedVenue => {
-  const text = stripHtml(venue);
-  const parts = text.split(',').map(s => s.trim());
-  return {
-    name: parts[0] || '',
-    addressLocality: parts[1] || '',
-    addressCountry: parts[2] || '',
-  };
-};
-
 /**
  * Extract a year (1900-2099) from a string
  * @param text - Text containing a year (e.g., "Digital — BRØQN, 2024")

--- a/src/utils/schemaHelpers.test.ts
+++ b/src/utils/schemaHelpers.test.ts
@@ -8,7 +8,7 @@ const baseEvent: LiveEvent = {
   id: 'madeiradig-2011',
   title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
   date: '2011-12-02',
-  venue: '<a href="https://example.com">Casa das Mudas</a>, Calheta, Portugal',
+  venue: { name: 'Casa das Mudas', url: 'https://example.com', city: 'Calheta', country: 'Portugal' },
 };
 
 describe('createMusicEventSchema', () => {

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -1,7 +1,7 @@
 import type { LiveEvent } from '@/types/live';
 import type { SchemaItemList, SchemaMusicAlbum, SchemaMusicEvent } from '@/types/schema';
 
-import { parseVenue, stripHtml } from './formatters';
+import { stripHtml } from './formatters';
 
 interface ReleaseForSchema {
   title: string;
@@ -23,18 +23,17 @@ export const createMusicEventSchema = (
   performerName: string,
   fallbackDate = '',
 ): SchemaMusicEvent => {
-  const venue = parseVenue(event.venue);
   return {
     '@type': 'MusicEvent',
     name: stripHtml(event.title),
     startDate: event.date || fallbackDate,
     location: {
       '@type': 'Place',
-      name: venue.name,
+      name: event.venue.name ?? '',
       address: {
         '@type': 'PostalAddress',
-        addressLocality: venue.addressLocality,
-        addressCountry: venue.addressCountry,
+        addressLocality: event.venue.city ?? '',
+        addressCountry: event.venue.country,
       },
     },
     performer: {


### PR DESCRIPTION
## Description
Resolves the `parseVenue` ambiguity (audit item 2) at the source — you chose **structured venue data**. The `venue` field was a free-text string that embedded an `<a>` link and was parsed positionally into name/city/country, which mislabeled anything that wasn't exactly 3 parts (e.g. the 2026 `"Portugal"` placeholders became a `Place` *named* "Portugal").

## Changes
- **Type**: new `EventVenue { name?, url?, city?, country }`; `LiveEvent.venue` is now `EventVenue`.
- **Data**: all **32** event venues converted to structured objects (scripted + verified; e.g. `{ name: 'Cooperativa Mula', url: '…', city: 'Barreiro', country: 'Portugal' }`, placeholders → `{ country: 'Portugal' }`).
- **EventItem**: renders venue name (optionally linked) + city + country from the structure instead of `v-html`.
- **schemaHelpers**: builds the JSON-LD `Place` from `venue.name/city/country` directly — exact for every event, including 1-part ones.
- **formatters**: removed the now-unused `parseVenue` + `ParsedVenue` and their tests.
- Tests updated + new venue-render cases (linked, unlinked, country-only).

## Testing
- `npm run test` (265) + `check-coverage` (floor 81) ✅
- `npm run type-check`, `npm run lint`, `npm run build` ✅
- Verified rendered `dist/live.html`: linked venues render `<a>Name</a>, City, Country`; placeholders render `Country`. No visual change.

## Note
Venue links are plain `<a href>` (as before); `App.vue`'s `processExternalLinks` still adds `target`/`rel` at runtime, so external-link behaviour is unchanged.