### PR TITLE
Remove the unused 'default' lightbox variant

### DIFF
--- a/src/components/LightboxOverlay.test.ts
+++ b/src/components/LightboxOverlay.test.ts
@@ -16,7 +16,6 @@ const mountOverlay = (props: Record<string, unknown> = {}) =>
       currentItem: image,
       currentIndex: 0,
       totalItems: 1,
-      variant: 'compact',
       ...props,
     },
   });

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -4,15 +4,12 @@ import { computed, nextTick, onMounted, ref } from 'vue';
 import type { LightboxItem } from '@/types';
 import { isLightboxImage, isLightboxVideo } from '@/types';
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   isOpen: boolean;
   currentItem: LightboxItem | null;
   currentIndex: number;
   totalItems: number;
-  variant?: 'default' | 'compact';
-}>(), {
-  variant: 'default',
-});
+}>();
 
 const emit = defineEmits<{
   close: [];
@@ -104,131 +101,71 @@ onMounted(async () => {
       @touchstart="handleTouchStart"
       @touchend="handleTouchEnd"
     >
-      <!-- Default variant: separate close button + side navigation -->
-      <template v-if="variant === 'default'">
+      <!-- Video -->
+      <iframe
+        v-if="isVideo && currentItem && isLightboxVideo(currentItem)"
+        :src="currentItem.url"
+        class="lightbox__video"
+        :title="currentItem.title || 'Video'"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        @click.stop
+      />
+
+      <!-- Image -->
+      <picture v-else-if="isImage && currentItem && isLightboxImage(currentItem)">
+        <source
+          :srcset="currentItem.src.replace('.jpg', '.webp')"
+          type="image/webp"
+        >
+        <img
+          :src="currentItem.src"
+          :alt="currentItem.alt"
+          class="lightbox__image"
+        >
+      </picture>
+
+      <!-- Navigation hints as buttons -->
+      <div class="lightbox__hints">
         <button
-          class="lightbox__close"
+          class="lightbox__hint lightbox__hint--prev"
+          :disabled="currentIndex === 0"
+          aria-label="Previous image"
+          @click.stop="handlePrev"
+        >
+          ←
+        </button>
+        <button
+          class="lightbox__hint lightbox__hint--close"
           aria-label="Close lightbox"
           @click.stop="handleClose"
-        />
-
+        >
+          ×
+        </button>
         <button
-          v-if="currentIndex > 0"
-          class="lightbox__nav lightbox__nav--prev"
-          aria-label="Previous item"
-          @click.stop="handlePrev"
-        />
-
-        <!-- Video -->
-        <iframe
-          v-if="isVideo && currentItem && isLightboxVideo(currentItem)"
-          :src="currentItem.url"
-          class="lightbox__video"
-          :title="currentItem.title || 'Video'"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen
-          @click.stop
-        />
-
-        <!-- Image -->
-        <picture v-else-if="isImage && currentItem && isLightboxImage(currentItem)">
-          <source
-            :srcset="currentItem.src.replace('.jpg', '.webp')"
-            type="image/webp"
-          >
-          <img
-            :src="currentItem.src"
-            :alt="currentItem.alt"
-            class="lightbox__image"
-          >
-        </picture>
-
-        <button
-          v-if="currentIndex < totalItems - 1"
-          class="lightbox__nav lightbox__nav--next"
+          class="lightbox__hint lightbox__hint--next"
+          :disabled="currentIndex >= totalItems - 1"
           aria-label="Next item"
           @click.stop="handleNext"
-        />
-
-        <!-- Keyboard hints -->
-        <div class="lightbox__hints">
-          <span class="lightbox__hint">ESC to close</span>
-          <span
-            v-if="totalItems > 1"
-            class="lightbox__hint"
-          >← → to navigate</span>
-        </div>
-      </template>
-
-      <!-- Compact variant: button hints + photographer credit -->
-      <template v-else-if="variant === 'compact'">
-        <!-- Video -->
-        <iframe
-          v-if="isVideo && currentItem && isLightboxVideo(currentItem)"
-          :src="currentItem.url"
-          class="lightbox__video"
-          :title="currentItem.title || 'Video'"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen
-          @click.stop
-        />
-
-        <!-- Image -->
-        <picture v-else-if="isImage && currentItem && isLightboxImage(currentItem)">
-          <source
-            :srcset="currentItem.src.replace('.jpg', '.webp')"
-            type="image/webp"
-          >
-          <img
-            :src="currentItem.src"
-            :alt="currentItem.alt"
-            class="lightbox__image"
-          >
-        </picture>
-
-        <!-- Navigation hints as buttons -->
-        <div class="lightbox__hints">
-          <button
-            class="lightbox__hint lightbox__hint--prev"
-            :disabled="currentIndex === 0"
-            aria-label="Previous image"
-            @click.stop="handlePrev"
-          >
-            ←
-          </button>
-          <button
-            class="lightbox__hint lightbox__hint--close"
-            aria-label="Close lightbox"
-            @click.stop="handleClose"
-          >
-            ×
-          </button>
-          <button
-            class="lightbox__hint lightbox__hint--next"
-            :disabled="currentIndex >= totalItems - 1"
-            aria-label="Next item"
-            @click.stop="handleNext"
-          >
-            →
-          </button>
-        </div>
-
-        <!-- Photographer credit -->
-        <div
-          v-if="photographer"
-          class="lightbox__credit"
         >
-          Photo by <a
-            v-if="photographer.url"
-            :href="photographer.url"
-            target="_blank"
-            rel="noopener noreferrer"
-          >{{ photographer.name }}</a>
-          <span v-else>{{ photographer.name }}</span>
-        </div>
-      </template>
+          →
+        </button>
+      </div>
+
+      <!-- Photographer credit -->
+      <div
+        v-if="photographer"
+        class="lightbox__credit"
+      >
+        Photo by <a
+          v-if="photographer.url"
+          :href="photographer.url"
+          target="_blank"
+          rel="noopener noreferrer"
+        >{{ photographer.name }}</a>
+        <span v-else>{{ photographer.name }}</span>
+      </div>
     </div>
   </Transition>
 </template>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -127,7 +127,6 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
       :current-item="currentItem"
       :current-index="currentIndex"
       :total-items="items.length"
-      variant="compact"
       @close="closeLightbox"
       @prev="goToPrev"
       @next="goToNext"

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -97,7 +97,6 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
       :current-item="currentItem"
       :current-index="currentIndex"
       :total-items="items.length"
-      variant="compact"
       @close="closeLightbox"
       @prev="goToPrev"
       @next="goToNext"

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -120,7 +120,6 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
       :current-item="currentItem"
       :current-index="currentIndex"
       :total-items="items.length"
-      variant="compact"
       @close="closeLightbox"
       @prev="goToPrev"
       @next="goToNext"


### PR DESCRIPTION
## Description
Dead-code cleanup (audit item 4a). `LightboxOverlay` had a `variant` prop with a `'default'` branch (~50 lines) that **no caller used** — About/Works/Live all pass `variant="compact"` — and whose controls (`.lightbox__close`, `.lightbox__nav`) had **no CSS**, so they'd have rendered as invisible zero-size buttons if ever used.

## Changes
- Remove the `variant` prop and the `<template v-if="variant === 'default'">` block; unwrap the `compact` markup as the component's only rendering.
- Drop the now-redundant `variant="compact"` from AboutView / LiveView / WorksView.
- Remove `variant` from `LightboxOverlay.test.ts`.

No behavior change — the compact UI is exactly what shipped everywhere.

## Testing
- `npm run type-check`, `npm run lint`, `npm run test` (270), `check-coverage` (floor 81), `npm run build` — all ✅

## ⚠️ Merge note
Touches `LightboxOverlay.vue`, which **#80 (new-tab cue)** also edits (the photographer link). Whichever merges second needs a trivial rebase — ping me.