### PR TITLE
Extract shared useHashScroll from useAccordion and PressView

### DIFF
--- a/src/composables/useAccordion.ts
+++ b/src/composables/useAccordion.ts
@@ -1,8 +1,9 @@
 import type { Ref } from 'vue';
-import { nextTick, onMounted, ref, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { nextTick, ref } from 'vue';
 
 import { ID_PREFIX, TIMING } from '@/utils/constants';
+
+import { useHashScroll } from './useHashScroll';
 
 interface UseAccordionReturn {
   openSection: Ref<string | null>;
@@ -21,27 +22,7 @@ export const useAccordion = (
   validSections: string[],
   findSectionForId: ((id: string) => string | null) | null = null,
 ): UseAccordionReturn => {
-  const route = useRoute();
   const openSection = ref<string | null>(initialSection);
-  const isInitialLoad = ref(true);
-
-  const handleToggle = (sectionId: string, isOpen: boolean): void => {
-    if (isOpen) {
-      openSection.value = sectionId;
-      // Update URL hash when opening a section
-      if (!isInitialLoad.value) {
-        window.history.replaceState(null, '', `#${ID_PREFIX.SECTION}${sectionId}`);
-      }
-      return;
-    }
-    if (openSection.value === sectionId) {
-      openSection.value = null;
-      // Clear hash when closing
-      if (!isInitialLoad.value) {
-        window.history.replaceState(null, '', window.location.pathname);
-      }
-    }
-  };
 
   const scrollToElement = (id: string): void => {
     nextTick(() => {
@@ -77,17 +58,26 @@ export const useAccordion = (
     if (shouldScroll) scrollToElement(id);
   };
 
-  onMounted(() => {
-    // Scroll to hash on initial load if present
-    processHash(route.hash, !!route.hash);
-    nextTick(() => {
-      isInitialLoad.value = false;
-    });
-  });
+  // Open (and scroll to) the hash target on load and on hash changes.
+  const { isInitialLoad } = useHashScroll(hash => processHash(hash, true), { immediate: true });
 
-  watch(() => route.hash, hash => {
-    if (!isInitialLoad.value) processHash(hash, true);
-  });
+  const handleToggle = (sectionId: string, isOpen: boolean): void => {
+    if (isOpen) {
+      openSection.value = sectionId;
+      // Update URL hash when opening a section
+      if (!isInitialLoad.value) {
+        window.history.replaceState(null, '', `#${ID_PREFIX.SECTION}${sectionId}`);
+      }
+      return;
+    }
+    if (openSection.value === sectionId) {
+      openSection.value = null;
+      // Clear hash when closing
+      if (!isInitialLoad.value) {
+        window.history.replaceState(null, '', window.location.pathname);
+      }
+    }
+  };
 
   return {
     openSection,

--- a/src/composables/useHashScroll.test.ts
+++ b/src/composables/useHashScroll.test.ts
@@ -1,0 +1,71 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Component, defineComponent, reactive } from 'vue';
+
+import { useHashScroll } from './useHashScroll';
+
+const mockRoute = reactive({ hash: '', path: '/press' });
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+}));
+
+const createComponent = (onHash: (hash: string) => void, options?: { immediate?: boolean }): Component =>
+  defineComponent({
+    setup() {
+      useHashScroll(onHash, options);
+      return {};
+    },
+    template: '<div />',
+  });
+
+describe('useHashScroll', () => {
+  beforeEach(() => {
+    mockRoute.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('does not run the handler on mount when there is no hash', () => {
+    const onHash = vi.fn();
+    mount(createComponent(onHash, { immediate: true }));
+    expect(onHash).not.toHaveBeenCalled();
+  });
+
+  it('runs the handler on mount when immediate and a hash is present', () => {
+    mockRoute.hash = '#target';
+    const onHash = vi.fn();
+    mount(createComponent(onHash, { immediate: true }));
+    expect(onHash).toHaveBeenCalledWith('#target');
+  });
+
+  it('does not run on mount when a hash is present but immediate is false', () => {
+    mockRoute.hash = '#target';
+    const onHash = vi.fn();
+    mount(createComponent(onHash));
+    expect(onHash).not.toHaveBeenCalled();
+  });
+
+  it('runs the handler when the hash changes after the initial render', async () => {
+    const onHash = vi.fn();
+    const wrapper = mount(createComponent(onHash));
+    await wrapper.vm.$nextTick();
+
+    mockRoute.hash = '#next';
+    await wrapper.vm.$nextTick();
+
+    expect(onHash).toHaveBeenCalledWith('#next');
+  });
+
+  it('ignores a cleared (empty) hash', async () => {
+    mockRoute.hash = '#a';
+    const onHash = vi.fn();
+    const wrapper = mount(createComponent(onHash));
+    await wrapper.vm.$nextTick();
+    onHash.mockClear();
+
+    mockRoute.hash = '';
+    await wrapper.vm.$nextTick();
+
+    expect(onHash).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/useHashScroll.ts
+++ b/src/composables/useHashScroll.ts
@@ -1,0 +1,41 @@
+import type { Ref } from 'vue';
+import { nextTick, onMounted, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+
+interface UseHashScrollOptions {
+  /** Run the handler once on mount if the URL already has a hash. */
+  immediate?: boolean;
+}
+
+interface UseHashScrollReturn {
+  isInitialLoad: Ref<boolean>;
+}
+
+/**
+ * Runs `onHash` when the URL hash changes after the initial render (and,
+ * optionally, once on mount). Centralises the `isInitialLoad` + hash-watch
+ * plumbing shared by the accordion and the press page.
+ * @param onHash - Handler invoked with the (non-empty) hash
+ * @param options - `immediate` fires the handler on mount when a hash is present
+ * @returns `isInitialLoad`, which consumers can read to gate side effects
+ */
+export const useHashScroll = (
+  onHash: (hash: string) => void,
+  { immediate = false }: UseHashScrollOptions = {},
+): UseHashScrollReturn => {
+  const route = useRoute();
+  const isInitialLoad = ref(true);
+
+  onMounted(() => {
+    if (immediate && route.hash) onHash(route.hash);
+    nextTick(() => {
+      isInitialLoad.value = false;
+    });
+  });
+
+  watch(() => route.hash, hash => {
+    if (!isInitialLoad.value && hash) onHash(hash);
+  });
+
+  return { isInitialLoad };
+};

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
-import { useRoute } from 'vue-router';
-
+import { useHashScroll } from '@/composables/useHashScroll';
 import { usePageHead } from '@/composables/usePageHead';
 import { pressQuotes } from '@/data/press';
 
@@ -10,24 +8,12 @@ usePageHead({
   description: 'Press coverage and reviews of Jerome Faria\'s work from The Quietus, Bodyspace, Indie Rock Mag, and more.',
 });
 
-const route = useRoute();
-const isInitialLoad = ref(true);
-
 const scrollToHash = (hash: string) => {
-  if (!hash) return;
   const element = document.getElementById(hash.replace('#', ''));
   element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 };
 
-onMounted(() => {
-  isInitialLoad.value = false;
-});
-
-watch(() => route.hash, hash => {
-  if (!isInitialLoad.value && hash) {
-    scrollToHash(hash);
-  }
-});
+useHashScroll(scrollToHash);
 </script>
 
 <template>


### PR DESCRIPTION
## Description
Dedup (audit item 4b). `PressView` hand-rolled the same `isInitialLoad` + `route.hash` watch that `useAccordion` already implements. Extracted into one composable.

## Changes
- **`useHashScroll.ts`** (new): owns the `isInitialLoad` ref, the on-mount pass (optional via `immediate`), and the post-initial `route.hash` watch; calls a caller-supplied `onHash(hash)`. Returns `isInitialLoad` for consumers that need it.
- **`useAccordion`**: uses `useHashScroll(hash => processHash(hash, true), { immediate: true })`; `handleToggle` reads the returned `isInitialLoad`. Removed the inline `onMounted`/`watch`/`useRoute`.
- **`PressView`**: uses `useHashScroll(scrollToHash)`; removed the hand-rolled ref/watch/onMounted.

Behavior is identical — all 18 existing `useAccordion` tests pass unchanged.

## Testing
- `npm run test` (275, +5 `useHashScroll` tests) ✅
- `npm run type-check`, `npm run lint`, `check-coverage` (floor 81), `npm run build` — all ✅

## ⚠️ Merge note
Touches `PressView.vue`, which **#80 (new-tab cue)** and **#83 (headings)** also edit — but those touch the *template* while this touches the *script*, so conflicts should be trivial. Ping me to rebase.