### PR TITLE
Refresh README coverage and ratchet the floor to ~83%

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Vue 3 + TypeScript portfolio website for [www.jeromefaria.com](https://www.jerom
 - **Frontend**: Vue 3 (Composition API), TypeScript (strict mode)
 - **Build**: Vite with SSG (Static Site Generation)
 - **Styling**: SCSS with BEM methodology
-- **Testing**: Vitest (unit — logic layer ~100%, views/components backfilling), Cypress E2E, axe-core accessibility
+- **Testing**: Vitest (unit — ~83% coverage; logic layer ~100%, all views + components covered), Cypress E2E, axe-core accessibility
 - **CI/CD**: GitHub Actions with quality gates
 - **Performance**: Lighthouse CI with performance budgets
 
@@ -53,7 +53,7 @@ npm run test:ui
 npm run test:coverage
 ```
 
-**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs — currently Lines 81%, Statements 80%, Functions 63%, Branches 70%.
+**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs. Current coverage is ~83% lines / 82% statements / 67% functions / 76% branches, with the floor set just below at Lines 82%, Statements 81%, Functions 65%, Branches 75%.
 
 ### E2E Tests
 

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -17,10 +17,10 @@ const __dirname = dirname(__filename);
 // (composables/utils) is ~100%; views and components are being backfilled with
 // unit tests, so raise these numbers as coverage climbs.
 const THRESHOLDS = {
-  lines: 81,
-  statements: 80,
-  functions: 63,
-  branches: 70,
+  lines: 82,
+  statements: 81,
+  functions: 65,
+  branches: 75,
 };
 
 const COVERAGE_SUMMARY_PATH = join(__dirname, '../coverage/coverage-summary.json');


### PR DESCRIPTION
Coverage climbed to ~83% lines / 82% stmts / 67% funcs / 76% branches after the backfill + Tier-2/3 work, but the floor and README were still at the views-backfill numbers (81/80/63/70). Raises the floor to 82/81/65/75 and states current coverage in the README. `check-coverage` passes (83.18% ≥ 82%).