### PR TITLE
Deepen unit tests: behavioural assertions and branch-gap coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run test:ui
 npm run test:coverage
 ```
 
-**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; views and components are being backfilled with unit tests (UI paths are also exercised by the Cypress E2E suite). CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs. Current coverage is ~95% lines / 93% statements / 86% functions / 83% branches, with the floor set just below at Lines 93%, Statements 91%, Functions 84%, Branches 81%.
+**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; the view and component tests assert behaviour (hash-driven accordion opening, link processing, focus trapping, image load/error fallbacks) rather than render counts, and UI paths are also exercised by the Cypress E2E suite. CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs. Current coverage is ~98% lines / 96% statements / 93% functions / 87% branches, with the floor set just below at Lines 96%, Statements 95%, Functions 91%, Branches 85%.
 
 ### E2E Tests
 

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -17,10 +17,10 @@ const __dirname = dirname(__filename);
 // (composables/utils) is ~100%; views and components are being backfilled with
 // unit tests, so raise these numbers as coverage climbs.
 const THRESHOLDS = {
-  lines: 93,
-  statements: 91,
-  functions: 84,
-  branches: 81,
+  lines: 96,
+  statements: 95,
+  functions: 91,
+  branches: 85,
 };
 
 const COVERAGE_SUMMARY_PATH = join(__dirname, '../coverage/coverage-summary.json');

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,6 +1,7 @@
 import { createHead } from '@unhead/vue/client';
-import { flushPromises, mount } from '@vue/test-utils';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
 import { createMemoryHistory, createRouter } from 'vue-router';
 
 import App from './App.vue';
@@ -8,8 +9,29 @@ import App from './App.vue';
 // A route component containing an external and an internal link, so we can
 // exercise App's processExternalLinks pass.
 const LinksPage = {
-  template: '<div><a href="https://external.example.com">external</a> <a href="/about">internal</a></div>',
+  template: `<div>
+    <a href="https://external.example.com">external</a>
+    <a href="/about">internal</a>
+    <a href="http://localhost/local-page">same-origin absolute</a>
+  </div>`,
 };
+
+// App wraps the router-view in <Suspense>, so the routed component commits to
+// the DOM a macrotask after mount — later than flushPromises (microtasks) can
+// wait for. Settle across a few macrotask + microtask rounds so onMounted's
+// processExternalLinks has run against the committed <main>.
+const settle = async () => {
+  for (let round = 0; round < 3; round += 1) {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await flushPromises();
+    await nextTick();
+  }
+};
+
+// App resolves the active <main> with a document-wide query, so only one App
+// may be attached at a time — otherwise a stale, still-attached instance would
+// be scanned instead of the current one.
+let activeWrapper: VueWrapper | null = null;
 
 const mountApp = async () => {
   const head = createHead();
@@ -23,12 +45,15 @@ const mountApp = async () => {
   router.push('/');
   await router.isReady();
   const wrapper = mount(App, { global: { plugins: [router, head] }, attachTo: document.body });
-  await flushPromises();
+  activeWrapper = wrapper;
+  await settle();
   return { wrapper, router };
 };
 
 describe('App', () => {
   afterEach(() => {
+    activeWrapper?.unmount();
+    activeWrapper = null;
     document.body.classList.remove('ready');
   });
 
@@ -43,11 +68,34 @@ describe('App', () => {
     expect(document.body.classList.contains('ready')).toBe(true);
   });
 
+  it('marks a cross-origin link in the main content as a new-tab, safe link', async () => {
+    const { wrapper } = await mountApp();
+    const external = wrapper.get('main a[href="https://external.example.com"]');
+
+    expect(external.attributes('target')).toBe('_blank');
+    expect(external.attributes('rel')).toBe('noopener noreferrer');
+  });
+
+  it('leaves a same-origin internal link untouched', async () => {
+    const { wrapper } = await mountApp();
+    const internal = wrapper.get('main a[href="/about"]');
+
+    expect(internal.attributes('target')).toBeUndefined();
+    expect(internal.attributes('rel')).toBeUndefined();
+  });
+
+  it('leaves a same-origin absolute link untouched', async () => {
+    const { wrapper } = await mountApp();
+    const sameOrigin = wrapper.get('main a[href="http://localhost/local-page"]');
+
+    expect(sameOrigin.attributes('target')).toBeUndefined();
+    expect(sameOrigin.attributes('rel')).toBeUndefined();
+  });
+
   it('reprocesses links on navigation without error', async () => {
     const { wrapper, router } = await mountApp();
     await router.push('/about');
-    await flushPromises();
-    await wrapper.vm.$nextTick();
+    await settle();
     expect(wrapper.find('main').exists()).toBe(true);
   });
 });

--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -112,6 +112,40 @@ describe('EventItem', () => {
       const wrapper = mountEvent(plainEvent);
       expect(wrapper.find('.event-photos-link').exists()).toBe(false);
     });
+
+    it('shows a "View video" control and emits the converted video on click', async () => {
+      const wrapper = mountEvent({
+        ...plainEvent,
+        videos: [{ url: 'https://player.vimeo.com/video/1', title: 'Live set', platform: 'vimeo' }],
+      });
+      const button = wrapper.get('.event-photos-link button');
+      expect(button.text()).toBe('View video');
+
+      await button.trigger('click');
+      const payload = wrapper.emitted('open-lightbox')?.[0];
+
+      expect(payload?.[1]).toBe(0);
+      expect(payload?.[0]).toEqual([
+        { type: 'video', url: 'https://player.vimeo.com/video/1', title: 'Live set', platform: 'vimeo' },
+      ]);
+    });
+
+    it('pluralises the video control and separates photo and video controls', () => {
+      const wrapper = mountEvent({
+        ...plainEvent,
+        images: [{ src: '/images/live/a-001.jpg', alt: 'A' }],
+        videos: [
+          { url: 'https://player.vimeo.com/video/1', title: 'One', platform: 'vimeo' },
+          { url: 'https://player.vimeo.com/video/2', title: 'Two', platform: 'vimeo' },
+        ],
+      });
+      const buttons = wrapper.findAll('.event-photos-link button');
+
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0].text()).toBe('View photo');
+      expect(buttons[1].text()).toBe('View videos');
+      expect(wrapper.get('.event-photos-link').text()).toContain('|');
+    });
   });
 
   describe('venue', () => {

--- a/src/components/LightboxOverlay.test.ts
+++ b/src/components/LightboxOverlay.test.ts
@@ -7,6 +7,7 @@ import type { LightboxItem } from '@/types';
 import LightboxOverlay from './LightboxOverlay.vue';
 
 const image: LightboxItem = { type: 'image', src: '/image.jpg', alt: 'Test image' };
+const video: LightboxItem = { type: 'video', url: 'https://player.example.com/v/1', title: 'A performance', platform: 'vimeo' };
 
 const mountOverlay = (props: Record<string, unknown> = {}) =>
   mount(LightboxOverlay, {
@@ -71,6 +72,100 @@ describe('LightboxOverlay', () => {
       expect(document.activeElement).toBe(first);
 
       wrapper.unmount();
+    });
+
+    it('wraps Shift+Tab from the first control forward to the last', async () => {
+      const wrapper = mountOverlay({ currentIndex: 1, totalItems: 3 });
+      await nextTick();
+
+      const focusable = Array.from(
+        wrapper.get('.lightbox').element.querySelectorAll<HTMLElement>('button:not([disabled])'),
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      first?.focus();
+
+      await wrapper.get('.lightbox').trigger('keydown', { key: 'Tab', shiftKey: true });
+
+      expect(document.activeElement).toBe(last);
+
+      wrapper.unmount();
+    });
+
+    it('ignores non-Tab keys without moving focus', async () => {
+      const wrapper = mountOverlay();
+      await nextTick();
+      const dialog = wrapper.get('.lightbox').element as HTMLElement;
+      dialog.focus();
+
+      await wrapper.get('.lightbox').trigger('keydown', { key: 'Enter' });
+
+      expect(document.activeElement).toBe(dialog);
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('media type', () => {
+    it('renders a video in an iframe and names the dialog as a video viewer', () => {
+      const wrapper = mountOverlay({ currentItem: video });
+      const iframe = wrapper.get('iframe.lightbox__video');
+
+      expect(iframe.attributes('src')).toBe('https://player.example.com/v/1');
+      expect(iframe.attributes('title')).toBe('A performance');
+      expect(wrapper.get('.lightbox').attributes('aria-label')).toBe('Video viewer');
+      expect(wrapper.find('picture').exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('serves a WebP source alongside the JPEG fallback for an image', () => {
+      const wrapper = mountOverlay({ currentItem: { type: 'image', src: '/photo.jpg', alt: 'A photo' } });
+
+      expect(wrapper.get('picture source').attributes('srcset')).toBe('/photo.webp');
+      expect(wrapper.get('img.lightbox__image').attributes('src')).toBe('/photo.jpg');
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('photographer credit', () => {
+    it('links the photographer name as a safe new-tab link when a url is given', () => {
+      const wrapper = mountOverlay({
+        currentItem: { type: 'image', src: '/p.jpg', alt: 'P', photographer: { name: 'Ana Lens', url: 'https://ana.example.com' } },
+      });
+      const credit = wrapper.get('.lightbox__credit');
+      const link = credit.get('a');
+
+      expect(link.attributes('href')).toBe('https://ana.example.com');
+      expect(link.attributes('target')).toBe('_blank');
+      expect(link.attributes('rel')).toBe('noopener noreferrer');
+      expect(link.text()).toContain('Ana Lens');
+      expect(credit.get('.visually-hidden').text()).toBe('(opens in a new tab)');
+
+      wrapper.unmount();
+    });
+
+    it('renders the photographer name as plain text when no url is given', () => {
+      const wrapper = mountOverlay({
+        currentItem: { type: 'image', src: '/p.jpg', alt: 'P', photographer: { name: 'Ana Lens' } },
+      });
+      const credit = wrapper.get('.lightbox__credit');
+
+      expect(credit.find('a').exists()).toBe(false);
+      expect(credit.text()).toContain('Ana Lens');
+
+      wrapper.unmount();
+    });
+
+    it('shows no credit for a video or an image without a photographer', () => {
+      const withoutPhotographer = mountOverlay({ currentItem: image });
+      expect(withoutPhotographer.find('.lightbox__credit').exists()).toBe(false);
+      withoutPhotographer.unmount();
+
+      const videoOverlay = mountOverlay({ currentItem: video });
+      expect(videoOverlay.find('.lightbox__credit').exists()).toBe(false);
+      videoOverlay.unmount();
     });
   });
 });

--- a/src/components/ReleaseItem.test.ts
+++ b/src/components/ReleaseItem.test.ts
@@ -66,6 +66,38 @@ describe('ReleaseItem', () => {
     expect(cover.find('img').attributes('src')).toBe('/images/ect.jpg');
   });
 
+  it('flags an external cover that links to Bandcamp with a modifier class', () => {
+    const bandcampExternal: ExternalRelease = {
+      id: 'bc-ext',
+      title: 'BC External',
+      meta: 'Digital, 2020',
+      coverImage: '/images/bc.jpg',
+      externalUrl: 'https://artist.bandcamp.com/album/bc-external',
+    };
+    const wrapper = mountRelease(bandcampExternal);
+    expect(wrapper.get('a.release-cover').classes()).toContain('release-cover--bandcamp');
+  });
+
+  it('falls back to a text-only layout when the cover image fails to load', async () => {
+    const wrapper = mountRelease(external);
+    expect(wrapper.find('a.release-cover').exists()).toBe(true);
+
+    await wrapper.get('a.release-cover img').trigger('error');
+
+    expect(wrapper.find('a.release-cover').exists()).toBe(false);
+    expect(wrapper.get('article').classes()).toContain('release--text-only');
+  });
+
+  it('marks the cover image as loaded once it fires the load event', async () => {
+    const wrapper = mountRelease(external);
+    const image = wrapper.get('a.release-cover img');
+    expect(image.classes()).not.toContain('is-loaded');
+
+    await image.trigger('load');
+
+    expect(wrapper.get('a.release-cover img').classes()).toContain('is-loaded');
+  });
+
   it('renders a static (unlinked) cover when there is no player or link', () => {
     const wrapper = mountRelease(staticCover);
     expect(wrapper.find('.release-cover--static').exists()).toBe(true);

--- a/src/composables/useAccordion.test.ts
+++ b/src/composables/useAccordion.test.ts
@@ -204,6 +204,52 @@ describe('useAccordion', () => {
     vi.useRealTimers();
   });
 
+  it('should scroll smoothly when reduced motion is not preferred', async () => {
+    vi.useFakeTimers();
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: false } as MediaQueryList);
+    mockRoute.hash = `#section-${VALID_SECTIONS[1]}`;
+
+    mount(createTestComponent());
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(ACCORDION_ANIMATION_TIMING);
+
+    expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }));
+
+    vi.useRealTimers();
+  });
+
+  it('should jump without animation when reduced motion is preferred', async () => {
+    vi.useFakeTimers();
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true } as MediaQueryList);
+    mockRoute.hash = `#section-${VALID_SECTIONS[1]}`;
+
+    mount(createTestComponent());
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(ACCORDION_ANIMATION_TIMING);
+
+    expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }));
+
+    vi.useRealTimers();
+  });
+
+  it('should scroll to the nested item id when a hash resolves via its parent section', async () => {
+    vi.useFakeTimers();
+    const itemId = 'nested-item-1';
+    const findSectionForId = (id: string): string | null => (id === itemId ? VALID_SECTIONS[1] : null);
+    mockRoute.hash = `#${itemId}`;
+
+    mount(createTestComponent(INITIAL_SECTION, VALID_SECTIONS, findSectionForId));
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(ACCORDION_ANIMATION_TIMING);
+
+    // Parent-resolved hashes scroll to the item itself, not the section trigger.
+    expect(getElementByIdSpy).toHaveBeenCalledWith(itemId);
+
+    vi.useRealTimers();
+  });
+
   it('should handle empty hash', async () => {
     mockRoute.hash = '';
 

--- a/src/views/AboutView.test.ts
+++ b/src/views/AboutView.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import LightboxOverlay from '@/components/LightboxOverlay.vue';
 import { aboutSections } from '@/data/about';
 import { mountView } from '@/test-support/viewHarness';
 
@@ -30,5 +31,21 @@ describe('AboutView', () => {
     const wrapper = await mountView(AboutView, '/about');
     await wrapper.get('.about-image-group__image').trigger('click');
     expect(wrapper.find('.lightbox').exists()).toBe(true);
+  });
+
+  it('opens the lightbox at the global index of a figure in a later group', async () => {
+    const wrapper = await mountView(AboutView, '/about');
+    const figures = wrapper.findAll('.about-image-group__image');
+    // Figure 4 lives in the second image group, so its global index only
+    // resolves correctly if the per-section start offset is applied.
+    const targetIndex = 4;
+    const figure = figures[targetIndex];
+    const expectedSrc = figure.get('img').attributes('src');
+
+    await figure.trigger('click');
+
+    const lightbox = wrapper.getComponent(LightboxOverlay);
+    expect(lightbox.props('currentIndex')).toBe(targetIndex);
+    expect(lightbox.props('currentItem')).toMatchObject({ type: 'image', src: expectedSrc });
   });
 });

--- a/src/views/LiveView.test.ts
+++ b/src/views/LiveView.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
 
 import AccordionSection from '@/components/AccordionSection.vue';
 import EventItem from '@/components/EventItem.vue';
@@ -6,6 +7,9 @@ import { liveData, liveYears } from '@/data/live';
 import { mountView } from '@/test-support/viewHarness';
 
 import LiveView from './LiveView.vue';
+
+const expandedYears = (wrapper: Awaited<ReturnType<typeof mountView>>): string[] =>
+  liveYears.filter(year => wrapper.get(`#trigger-${year}`).attributes('aria-expanded') === 'true');
 
 describe('LiveView', () => {
   it('renders an accordion section for every year', async () => {
@@ -17,5 +21,27 @@ describe('LiveView', () => {
     const wrapper = await mountView(LiveView, '/live');
     const totalEvents = Object.values(liveData).reduce((sum, year) => sum + year.items.length, 0);
     expect(wrapper.findAllComponents(EventItem)).toHaveLength(totalEvents);
+  });
+
+  it('opens only the most recent year by default', async () => {
+    const wrapper = await mountView(LiveView, '/live');
+    expect(expandedYears(wrapper)).toEqual([liveYears[0]]);
+  });
+
+  it('opens the year that owns a deep-linked event id from the URL hash', async () => {
+    // `showcase-casa-amarela` lives under 2025, not the default (most recent) year.
+    const wrapper = await mountView(LiveView, '/live#showcase-casa-amarela');
+    await nextTick();
+    expect(expandedYears(wrapper)).toEqual(['2025']);
+  });
+
+  it('switches the open year when another year trigger is activated', async () => {
+    const wrapper = await mountView(LiveView, '/live');
+    const secondYear = liveYears[1];
+
+    await wrapper.get(`#trigger-${secondYear}`).trigger('click');
+    await nextTick();
+
+    expect(expandedYears(wrapper)).toEqual([secondYear]);
   });
 });

--- a/src/views/WorksView.test.ts
+++ b/src/views/WorksView.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
 
 import AccordionSection from '@/components/AccordionSection.vue';
 import ReleaseItem from '@/components/ReleaseItem.vue';
@@ -6,6 +7,9 @@ import { worksData, worksSections } from '@/data/works';
 import { mountView } from '@/test-support/viewHarness';
 
 import WorksView from './WorksView.vue';
+
+const expandedSections = (wrapper: Awaited<ReturnType<typeof mountView>>): string[] =>
+  worksSections.filter(section => wrapper.get(`#trigger-${section}`).attributes('aria-expanded') === 'true');
 
 describe('WorksView', () => {
   it('renders an accordion section for every works category', async () => {
@@ -23,5 +27,26 @@ describe('WorksView', () => {
     const wrapper = await mountView(WorksView, '/works');
     expect(wrapper.get('h1.visually-hidden').text()).toBe('Works');
     expect(wrapper.findAll('h2.accordion-heading .accordion-trigger')).toHaveLength(worksSections.length);
+  });
+
+  it('opens the solo section by default', async () => {
+    const wrapper = await mountView(WorksView, '/works');
+    expect(expandedSections(wrapper)).toEqual(['solo']);
+  });
+
+  it('opens the section that owns a deep-linked release id from the URL hash', async () => {
+    // `overlapse-xiii` lives under collaborations, not the default solo section.
+    const wrapper = await mountView(WorksView, '/works#overlapse-xiii');
+    await nextTick();
+    expect(expandedSections(wrapper)).toEqual(['collaborations']);
+  });
+
+  it('switches the open section when another category trigger is activated', async () => {
+    const wrapper = await mountView(WorksView, '/works');
+
+    await wrapper.get('#trigger-film').trigger('click');
+    await nextTick();
+
+    expect(expandedSections(wrapper)).toEqual(['film']);
   });
 });


### PR DESCRIPTION
## Description

A test-depth pass that converts the high line-coverage number into coverage a discerning reviewer can trust. It replaces shallow render-count assertions with behavioural ones and closes the branch gaps that sat behind the ~95% line coverage. **No production source is changed** — this is tests, the coverage floor, and the README.

## Changes

**Behavioural assertions (were render/structure counts):**
- **App** — restored a robust link-processing test: a cross-origin link in the main content is marked `target="_blank"` + `rel="noopener noreferrer"`, while same-origin links (both relative `/about` and absolute `http://localhost/...`) are left untouched. This replaces the assertion that was previously dropped as flaky. Two real robustness fixes made it deterministic (verified 5× + 3×):
  - `settle()` across macrotasks — App wraps the router-view in `<Suspense>`, so the routed component commits a macrotask after mount, later than `flushPromises` (microtasks) waits for. `onMounted`'s `processExternalLinks` only sees a populated `<main>` after that boundary.
  - unmount between cases — `App` resolves the active `<main>` with a document-wide `querySelector`, so a stale still-attached instance would be scanned instead of the current one.
- **LiveView / WorksView** — a deep-linked hash id (`/live#showcase-casa-amarela`, `/works#overlapse-xiii`) opens the *owning* accordion section (not the default), and activating another section trigger switches the open section.
- **AboutView** — clicking a figure in a *later* image group opens the lightbox at the correct global index (exercises the per-section start-offset lookup).

**Branch-gap coverage:**
- **LightboxOverlay** — video branch (iframe + "Video viewer" label), photographer credit (linked new-tab vs plain text vs absent), and Shift+Tab focus wrapping.
- **EventItem** — video media control and photo/video pluralisation.
- **ReleaseItem** — Bandcamp external-cover modifier class, and the image `load`/`error` fallbacks (error → text-only layout).
- **useAccordion** — the reduced-motion scroll branch (`behavior: 'auto'`) and the nested-item scroll target via parent-section resolution.

**Floor + docs:**
- Ratcheted `scripts/check-coverage.js` to Lines 96 / Statements 95 / Functions 91 / Branches 85 (just below the achieved figures).
- Refreshed the README coverage line.

## Coverage (whole `src` tree, `all: true`)

| Metric | Before | After |
|---|---|---|
| Lines | 94.86% | 97.69% |
| Statements | 92.78% | 96.08% |
| Functions | 85.93% | 92.70% |
| Branches | 82.81% | 87.25% |

317 unit tests (was 292).

## Testing

```bash
gh pr checkout <this-PR>
npm ci
npm run type-check
npm run lint
npm run test:coverage && node scripts/check-coverage.js
npm run build
```

All green locally. No UI change, so no browser smoke is required.