### PR TITLE
De-flake E2E specs and reprocess external links on navigation

### DIFF
--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -187,7 +187,7 @@ describe('Accessibility', () => {
   describe('ARIA Attributes', () => {
     it('should have valid ARIA attributes', () => {
       cy.visit('/');
-      cy.injectAxe();
+      cy.waitForHydration();
 
       cy.checkA11y(null, {
         runOnly: {

--- a/cypress/e2e/lightbox.cy.ts
+++ b/cypress/e2e/lightbox.cy.ts
@@ -1,65 +1,69 @@
-// Constants — WorksView uses the 'compact' variant of LightboxOverlay
 const LIGHTBOX_SELECTOR = '.lightbox';
 const LIGHTBOX_CLOSE_SELECTOR = '.lightbox__hint--close';
 const LIGHTBOX_NEXT_SELECTOR = '.lightbox__hint--next';
 const LIGHTBOX_IMAGE_SELECTOR = '.lightbox__image';
 const LIGHTBOX_CREDIT_SELECTOR = '.lightbox__credit';
+const ACCORDION_SECTION_SELECTOR = '.accordion-section';
 const ACCORDION_TRIGGER_SELECTOR = '.accordion-trigger';
 const GALLERY_BUTTON_SELECTOR = '.link-discrete';
+// A gallery button is only actionable while its own accordion section is open —
+// collapsed sections are `inert`. Scope every interaction to a visible one.
+const VISIBLE_GALLERY_BUTTON = `${GALLERY_BUTTON_SELECTOR}:visible`;
 
 /**
- * Open all accordion sections that are not already open,
- * then wait for animations to complete before proceeding.
+ * Open the accordion section that contains the first gallery button and wait
+ * for that button to become actionable, so callers can click a real, visible,
+ * non-inert control (no forced clicks, no fixed animation waits).
  */
 function openFirstGallery(): void {
   cy.visit('/works');
+  cy.waitForHydration();
 
-  // Re-query by index on each iteration so stale refs after re-renders don't cause failures
-  cy.get(ACCORDION_TRIGGER_SELECTOR).then($triggers => {
-    const count = $triggers.length;
-    for (let i = 0; i < count; i++) {
-      cy.get(ACCORDION_TRIGGER_SELECTOR).eq(i).then($t => {
-        if ($t.attr('aria-expanded') !== 'true') {
-          cy.get(ACCORDION_TRIGGER_SELECTOR).eq(i).click();
-        }
-      });
-    }
-  });
+  // The accordion keeps a single section open at a time, so find the section
+  // owning the first gallery button and open it if it isn't already.
+  cy.get(GALLERY_BUTTON_SELECTOR).first()
+    .closest(ACCORDION_SECTION_SELECTOR)
+    .find(ACCORDION_TRIGGER_SELECTOR)
+    .then($trigger => {
+      if ($trigger.attr('aria-expanded') !== 'true') {
+        cy.wrap($trigger).click();
+      }
+    });
 
-  // Wait for all opacity transitions to complete:
-  // 150ms transition-delay + 300ms transition-base + 150ms buffer
-  cy.wait(650);
+  // Retry-able assertion waits out the expand animation deterministically.
+  cy.get(VISIBLE_GALLERY_BUTTON).first().should('be.visible');
+}
 
-  // Verify gallery buttons exist in the DOM
-  cy.get(GALLERY_BUTTON_SELECTOR).should('have.length.greaterThan', 0);
+/**
+ * Open the lightbox from the first visible gallery button and wait for it.
+ */
+function openLightboxFromFirstGallery(): void {
+  openFirstGallery();
+  cy.get(VISIBLE_GALLERY_BUTTON).first().click();
+  cy.get(LIGHTBOX_SELECTOR).should('be.visible');
 }
 
 describe('Lightbox', () => {
   describe('Opening', () => {
     it('opens lightbox when clicking a View gallery button', () => {
-      openFirstGallery();
-      cy.get(GALLERY_BUTTON_SELECTOR).first().click({ force: true });
+      openLightboxFromFirstGallery();
       cy.get(LIGHTBOX_SELECTOR).should('be.visible');
     });
 
     it('displays an image in the lightbox', () => {
-      openFirstGallery();
-      cy.get(GALLERY_BUTTON_SELECTOR).first().click({ force: true });
+      openLightboxFromFirstGallery();
       cy.get(LIGHTBOX_IMAGE_SELECTOR).should('be.visible');
     });
 
     it('sets body overflow to hidden when open', () => {
-      openFirstGallery();
-      cy.get(GALLERY_BUTTON_SELECTOR).first().click({ force: true });
+      openLightboxFromFirstGallery();
       cy.get('body').should('have.css', 'overflow', 'hidden');
     });
   });
 
   describe('Closing', () => {
     beforeEach(() => {
-      openFirstGallery();
-      cy.get(GALLERY_BUTTON_SELECTOR).first().click({ force: true });
-      cy.get(LIGHTBOX_SELECTOR).should('be.visible');
+      openLightboxFromFirstGallery();
     });
 
     it('closes lightbox when clicking the close button', () => {
@@ -80,9 +84,7 @@ describe('Lightbox', () => {
 
   describe('Navigation', () => {
     beforeEach(() => {
-      openFirstGallery();
-      cy.get(GALLERY_BUTTON_SELECTOR).first().click({ force: true });
-      cy.get(LIGHTBOX_SELECTOR).should('be.visible');
+      openLightboxFromFirstGallery();
     });
 
     it('shows next image when clicking the next button', () => {
@@ -129,9 +131,7 @@ describe('Lightbox', () => {
 
   describe('Photographer credit', () => {
     it('shows photographer credit when present', () => {
-      openFirstGallery();
-      cy.get(GALLERY_BUTTON_SELECTOR).first().click({ force: true });
-      cy.get(LIGHTBOX_SELECTOR).should('be.visible');
+      openLightboxFromFirstGallery();
       cy.get('body').then($body => {
         if ($body.find(LIGHTBOX_CREDIT_SELECTOR).length > 0) {
           cy.get(LIGHTBOX_CREDIT_SELECTOR).should('be.visible');
@@ -144,9 +144,7 @@ describe('Lightbox', () => {
 
   describe('Accessibility', () => {
     beforeEach(() => {
-      openFirstGallery();
-      cy.get(GALLERY_BUTTON_SELECTOR).first().click({ force: true });
-      cy.get(LIGHTBOX_SELECTOR).should('be.visible');
+      openLightboxFromFirstGallery();
     });
 
     it('close button is focusable', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -4,13 +4,17 @@
  */
 
 /**
- * Wait for Vue hydration to complete
- * Ensures event handlers are fully attached before testing
+ * Wait for Vue hydration to complete.
+ * `body.ready` is added in App's onMounted, i.e. after the app has mounted and
+ * hydrated (event handlers attached). Waiting for web fonts to finish loading
+ * on top of that removes a FOUT-driven flake class from axe colour-contrast
+ * checks, and replaces the previous arbitrary fixed delay with a deterministic
+ * signal.
  */
 Cypress.Commands.add('waitForHydration', () => {
   cy.get('body.ready', { timeout: 10000 }).should('exist');
+  cy.document().then(doc => cy.wrap(doc.fonts.ready, { timeout: 10000 }));
   cy.injectAxe();
-  cy.wait(100); // Handler attach delay
 });
 
 /**

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -16,6 +16,12 @@ const LinksPage = {
   </div>`,
 };
 
+// A distinct page whose external link only exists after navigating to it, so
+// the nav-reprocess test proves a freshly rendered link is handled.
+const SecondPage = {
+  template: '<div><a href="https://second.example.com">second</a></div>',
+};
+
 // App wraps the router-view in <Suspense>, so the routed component commits to
 // the DOM a macrotask after mount — later than flushPromises (microtasks) can
 // wait for. Settle across a few macrotask + microtask rounds so onMounted's
@@ -39,7 +45,7 @@ const mountApp = async () => {
     history: createMemoryHistory(),
     routes: [
       { path: '/', component: LinksPage },
-      { path: '/about', component: LinksPage },
+      { path: '/about', component: SecondPage },
     ],
   });
   router.push('/');
@@ -92,10 +98,13 @@ describe('App', () => {
     expect(sameOrigin.attributes('rel')).toBeUndefined();
   });
 
-  it('reprocesses links on navigation without error', async () => {
+  it('reprocesses a freshly rendered external link after navigation', async () => {
     const { wrapper, router } = await mountApp();
     await router.push('/about');
     await settle();
-    expect(wrapper.find('main').exists()).toBe(true);
+
+    const external = wrapper.get('main a[href="https://second.example.com"]');
+    expect(external.attributes('target')).toBe('_blank');
+    expect(external.attributes('rel')).toBe('noopener noreferrer');
   });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import { nextTick, onMounted, watch } from 'vue';
-import { RouterView, useRoute } from 'vue-router';
+import { nextTick, onMounted } from 'vue';
+import { RouterView } from 'vue-router';
 
 import SiteFooter from '@/components/SiteFooter.vue';
 import SiteHeader from '@/components/SiteHeader.vue';
-
-const route = useRoute();
 
 const processExternalLinks = () => {
   // Only process links in main content area, not entire document
@@ -21,13 +19,17 @@ const processExternalLinks = () => {
   });
 };
 
+// The routed view renders inside <Suspense>, so on navigation the new page is
+// committed asynchronously — later than a route watcher's nextTick would fire.
+// Reprocessing on the Suspense `resolve` event guarantees the freshly rendered
+// page (including links inside v-html content) is in the DOM before we scan it.
+const handleContentResolved = () => {
+  nextTick(() => processExternalLinks());
+};
+
 onMounted(() => {
   processExternalLinks();
   document.body.classList.add('ready');
-});
-watch(() => route.path, async () => {
-  await nextTick();
-  processExternalLinks();
 });
 </script>
 
@@ -44,7 +46,7 @@ watch(() => route.path, async () => {
           name="page"
           mode="out-in"
         >
-          <Suspense>
+          <Suspense @resolve="handleContentResolved">
             <component :is="Component" />
             <template #fallback>
               <div


### PR DESCRIPTION
## Description

Two robustness fixes so the E2E suite and the external-link handling are airtight. The **Cypress suite can now actually run** (an Apple-Silicon/Rosetta esbuild-arch issue in the sandbox was resolved locally), so the E2E changes are verified by real runs at `retries=0` — stricter than CI's `retries: 2` — rather than by static reasoning.

## Changes

### 1. Reprocess external links on the Suspense `resolve` event (`src/App.vue`)
The routed view renders inside `<Suspense>`, so on client-side navigation the new page commits **asynchronously** — later than the previous `route.path` watcher's `nextTick` fired. That left external links inside freshly rendered `v-html` content (bio, descriptions) without `target="_blank"` / `rel="noopener noreferrer"` on the first paint after navigation.

Fix: drive the reprocess off `<Suspense @resolve>`, which fires exactly when the new page's DOM is committed. The unit test now **asserts** a freshly rendered external link is handled after navigation — deterministically (was previously a no-assert smoke because the timing was racy).

### 2. Harden the E2E specs against CI-load and cross-browser flakiness
Removed the timing- and environment-sensitive constructs that only surfaced under slower CI runners and non-Chromium browsers — and were being masked by the retry count:

- **`lightbox.cy.ts`** — the gallery helper opened *every* accordion in a loop (dead logic: the accordion keeps a single section open) and then **force-clicked** a button that could sit inside a collapsed, `inert` section, whose click behaviour differs across browsers (the prime Firefox/Edge suspect). Replaced with a deterministic helper that opens the section owning the first gallery button and clicks a real, **visible, non-inert** control — no forced clicks — and dropped the fixed `cy.wait(650)` animation wait for a retry-able visibility assertion. Also removed a stale "compact variant" comment.
- **`support/commands.ts`** — replaced the arbitrary `cy.wait(100)` "handler attach" delay with a deterministic wait on `document.fonts.ready`, which also removes a FOUT-driven flake class from axe colour-contrast checks.
- **`accessibility.cy.ts`** — the ARIA-attributes axe check now runs after `waitForHydration`, so axe never runs before fonts settle.

## Verification (real Cypress runs, `retries=0`)

| Browser | Scope | Result |
|---|---|---|
| Electron | full suite (×3) | all pass |
| Chrome | full suite (80 tests) | all pass |
| Chrome | lightbox + navigation | 24/24 |
| Firefox | reworked lightbox spec | 12/12 |

Plus: 317 unit tests pass, type-check clean, lint clean.

## Not included — deploy re-gating (recommended follow-up)
Deploy was decoupled from E2E in #43 because of this flakiness. With the root causes fixed, **re-gating deploy on E2E is now reasonable** — but that's a deploy-velocity policy call, and my verification is local-only (not the CI ubuntu/Edge environment where the flakes actually occurred). I've left `deploy.yml` unchanged rather than gate public deploys on local-only evidence. Suggested path: let this ride a few green CI cycles, then re-add E2E as a `needs:` of the deploy `build` job (keeping `retries: 2` as a safety net).

## Testing
```bash
gh pr checkout <this-PR>
npm ci
npm run type-check && npm run lint && npm run test:coverage
npm run build
npm run test:e2e   # Cypress installs its own browser binary on first run
```