### PR TITLE
Re-gate deployment on the cross-browser E2E suite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,12 +71,68 @@ jobs:
         with:
           path: dist
 
+      # Plain copy of the built site so the E2E gate exercises the exact
+      # artifact that will be deployed, without rebuilding.
+      - name: Upload dist for E2E
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  e2e:
+    name: E2E Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox, edge]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Run Cypress E2E tests
+        uses: cypress-io/github-action@v7
+        with:
+          browser: ${{ matrix.browser }}
+          start: npm run preview
+          wait-on: 'http://localhost:4173'
+          wait-on-timeout: 120
+          config: baseUrl=http://localhost:4173
+
+      - name: Upload Cypress screenshots
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: cypress-screenshots-${{ matrix.browser }}
+          path: cypress/screenshots/
+          retention-days: 30
+
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, e2e]
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ Every push to `master` and pull request triggers a comprehensive CI pipeline wit
 - Accessibility testing with axe-core
 - Specs: `accessibility`, `accordion`, `contact-form`, `lightbox`, `navigation`
 
-**Quality Gates**: All four CI jobs (Quality Checks, Build, Lighthouse, E2E) must pass for the CI workflow to be green. Deployment runs on its own workflow and gates on type-check, lint, unit tests with coverage, and the production build.
+**Quality Gates**: All four CI jobs (Quality Checks, Build, Lighthouse, E2E) must pass for the CI workflow to be green. Deployment runs on its own workflow and gates on type-check, lint, unit tests with coverage, the production build, and the cross-browser E2E suite (Chrome, Firefox, Edge) run against the exact artifact to be deployed.
 
 ## Deployment
 
-The site deploys to GitHub Pages via GitHub Actions on push to `master` once the deploy workflow's pre-deploy checks and build succeed.
+The site deploys to GitHub Pages via GitHub Actions on push to `master` once the deploy workflow's pre-deploy checks, production build, and cross-browser E2E gate succeed.
 
 ## License
 


### PR DESCRIPTION
## Description

Re-couples deployment to the E2E suite. E2E was decoupled from deploy in #43 because it was flaky; with the root causes fixed in #95 and verified green in CI across Chrome, Firefox and Edge, a broken user-facing flow should once again block publication.

## Changes

- **`deploy.yml`**: the `build` job now also uploads a plain `dist` artifact; a new matrixed **`e2e`** job (Chrome, Firefox, Edge) downloads that **exact** artifact and runs Cypress against it via `npm run preview`; the `deploy` job now `needs: [build, e2e]`. Pipeline order: `pre-deploy-checks → build → e2e → deploy`.
- **`README.md`**: documents that deploy gates on the cross-browser E2E suite.

## Design notes

- **Tests the shipped artifact:** E2E downloads the same `dist` the deploy uploads, rather than rebuilding — so the gate exercises precisely what goes live.
- **Safety net retained:** `retries: 2` stays in the Cypress config, so any residual CI-only flake self-heals rather than blocking a deploy on a one-off.
- **Failure mode is benign:** a genuinely failing E2E run blocks (delays) a re-runnable deploy — it never ships a broken build.

## Verification

`deploy.yml` only executes on push to `master`, so the gate itself is proven by the **post-merge deploy run**. On this PR, the CI workflow re-validates the specs, build, and cross-browser E2E (the same job config mirrored here). YAML structure validated locally (`jobs`, `needs`, `matrix`).