### PR TITLE
Modernise remaining legacy patterns and enforce the standard

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -65,6 +65,13 @@ export default [
       // Object shorthand
       'object-shorthand': ['error', 'always'],
 
+      // Modern JavaScript over legacy patterns
+      'eqeqeq': ['error', 'always'],
+      'prefer-object-spread': 'error',
+      'no-array-constructor': 'error',
+      'prefer-spread': 'error',
+      'prefer-rest-params': 'error',
+
       // Early returns
       'no-else-return': ['error', { allowElseIf: false }],
       'no-lonely-if': 'error',
@@ -160,6 +167,13 @@ export default [
 
       // Object shorthand
       'object-shorthand': ['error', 'always'],
+
+      // Modern JavaScript over legacy patterns
+      'eqeqeq': ['error', 'always'],
+      'prefer-object-spread': 'error',
+      'no-array-constructor': 'error',
+      'prefer-spread': 'error',
+      'prefer-rest-params': 'error',
 
       // Early returns
       'no-else-return': ['error', { allowElseIf: false }],

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -158,11 +158,12 @@ const isBandcampLink = computed(() => {
       >
         <button
           class="link-discrete"
-          @click="emit('open-lightbox', release.images.map(img => {
-            const lightboxImg = { type: 'image' as const, src: img.src, alt: img.alt };
-            if (img.photographer) Object.assign(lightboxImg, { photographer: img.photographer });
-            return lightboxImg;
-          }), 0)"
+          @click="emit('open-lightbox', release.images.map(img => ({
+            type: 'image' as const,
+            src: img.src,
+            alt: img.alt,
+            ...(img.photographer ? { photographer: img.photographer } : {}),
+          })), 0)"
         >
           View gallery
         </button>

--- a/src/composables/useContactForm.ts
+++ b/src/composables/useContactForm.ts
@@ -99,9 +99,11 @@ export const useContactForm = (submitUrl: string): UseContactFormReturn => {
 
   const handleSubmit = async (event: Event): Promise<void> => {
     event.preventDefault();
-    isSubmitting.value = true;
 
-    const form = event.target as HTMLFormElement;
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) return;
+
+    isSubmitting.value = true;
     const formDataToSend = new FormData(form);
 
     try {

--- a/src/composables/usePageHead.ts
+++ b/src/composables/usePageHead.ts
@@ -7,7 +7,7 @@ interface UsePageHeadOptions {
   title: string;
   description: string;
   ogType?: string;
-  schema?: Record<string, unknown> | null;
+  schema?: object | null;
   includeImage?: boolean;
   noIndex?: boolean;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,23 +27,26 @@ export const createApp = ViteSSG(
     },
   },
   ({ router, isClient }: ViteSSGContext) => {
-    // Handle SPA redirect from 404.html (client-side only)
-    if (isClient) {
-      const redirect = sessionStorage.getItem('spa-redirect');
-      if (redirect) {
-        sessionStorage.removeItem('spa-redirect');
-        router.replace(redirect);
-      }
+    // Client-side only: SSG pre-render has no session storage or live DOM.
+    if (!isClient) return;
 
-      // Add ready class to body when Vue is fully hydrated
-      // Use requestAnimationFrame to ensure event handlers are attached
-      router.isReady().then(() => {
+    // Handle SPA redirect from 404.html.
+    const redirect = sessionStorage.getItem('spa-redirect');
+    if (redirect) {
+      sessionStorage.removeItem('spa-redirect');
+      router.replace(redirect);
+    }
+
+    // Add the ready class to body once Vue is fully hydrated. This is a
+    // deliberate fire-and-forget: the setup callback must NOT await
+    // router.isReady() here, since that resolves only after mount and would
+    // deadlock hydration. The nested rAF ensures event handlers are attached.
+    router.isReady().then(() => {
+      requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            document.body.classList.add('ready');
-          });
+          document.body.classList.add('ready');
         });
       });
-    }
+    });
   },
 );

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -53,7 +53,7 @@ const eventsSchema = computed(() =>
 usePageHead({
   title: 'Live',
   description: 'Live performance history of Jerome Faria from 2005 to present, including festivals, concerts, and collaborations.',
-  schema: eventsSchema.value as unknown as Record<string, unknown>,
+  schema: eventsSchema.value,
 });
 
 const findYearForEvent = (eventId: string): string | null =>

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -23,10 +23,7 @@ const albumSchemas = soloSection
     })
     .map(release => {
       const datePublished = extractYear(release.meta ?? null);
-      const releaseWithDate = { ...release };
-      if (datePublished) {
-        Object.assign(releaseWithDate, { datePublished });
-      }
+      const releaseWithDate = { ...release, ...(datePublished ? { datePublished } : {}) };
       return createMusicAlbumSchema(
         releaseWithDate,
         siteConfig.author.name,


### PR DESCRIPTION
## Description

An audit of `src/` against the modern JS/TS standard (optional chaining, nullish coalescing, destructuring, async/await, no unsafe casts, no legacy idioms). **The codebase was already strongly compliant** — the sweep found no `var`, no loose equality, no legacy string methods (`.substr`/`escape`), no `Object.assign` clones, no `.call`/`.apply`, no C-style loops, no enums/namespaces, no `arguments`. ESLint already enforces most of it.

This PR polishes the few remaining spots and closes the enforcement gaps so the standard holds going forward.

## Changes

**Fixes (6 spots):**
- **`usePageHead`** — type `schema` as `object | null` (it is only `JSON.stringify`'d). This removes an `as unknown as Record<string, unknown>` **double-cast** at the `LiveView` call site — the one genuine unsafe-cast smell.
- **`useContactForm`** — replace `event.target as HTMLFormElement` with an `instanceof` narrowing (guard-first, so `isSubmitting` isn't left stuck on the impossible path).
- **`WorksView` / `ReleaseItem`** — replace conditional `Object.assign` mutations with conditional **object spread**. (The explicit spread is also more type-safe — `Object.assign` was bypassing the property type-check.)
- **`main.ts`** — tidy the ViteSSG setup block with an early return, and **document** that `router.isReady().then(...)` is a deliberate fire-and-forget.

**Enforcement (ESLint, both `.ts` and `.vue` blocks):** `eqeqeq`, `prefer-object-spread`, `no-array-constructor`, `prefer-spread`, `prefer-rest-params` — all non-type-aware, all passing repo-wide.

## A caught regression worth noting

I initially converted `main.ts`'s `.then()` to `await router.isReady()`. That is the *wrong* transformation here: awaiting inside the setup callback blocks the app mount (isReady resolves only after mount), **deadlocking hydration**. The Playwright suite caught it immediately (42 hydration-dependent tests failed), so it was reverted and the constraint documented. A nice demonstration of the E2E gate earning its keep.

## Verification

| Check | Result |
|---|---|
| Lint (incl. new rules) | 0 errors |
| Type-check | clean |
| Unit tests + coverage floor | 317 pass |
| Production build | clean |
| Playwright E2E (Chromium/Firefox/WebKit) | **237 pass** |

## Follow-up (not in scope)
Type-aware rules (`prefer-nullish-coalescing`, `prefer-optional-chain`, `prefer-includes`) would enforce more, but require enabling type-aware linting (parser `project` service) — a larger, perf-sensitive change worth its own PR.