### PR TITLE
Deduplicate ESLint config and extract useScrollLock

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,6 +4,103 @@ import pluginVue from 'eslint-plugin-vue';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import vueParser from 'vue-eslint-parser';
 
+// Shared across the TypeScript and Vue configs so the rule set lives in one place.
+const sharedPlugins = {
+  '@typescript-eslint': tseslint,
+  'simple-import-sort': simpleImportSort,
+};
+
+const baseRules = {
+  // Semicolons
+  'semi': ['error', 'always'],
+
+  // Quotes
+  'quotes': ['error', 'single', { avoidEscape: true }],
+
+  // Indentation
+  'indent': ['error', 2, { SwitchCase: 1 }],
+
+  // Trailing commas in multiline
+  'comma-dangle': ['error', 'always-multiline'],
+
+  // Spacing
+  'object-curly-spacing': ['error', 'always'],
+  'array-bracket-spacing': ['error', 'never'],
+  'comma-spacing': ['error', { before: false, after: true }],
+  'key-spacing': ['error', { beforeColon: false, afterColon: true }],
+  'space-before-function-paren': ['error', {
+    anonymous: 'always',
+    named: 'never',
+    asyncArrow: 'always',
+  }],
+  'space-infix-ops': 'error',
+  'keyword-spacing': ['error', { before: true, after: true }],
+  'space-before-blocks': 'error',
+
+  // Arrow functions
+  'arrow-spacing': ['error', { before: true, after: true }],
+  'arrow-parens': ['error', 'as-needed'],
+
+  // Variable declarations
+  'prefer-const': 'error',
+  'no-var': 'error',
+  'prefer-destructuring': ['error', {
+    array: false,
+    object: true,
+  }],
+
+  // Template literals
+  'prefer-template': 'error',
+
+  // Object shorthand
+  'object-shorthand': ['error', 'always'],
+
+  // Modern JavaScript over legacy patterns
+  'eqeqeq': ['error', 'always'],
+  'prefer-object-spread': 'error',
+  'no-array-constructor': 'error',
+  'prefer-spread': 'error',
+  'prefer-rest-params': 'error',
+
+  // Early returns
+  'no-else-return': ['error', { allowElseIf: false }],
+  'no-lonely-if': 'error',
+
+  // General formatting
+  'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0 }],
+  'eol-last': ['error', 'always'],
+  'no-trailing-spaces': 'error',
+
+  // Import sorting
+  'simple-import-sort/imports': 'error',
+  'simple-import-sort/exports': 'error',
+
+  // TypeScript-specific rules (only rules that don't require type information)
+  '@typescript-eslint/no-explicit-any': 'error',
+  '@typescript-eslint/no-unused-vars': ['error', {
+    argsIgnorePattern: '^_',
+    varsIgnorePattern: '^_',
+  }],
+};
+
+const vueRules = {
+  'vue/multi-word-component-names': 'off',
+  'vue/no-v-html': 'off', // Content is author-controlled, not user input
+  'vue/html-indent': ['error', 2],
+  'vue/max-attributes-per-line': ['error', {
+    singleline: 3,
+    multiline: 1,
+  }],
+  'vue/first-attribute-linebreak': ['error', {
+    singleline: 'ignore',
+    multiline: 'below',
+  }],
+  'vue/html-closing-bracket-newline': ['error', {
+    singleline: 'never',
+    multiline: 'always',
+  }],
+};
+
 export default [
   ...pluginVue.configs['flat/recommended'],
   {
@@ -16,99 +113,8 @@ export default [
         sourceType: 'module',
       },
     },
-    plugins: {
-      '@typescript-eslint': tseslint,
-      'simple-import-sort': simpleImportSort,
-    },
-    rules: {
-      // Semicolons
-      'semi': ['error', 'always'],
-
-      // Quotes
-      'quotes': ['error', 'single', { avoidEscape: true }],
-
-      // Indentation
-      'indent': ['error', 2, { SwitchCase: 1 }],
-
-      // Trailing commas in multiline
-      'comma-dangle': ['error', 'always-multiline'],
-
-      // Spacing
-      'object-curly-spacing': ['error', 'always'],
-      'array-bracket-spacing': ['error', 'never'],
-      'comma-spacing': ['error', { before: false, after: true }],
-      'key-spacing': ['error', { beforeColon: false, afterColon: true }],
-      'space-before-function-paren': ['error', {
-        anonymous: 'always',
-        named: 'never',
-        asyncArrow: 'always',
-      }],
-      'space-infix-ops': 'error',
-      'keyword-spacing': ['error', { before: true, after: true }],
-      'space-before-blocks': 'error',
-
-      // Arrow functions
-      'arrow-spacing': ['error', { before: true, after: true }],
-      'arrow-parens': ['error', 'as-needed'],
-
-      // Variable declarations
-      'prefer-const': 'error',
-      'no-var': 'error',
-      'prefer-destructuring': ['error', {
-        array: false,
-        object: true,
-      }],
-
-      // Template literals
-      'prefer-template': 'error',
-
-      // Object shorthand
-      'object-shorthand': ['error', 'always'],
-
-      // Modern JavaScript over legacy patterns
-      'eqeqeq': ['error', 'always'],
-      'prefer-object-spread': 'error',
-      'no-array-constructor': 'error',
-      'prefer-spread': 'error',
-      'prefer-rest-params': 'error',
-
-      // Early returns
-      'no-else-return': ['error', { allowElseIf: false }],
-      'no-lonely-if': 'error',
-
-      // General formatting
-      'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0 }],
-      'eol-last': ['error', 'always'],
-      'no-trailing-spaces': 'error',
-
-      // Import sorting
-      'simple-import-sort/imports': 'error',
-      'simple-import-sort/exports': 'error',
-
-      // TypeScript-specific rules (only rules that don't require type information)
-      '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
-      }],
-
-      // Vue-specific rules
-      'vue/multi-word-component-names': 'off',
-      'vue/no-v-html': 'off', // Content is author-controlled, not user input
-      'vue/html-indent': ['error', 2],
-      'vue/max-attributes-per-line': ['error', {
-        singleline: 3,
-        multiline: 1,
-      }],
-      'vue/first-attribute-linebreak': ['error', {
-        singleline: 'ignore',
-        multiline: 'below',
-      }],
-      'vue/html-closing-bracket-newline': ['error', {
-        singleline: 'never',
-        multiline: 'always',
-      }],
-    },
+    plugins: sharedPlugins,
+    rules: { ...baseRules, ...vueRules },
   },
   {
     files: ['**/*.ts', '**/*.tsx'],
@@ -119,81 +125,7 @@ export default [
         sourceType: 'module',
       },
     },
-    plugins: {
-      '@typescript-eslint': tseslint,
-      'simple-import-sort': simpleImportSort,
-    },
-    rules: {
-      // Semicolons
-      'semi': ['error', 'always'],
-
-      // Quotes
-      'quotes': ['error', 'single', { avoidEscape: true }],
-
-      // Indentation
-      'indent': ['error', 2, { SwitchCase: 1 }],
-
-      // Trailing commas in multiline
-      'comma-dangle': ['error', 'always-multiline'],
-
-      // Spacing
-      'object-curly-spacing': ['error', 'always'],
-      'array-bracket-spacing': ['error', 'never'],
-      'comma-spacing': ['error', { before: false, after: true }],
-      'key-spacing': ['error', { beforeColon: false, afterColon: true }],
-      'space-before-function-paren': ['error', {
-        anonymous: 'always',
-        named: 'never',
-        asyncArrow: 'always',
-      }],
-      'space-infix-ops': 'error',
-      'keyword-spacing': ['error', { before: true, after: true }],
-      'space-before-blocks': 'error',
-
-      // Arrow functions
-      'arrow-spacing': ['error', { before: true, after: true }],
-      'arrow-parens': ['error', 'as-needed'],
-
-      // Variable declarations
-      'prefer-const': 'error',
-      'no-var': 'error',
-      'prefer-destructuring': ['error', {
-        array: false,
-        object: true,
-      }],
-
-      // Template literals
-      'prefer-template': 'error',
-
-      // Object shorthand
-      'object-shorthand': ['error', 'always'],
-
-      // Modern JavaScript over legacy patterns
-      'eqeqeq': ['error', 'always'],
-      'prefer-object-spread': 'error',
-      'no-array-constructor': 'error',
-      'prefer-spread': 'error',
-      'prefer-rest-params': 'error',
-
-      // Early returns
-      'no-else-return': ['error', { allowElseIf: false }],
-      'no-lonely-if': 'error',
-
-      // General formatting
-      'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0 }],
-      'eol-last': ['error', 'always'],
-      'no-trailing-spaces': 'error',
-
-      // Import sorting
-      'simple-import-sort/imports': 'error',
-      'simple-import-sort/exports': 'error',
-
-      // TypeScript-specific rules (only rules that don't require type information)
-      '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
-      }],
-    },
+    plugins: sharedPlugins,
+    rules: baseRules,
   },
 ];

--- a/src/composables/useLightbox.ts
+++ b/src/composables/useLightbox.ts
@@ -3,6 +3,8 @@ import { onMounted, onUnmounted, ref } from 'vue';
 
 import type { LightboxItem } from '@/types/lightbox';
 
+import { useScrollLock } from './useScrollLock';
+
 interface UseLightboxReturn {
   isOpen: Ref<boolean>;
   currentItem: Ref<LightboxItem | null>;
@@ -28,13 +30,15 @@ export const useLightbox = (): UseLightboxReturn => {
   // Element focused before opening, restored on close (WCAG 2.4.3)
   let previouslyFocused: HTMLElement | null = null;
 
+  const { lock, unlock } = useScrollLock();
+
   const openLightbox = (allItems: LightboxItem[] = [], index = 0): void => {
     previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     items.value = allItems;
     currentIndex.value = index;
     updateCurrentItem(index);
     isOpen.value = true;
-    document.body.style.overflow = 'hidden';
+    lock();
   };
 
   const closeLightbox = (): void => {
@@ -42,7 +46,7 @@ export const useLightbox = (): UseLightboxReturn => {
     currentItem.value = null;
     items.value = [];
     currentIndex.value = 0;
-    document.body.style.overflow = '';
+    unlock();
     previouslyFocused?.focus();
     previouslyFocused = null;
   };
@@ -89,9 +93,9 @@ export const useLightbox = (): UseLightboxReturn => {
     document.addEventListener('keydown', handleKeydown, { signal: abortController.signal });
   });
 
+  // Body scroll is released by useScrollLock's own unmount hook.
   onUnmounted(() => {
     abortController.abort();
-    document.body.style.overflow = '';
   });
 
   return {

--- a/src/composables/useScrollLock.test.ts
+++ b/src/composables/useScrollLock.test.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defineComponent } from 'vue';
+
+import { useScrollLock } from './useScrollLock';
+
+const mountWithScrollLock = () => {
+  let api: ReturnType<typeof useScrollLock> | null = null;
+
+  const wrapper = mount(defineComponent({
+    setup() {
+      api = useScrollLock();
+      return () => null;
+    },
+  }));
+
+  if (!api) throw new Error('useScrollLock did not initialise');
+  return { wrapper, api };
+};
+
+describe('useScrollLock', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('starts unlocked', () => {
+    const { api } = mountWithScrollLock();
+    expect(api.isLocked.value).toBe(false);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('locks and unlocks body scroll', () => {
+    const { api } = mountWithScrollLock();
+
+    api.lock();
+    expect(api.isLocked.value).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    api.unlock();
+    expect(api.isLocked.value).toBe(false);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('releases the lock automatically on unmount', () => {
+    const { wrapper, api } = mountWithScrollLock();
+
+    api.lock();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    wrapper.unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/src/composables/useScrollLock.ts
+++ b/src/composables/useScrollLock.ts
@@ -1,0 +1,31 @@
+import type { Ref } from 'vue';
+import { onUnmounted, ref } from 'vue';
+
+interface UseScrollLockReturn {
+  isLocked: Ref<boolean>;
+  lock: () => void;
+  unlock: () => void;
+}
+
+/**
+ * Locks and restores body scroll — the scroll-management concern for modal
+ * overlays such as the lightbox. Always releases the lock on unmount, so a
+ * component torn down while still open can never leave the page unscrollable.
+ */
+export const useScrollLock = (): UseScrollLockReturn => {
+  const isLocked = ref(false);
+
+  const lock = (): void => {
+    document.body.style.overflow = 'hidden';
+    isLocked.value = true;
+  };
+
+  const unlock = (): void => {
+    document.body.style.overflow = '';
+    isLocked.value = false;
+  };
+
+  onUnmounted(unlock);
+
+  return { isLocked, lock, unlock };
+};


### PR DESCRIPTION
## Description

Closes two code-quality gaps surfaced by the alignment audit.

### 1. ESLint config no longer duplicates its rule set
The config repeated its entire ~80-line rule set across the TypeScript block and the Vue block — a DRY violation in the very file that enforces DRY (and it actively cost effort: the recent modern-JS rules had to be added in both places). Hoisted a shared `baseRules` object and `sharedPlugins`; both blocks now spread `baseRules`, and the Vue block adds only its `vue/*` rules on top. **Lint output is identical** — 0 errors, the same 15 pre-existing warnings.

### 2. `useScrollLock` extracted from `useLightbox`
`useLightbox` mutated `document.body.style.overflow` directly in three spots (open, close, unmount) — a direct shared-state mutation. Extracted it into a small, named, **testable** `useScrollLock` composable (the canonical home for modal scroll management) that always releases the lock on unmount. The lightbox now calls `lock()`/`unlock()` and its own unmount hook no longer touches body style.

## Verification

- Lint: **0 errors** (config refactor is behaviour-preserving)
- Type-check: clean
- Unit: **320 tests** (+3 new `useScrollLock` specs), coverage floor met, `useLightbox` still 100% lines
- E2E: lightbox spec (body-overflow lock/restore) green on Chromium; full suite runs in CI across Chromium/Firefox/WebKit