### PR TITLE
Consolidate CI and deploy workflows to remove duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches: [master]
+  # On master, this pipeline runs as the deploy workflow's gate (workflow_call)
+  # rather than standalone, so the checks execute exactly once per push.
   workflow_call:
 
 # Cancel in-progress runs when a new workflow with the same group name is triggered

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,123 +15,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pre-deploy-checks:
-    name: Pre-Deploy Checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+  # Run the full CI pipeline (quality checks, build, Lighthouse, cross-browser
+  # E2E) as the deploy gate — the exact workflow that runs on pull requests, so
+  # the checks are defined in a single place.
+  checks:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Type check
-        run: npm run type-check
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Run unit tests with coverage
-        run: npm run test:coverage
-
-      - name: Check coverage thresholds
-        run: node scripts/check-coverage.js
-
-  build:
-    needs: pre-deploy-checks
+  build-pages:
+    needs: checks
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: dist
-
-      # Plain copy of the built site so the E2E gate exercises the exact
-      # artifact that will be deployed, without rebuilding.
-      - name: Upload dist for E2E
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: dist/
-          retention-days: 1
-
-  e2e:
-    name: E2E Tests
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    strategy:
-      fail-fast: false
-      matrix:
-        project: [chromium, firefox, webkit]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browser
-        run: npx playwright install --with-deps ${{ matrix.project }}
-
-      - name: Download build artifacts
+      # Reuse the exact dist the E2E gate exercised, repackaged as a Pages
+      # artifact — no rebuild, so what ships is what was tested.
+      - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
-      - name: Run Playwright tests
-        run: npx playwright test --project=${{ matrix.project }}
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
 
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
-        if: failure()
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          name: playwright-report-${{ matrix.project }}
-          path: |
-            playwright-report/
-            test-results/
-          retention-days: 30
+          path: dist
 
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: [build, e2e]
+    needs: build-pages
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Jerome Faria - Personal Website
 
-[![CI](https://github.com/jeromefaria/jeromefaria.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/jeromefaria/jeromefaria.github.io/actions/workflows/ci.yml)
+[![CI/CD](https://github.com/jeromefaria/jeromefaria.github.io/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/jeromefaria/jeromefaria.github.io/actions/workflows/deploy.yml)
 [![codecov](https://codecov.io/gh/jeromefaria/jeromefaria.github.io/branch/master/graph/badge.svg)](https://codecov.io/gh/jeromefaria/jeromefaria.github.io)
-[![Deploy](https://github.com/jeromefaria/jeromefaria.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/jeromefaria/jeromefaria.github.io/actions/workflows/deploy.yml)
 
 Vue 3 + TypeScript portfolio website for [www.jeromefaria.com](https://www.jeromefaria.com).
 
@@ -136,7 +135,7 @@ npm run lint:fix && npm run type-check && npm run test:coverage && npm run build
 
 ## CI/CD Pipeline
 
-Every push to `master` and pull request triggers a comprehensive CI pipeline with the following jobs:
+The CI pipeline (`ci.yml`) runs on every pull request, and is reused as the deploy gate on `master` (via `workflow_call`) so the checks are defined in exactly one place. It has the following jobs:
 
 ### Quality Checks
 - TypeScript type checking
@@ -160,11 +159,11 @@ Every push to `master` and pull request triggers a comprehensive CI pipeline wit
 - Accessibility testing with axe-core (`@axe-core/playwright`)
 - Specs: `accessibility`, `accordion`, `contact-form`, `lightbox`, `navigation`
 
-**Quality Gates**: All four CI jobs (Quality Checks, Build, Lighthouse, E2E) must pass for the CI workflow to be green. Deployment runs on its own workflow and gates on type-check, lint, unit tests with coverage, the production build, and the cross-browser E2E suite (Chromium, Firefox, WebKit) run against the exact artifact to be deployed.
+**Quality Gates**: All four CI jobs (Quality Checks, Build, Lighthouse, E2E) must pass for the pipeline to be green.
 
 ## Deployment
 
-The site deploys to GitHub Pages via GitHub Actions on push to `master` once the deploy workflow's pre-deploy checks, production build, and cross-browser E2E gate succeed.
+The site deploys to GitHub Pages via GitHub Actions on push to `master`. The deploy workflow (`deploy.yml`) first runs the full CI pipeline as its gate, then repackages the **exact `dist` the E2E suite exercised** as a Pages artifact and publishes it — so what ships is what was tested, and the checks aren't duplicated between the two workflows.
 
 ## License
 


### PR DESCRIPTION
## Description

Closes the workflow-duplication gap from the audit: `deploy.yml` duplicated `ci.yml`'s quality checks and cross-browser E2E job (~70 lines), and `ci.yml` running standalone on master pushes was the source of the occasional concurrency-cancellation seen earlier this session.

## Changes

- **`deploy.yml`** now reuses `ci.yml` as its gate via `workflow_call` (`secrets: inherit`), then `build-pages` downloads the **exact `dist` the E2E suite exercised** and publishes it as the Pages artifact. Pipeline: `checks (= ci.yml) → build-pages → deploy`. The duplicated `pre-deploy-checks` and inline `e2e` jobs are gone.
- **`ci.yml`** triggers on `pull_request` + `workflow_call` only (dropped `push: master`). On master the checks now run **exactly once** — as the deploy gate — which also eliminates the standalone-master concurrency cancellation.
- **README** badges collapse to one **CI/CD** pipeline badge (`deploy.yml`, which now encompasses all checks on master) plus codecov; the CI/CD prose reflects the single-source-of-checks architecture.

## Result

- The checks (quality, build, Lighthouse, cross-browser E2E) are defined in **one place**.
- No double-run of checks on master; no more spurious cancellations.
- "What ships is what was tested" is now literal — deploy publishes the same `dist` artifact the E2E gate ran against.

## Validation note

`ci.yml` runs on this PR (`pull_request`), so its changes are validated here. `deploy.yml` only runs on `push: master`, so the reusable-call + artifact-repackage path is exercised on merge — I'll watch that run and fix-forward if needed (a failed deploy leaves the previously deployed site untouched).