### PR TITLE
Enable type-aware ESLint rules on the app source

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -58,6 +58,7 @@ test.describe('Accessibility', () => {
   test.describe('Focus Management', () => {
     test('should have visible focus indicators', async ({ page }) => {
       await page.goto('/');
+      await waitForHydration(page);
 
       const firstLink = page.locator('a').first();
       await firstLink.focus();
@@ -71,6 +72,7 @@ test.describe('Accessibility', () => {
 
     test('should maintain focus order', async ({ page }) => {
       await page.goto('/works');
+      await waitForHydration(page);
 
       const interactive = page.locator('a, button, input, textarea, [tabindex="0"]').first();
       await interactive.focus();

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -101,6 +101,15 @@ const vueRules = {
   }],
 };
 
+// Rules that need type information. Scoped to the app source (src, excluding
+// tests), which is covered by tsconfig.json.
+const typeAwareRules = {
+  '@typescript-eslint/prefer-nullish-coalescing': 'error',
+  '@typescript-eslint/prefer-optional-chain': 'error',
+  '@typescript-eslint/prefer-includes': 'error',
+  '@typescript-eslint/no-floating-promises': 'error',
+};
+
 export default [
   ...pluginVue.configs['flat/recommended'],
   {
@@ -127,5 +136,36 @@ export default [
     },
     plugins: sharedPlugins,
     rules: baseRules,
+  },
+  {
+    // Type-aware rules for the app source (excludes co-located tests + helpers,
+    // which tsconfig.json does not include).
+    files: ['src/**/*.ts'],
+    ignores: ['src/**/*.test.ts', 'src/test-support/**', 'src/test-setup.ts'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        projectService: true,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: sharedPlugins,
+    rules: typeAwareRules,
+  },
+  {
+    files: ['src/**/*.vue'],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: {
+        parser: tsparser,
+        projectService: true,
+        extraFileExtensions: ['.vue'],
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: sharedPlugins,
+    rules: typeAwareRules,
   },
 ];

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,7 @@ const processExternalLinks = () => {
 // Reprocessing on the Suspense `resolve` event guarantees the freshly rendered
 // page (including links inside v-html content) is in the DOM before we scan it.
 const handleContentResolved = () => {
-  nextTick(() => processExternalLinks());
+  void nextTick(() => processExternalLinks());
 };
 
 onMounted(() => {

--- a/src/components/AccordionSection.vue
+++ b/src/components/AccordionSection.vue
@@ -42,7 +42,7 @@ const toggle = () => {
 
   if (!willExpand) return;
 
-  nextTick(() => {
+  void nextTick(() => {
     setTimeout(() => {
       scrollToSection();
       contentRef.value?.focus({ preventScroll: true });

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -26,7 +26,7 @@ const isImage = computed(() => props.currentItem !== null && isLightboxImage(pro
 // Computed photographer credit (if exists on current image)
 const photographer = computed(() => {
   if (props.currentItem && isLightboxImage(props.currentItem)) {
-    return props.currentItem.photographer || null;
+    return props.currentItem.photographer ?? null;
   }
   return null;
 });

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -33,7 +33,7 @@ const {
   webpSrc,
   handleImageLoad,
   handleImageError,
-} = useImageLoader(getCoverImage(props.release) || '');
+} = useImageLoader(getCoverImage(props.release) ?? '');
 
 // Computed properties with type guards for release properties
 const hasBandcampId = computed(() => 'bandcampId' in props.release && props.release.bandcampId);

--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -22,7 +22,7 @@ const closeNav = () => {
 const openNav = () => {
   navOpen.value = true;
   // Move focus into the menu once it's rendered so keyboard users land in it.
-  nextTick(() => {
+  void nextTick(() => {
     navMenu.value?.querySelector<HTMLElement>('.nav__link')?.focus();
   });
 };

--- a/src/composables/useAccordion.ts
+++ b/src/composables/useAccordion.ts
@@ -25,7 +25,7 @@ export const useAccordion = (
   const openSection = ref<string | null>(initialSection);
 
   const scrollToElement = (id: string): void => {
-    nextTick(() => {
+    void nextTick(() => {
       setTimeout(() => {
         const element = document.getElementById(id);
         if (element) {

--- a/src/composables/useHashScroll.ts
+++ b/src/composables/useHashScroll.ts
@@ -28,7 +28,7 @@ export const useHashScroll = (
 
   onMounted(() => {
     if (immediate && route.hash) onHash(route.hash);
-    nextTick(() => {
+    void nextTick(() => {
       isInitialLoad.value = false;
     });
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,14 +34,14 @@ export const createApp = ViteSSG(
     const redirect = sessionStorage.getItem('spa-redirect');
     if (redirect) {
       sessionStorage.removeItem('spa-redirect');
-      router.replace(redirect);
+      void router.replace(redirect);
     }
 
     // Add the ready class to body once Vue is fully hydrated. This is a
     // deliberate fire-and-forget: the setup callback must NOT await
     // router.isReady() here, since that resolves only after mount and would
     // deadlock hydration. The nested rAF ensures event handlers are attached.
-    router.isReady().then(() => {
+    void router.isReady().then(() => {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           document.body.classList.add('ready');

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -82,8 +82,8 @@ export const createMusicAlbumSchema = (
   const schema: SchemaMusicAlbum = {
     '@type': 'MusicAlbum',
     name: release.title,
-    url: release.bandcampUrl || '',
-    datePublished: release.datePublished || '',
+    url: release.bandcampUrl ?? '',
+    datePublished: release.datePublished ?? '',
     byArtist: {
       '@type': 'Person',
       name: artistName,

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -36,7 +36,7 @@ const sortedLiveData = computed<LiveData>(() => {
 const eventSchemas = computed(() =>
   liveYears.flatMap(year => {
     const yearData = sortedLiveData.value[year];
-    return (yearData?.items || []).map(event =>
+    return (yearData?.items ?? []).map(event =>
       createMusicEventSchema(event, siteConfig.author.name, `${year}-01-01`),
     );
   }),
@@ -62,7 +62,7 @@ const findYearForEvent = (eventId: string): string | null =>
     return yearData?.items?.some(e => e.id === eventId);
   }) ?? null;
 
-const { openSection, handleToggle } = useAccordion(liveYears[0] || '', liveYears, findYearForEvent);
+const { openSection, handleToggle } = useAccordion(liveYears[0] ?? '', liveYears, findYearForEvent);
 const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, goToNext, goToPrev, handleTouchStart, handleTouchEnd } = useLightboxWithSwipe();
 </script>
 


### PR DESCRIPTION
## Description

Adds the enforcement tier deferred earlier: **type-information-dependent ESLint rules**, scoped to the app source (`src`, excluding co-located tests which `tsconfig.json` doesn't include), wired via `projectService`.

## Rules enabled
- `@typescript-eslint/prefer-nullish-coalescing`
- `@typescript-eslint/prefer-optional-chain`
- `@typescript-eslint/prefer-includes`
- `@typescript-eslint/no-floating-promises`

## Fixes (all behaviour-preserving)
- **7 × `void`** on deliberate fire-and-forget async calls (`nextTick(...)` scheduling in App/AccordionSection/SiteHeader/useAccordion/useHashScroll, `router.replace` on the 404 redirect, and the `router.isReady()` ready-class hook). `void` is a runtime no-op; the rule just makes "intentionally not awaited" explicit.
- **6 × `||`→`??`** where the left operand is a string/array/object (nullish-equivalent). I checked each — none are number fallbacks where `0 || x` and `0 ?? x` would differ.

## Also
- Hardened the two Focus-Management E2E tests to `waitForHydration` before focusing — they were a pre-existing flake (focusing before hydration settled). Confirmed: the suite was 79/79 green on Chromium after the change.

## Verification
Lint **0 errors** (type-aware rules pass), type-check clean, 320 unit tests, production build, and the full Chromium E2E suite (79) green. CI re-validates cross-browser + the enforced Lighthouse/bundle gates.