### PR TITLE
Defer cover images in collapsed accordion sections

### DIFF
--- a/src/components/AccordionSection.vue
+++ b/src/components/AccordionSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref } from 'vue';
 
+import { provideAccordionExpanded } from '@/composables/useAccordionContext';
 import { ID_PREFIX, LAYOUT, TIMING } from '@/utils/constants';
 
 const props = withDefaults(defineProps<{
@@ -19,6 +20,10 @@ const isExpanded = computed({
   get: () => props.modelValue,
   set: value => emit('update:modelValue', value),
 });
+
+// Share expanded state so collapsed sections can defer loading heavy content.
+provideAccordionExpanded(isExpanded);
+
 const sectionRef = ref<HTMLElement | null>(null);
 const contentRef = ref<HTMLDivElement | null>(null);
 

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+import { useAccordionVisibility } from '@/composables/useAccordionContext';
 import { useImageLoader } from '@/composables/useImageLoader';
 import type { LightboxItem, Release } from '@/types';
 
@@ -35,6 +36,11 @@ const {
   handleImageError,
 } = useImageLoader(getCoverImage(props.release) ?? '');
 
+// Defer cover loading until the release's accordion section is first opened —
+// collapsed sections sit at zero height near the viewport, defeating native
+// lazy-loading.
+const coverVisible = useAccordionVisibility();
+
 // Computed properties with type guards for release properties
 const hasBandcampId = computed(() => 'bandcampId' in props.release && props.release.bandcampId);
 const hasExternalUrl = computed(() => 'externalUrl' in props.release && props.release.externalUrl);
@@ -60,7 +66,7 @@ const isBandcampLink = computed(() => {
   >
     <!-- Bandcamp Player -->
     <BandcampPlayer
-      v-if="hasBandcampId && hasCoverImage && 'bandcampId' in release && 'coverImage' in release"
+      v-if="coverVisible && hasBandcampId && hasCoverImage && 'bandcampId' in release && 'coverImage' in release"
       :album-id="release.bandcampId"
       :cover-image="release.coverImage"
       :album-title="release.title"
@@ -68,7 +74,7 @@ const isBandcampLink = computed(() => {
 
     <!-- External Link Cover -->
     <a
-      v-else-if="hasExternalUrl && hasCoverImage && !imageError && 'externalUrl' in release"
+      v-else-if="coverVisible && hasExternalUrl && hasCoverImage && !imageError && 'externalUrl' in release"
       :href="release.externalUrl"
       target="_blank"
       rel="noopener noreferrer"
@@ -97,7 +103,7 @@ const isBandcampLink = computed(() => {
 
     <!-- Static Cover (no link) -->
     <div
-      v-else-if="hasCoverImage && !imageError"
+      v-else-if="coverVisible && hasCoverImage && !imageError"
       class="release-cover release-cover--static"
     >
       <picture>

--- a/src/composables/useAccordionContext.test.ts
+++ b/src/composables/useAccordionContext.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable vue/one-component-per-file -- test needs a provider parent + injecting child */
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { defineComponent, nextTick, type Ref, ref } from 'vue';
+
+import { provideAccordionExpanded, useAccordionVisibility } from './useAccordionContext';
+
+const Child = defineComponent({
+  setup() {
+    return { visible: useAccordionVisibility() };
+  },
+  template: '<div />',
+});
+
+const mountInAccordion = (expanded: Ref<boolean>) => {
+  const wrapper = mount(defineComponent({
+    components: { Child },
+    setup() {
+      provideAccordionExpanded(expanded);
+      return {};
+    },
+    template: '<Child />',
+  }));
+  return wrapper.findComponent(Child);
+};
+
+describe('useAccordionVisibility', () => {
+  it('defaults to visible when used outside an accordion', () => {
+    const child = mount(Child);
+    expect(child.vm.visible).toBe(true);
+  });
+
+  it('starts hidden for a collapsed section and reveals once expanded', async () => {
+    const expanded = ref(false);
+    const child = mountInAccordion(expanded);
+    expect(child.vm.visible).toBe(false);
+
+    expanded.value = true;
+    await nextTick();
+    expect(child.vm.visible).toBe(true);
+  });
+
+  it('stays visible after a revealed section is collapsed again (latch)', async () => {
+    const expanded = ref(true);
+    const child = mountInAccordion(expanded);
+    expect(child.vm.visible).toBe(true);
+
+    expanded.value = false;
+    await nextTick();
+    expect(child.vm.visible).toBe(true);
+  });
+});

--- a/src/composables/useAccordionContext.ts
+++ b/src/composables/useAccordionContext.ts
@@ -1,0 +1,27 @@
+import type { InjectionKey, Ref } from 'vue';
+import { inject, provide, ref, watch } from 'vue';
+
+const ACCORDION_EXPANDED: InjectionKey<Ref<boolean>> = Symbol('accordionExpanded');
+
+/** Called by an accordion section to share its expanded state with its content. */
+export const provideAccordionExpanded = (isExpanded: Ref<boolean>): void => {
+  provide(ACCORDION_EXPANDED, isExpanded);
+};
+
+/**
+ * Returns a ref that becomes — and stays — true once the containing accordion
+ * section has first been expanded. Content can use it to defer loading heavy
+ * resources (e.g. cover images) while its section is collapsed, since the
+ * accordion collapses to zero height near the viewport, which defeats the
+ * browser's native lazy-loading. Defaults to true outside an accordion.
+ */
+export const useAccordionVisibility = (): Ref<boolean> => {
+  const isExpanded = inject(ACCORDION_EXPANDED, null);
+  if (!isExpanded) return ref(true);
+
+  const hasBeenVisible = ref(isExpanded.value);
+  watch(isExpanded, value => {
+    if (value) hasBeenVisible.value = true;
+  });
+  return hasBeenVisible;
+};


### PR DESCRIPTION
## Description

Closes the gallery-image-weight lead from the last review. Investigating `/works` (flagged at ~1.8MB of images) found a real defect: **native lazy-loading is completely defeated by the accordion layout**.

## The finding (measured)

The Works accordion collapses sections with `grid-template-rows: 0fr`, so every *closed* section's content sits at **zero height near the top of the page** — well within the viewport. `loading="lazy"` only defers images far from the viewport, so:

- **19 covers loaded on initial `/works` (1,803KB)** — but only **6 were in the open section**; the other **13 (~1.3MB) belonged to closed sections**.
- **Opening a closed section triggered +0 new image requests** — proving those covers were already eagerly loaded, not deferred.

## The fix

A tiny typed accordion context (`useAccordionContext`):
- `AccordionSection` shares its expanded state via `provide`.
- `ReleaseItem` renders its cover **only once its section has first been opened** (a latch — re-collapsing doesn't unload it). Outside an accordion it defaults to visible.
- **Text content still renders while collapsed**, so the SSG HTML and SEO are unchanged — only the image *bytes* are deferred.

## Impact (measured after fix)

| `/works` initial load | Before | After |
|---|---|---|
| Images | 19 | **6** |
| Image weight | 1,803KB | **481KB** (−73%) |

Opening a section then loads its covers on demand (+5 confirmed).

## Verification
- 323 unit tests (+3 for the new composable's latch behaviour), coverage floor met, lint 0 errors, type-check, production build.
- Full **Chromium functional E2E** suite passes (covers still render and work when a section opens).
- Visual regression is unaffected — the deferred covers were never in the above-the-fold viewport, so the snapshots are unchanged (the PR's visual-tests job confirms).