### PR TITLE
Fix stray focus ring on first mobile-nav item (touch)

### DIFF
--- a/src/components/SiteHeader.test.ts
+++ b/src/components/SiteHeader.test.ts
@@ -70,11 +70,15 @@ describe('SiteHeader', () => {
     expect(wrapper.get('nav').attributes('id')).toBe('primary-nav');
   });
 
-  it('moves focus into the menu when opened', async () => {
+  it('moves focus to the menu container (not an interactive link) when opened', async () => {
     const { wrapper } = await mountHeader();
     await wrapper.get('.nav-toggle').trigger('click');
     await wrapper.vm.$nextTick();
-    expect(document.activeElement).toBe(wrapper.get('.nav__link').element);
+    // Focusing the tabindex="-1" container lands keyboard/AT users in the nav
+    // region without giving a link a focus ring on a touch-opened menu.
+    const nav = wrapper.get('#primary-nav');
+    expect(nav.attributes('tabindex')).toBe('-1');
+    expect(document.activeElement).toBe(nav.element);
   });
 
   it('closes on Escape and returns focus to the toggle', async () => {

--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -21,9 +21,12 @@ const closeNav = () => {
 
 const openNav = () => {
   navOpen.value = true;
-  // Move focus into the menu once it's rendered so keyboard users land in it.
+  // Move focus to the menu container (not the first link) once it's rendered,
+  // so keyboard and screen-reader users land in the labelled nav region. The
+  // container is tabindex="-1" and non-interactive, so — unlike focusing a
+  // link — this never paints a focus ring when the menu is opened by touch.
   void nextTick(() => {
-    navMenu.value?.querySelector<HTMLElement>('.nav__link')?.focus();
+    navMenu.value?.focus();
   });
 };
 
@@ -95,6 +98,7 @@ watch(() => route.path, () => {
         class="nav"
         :class="{ 'nav--open': navOpen, 'nav--closing': navClosing }"
         aria-label="Main navigation"
+        tabindex="-1"
         @keydown="handleNavKeydown"
       >
         <div class="nav__inner">

--- a/src/styles/_masthead.scss
+++ b/src/styles/_masthead.scss
@@ -79,6 +79,13 @@
   width: 100%;
   border-top: 1px solid var(--color-border-subtle);
 
+  // The menu container is focused programmatically on open (tabindex="-1") to
+  // move keyboard/AT users into the region; it is never a Tab stop itself, so
+  // it must not show a focus ring.
+  &:focus {
+    outline: none;
+  }
+
   @include respond-to(md) {
     display: flex;
     width: auto;


### PR DESCRIPTION
## Description

Removes a stray focus-ring box that appears around the first mobile-nav item (**ABOUT**) when the menu is opened by touch on iOS Safari.

## Root cause

The mobile menu is a disclosure (hamburger → expands `<nav>`). On open, `SiteHeader` moved focus to the first `.nav__link` so keyboard and screen-reader users land inside the menu. Because that `.focus()` is **programmatic**, iOS Safari applies `:focus-visible` to the link even when the menu was opened by a tap — so the global focus outline (`_base.scss`) paints a box around the first item. (Headless WebKit/Chromium don't reproduce Safari's heuristic, so this never surfaced in the visual/E2E suites.)

## Fix

Move focus to the **`<nav>` container** instead of a link:

- `<nav id="primary-nav">` gets `tabindex="-1"` (programmatically focusable, never a Tab stop) and `outline: none` on `:focus`.
- `openNav()` calls `navMenu.focus()` rather than querying the first `.nav__link`.

Keyboard and AT users still land in the labelled "Main navigation" region; Escape still closes and restores focus to the toggle; tabbing onto the links still shows proper `:focus-visible` rings. But no interactive element receives programmatic focus, so touch can't trigger a spurious ring on any engine.

## Testing

1. `gh pr checkout <N> -f && npm ci && npm run dev`
2. On a **touch device / responsive mode** (≤767px), open `/about`, **tap the hamburger** — the menu opens and **no box appears** around ABOUT.
3. Keyboard: Tab to the hamburger, press Enter to open, Tab into the list — links show their focus ring; press **Escape** — menu closes and focus returns to the hamburger.
4. Desktop (≥768px) nav is unaffected.

## Refactor assessment

- Contained change to `SiteHeader.vue`, its test, and the `.nav` block in `_masthead.scss`; no extraction warranted.
- Unit test updated to assert focus lands on the `tabindex="-1"` container rather than the first link.
