### PR TITLE
Format visually-hidden page headings to satisfy the vue lint rule

### DIFF
--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -61,7 +61,9 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
       class="page"
       data-page="about"
     >
-      <h1 class="visually-hidden">About</h1>
+      <h1 class="visually-hidden">
+        About
+      </h1>
       <template
         v-for="(section, sectionIndex) in aboutSections"
         :key="section.id"

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -32,7 +32,9 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, errors, 
       class="page"
       data-page="contact"
     >
-      <h1 class="visually-hidden">Contact</h1>
+      <h1 class="visually-hidden">
+        Contact
+      </h1>
       <!-- Introduction -->
       <div
         v-show="!showSuccess"

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -72,7 +72,9 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
       class="page"
       data-page="live"
     >
-      <h1 class="visually-hidden">Live</h1>
+      <h1 class="visually-hidden">
+        Live
+      </h1>
       <AccordionSection
         v-for="year in liveYears"
         :id="year"

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -22,7 +22,9 @@ useHashScroll(scrollToHash);
       class="page"
       data-page="press"
     >
-      <h1 class="visually-hidden">Press</h1>
+      <h1 class="visually-hidden">
+        Press
+      </h1>
       <blockquote
         v-for="item in pressQuotes"
         :id="item.id"

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -91,7 +91,9 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
       class="page"
       data-page="works"
     >
-      <h1 class="visually-hidden">Works</h1>
+      <h1 class="visually-hidden">
+        Works
+      </h1>
       <AccordionSection
         v-for="sectionKey in worksSections"
         :id="sectionKey"


### PR DESCRIPTION
## Description

Applies the ESLint autofix for `vue/singleline-html-element-content-newline` on the five per-view visually-hidden `<h1>` headings, so `npm run lint` runs clean of that warning.

## Changes

- `AboutView`, `ContactView`, `LiveView`, `PressView`, `WorksView`: the one-line `<h1 class="visually-hidden">Page</h1>` is split across three lines (content on its own line), as the rule requires for elements that have an attribute and content.

Whitespace-only in the template — Vue condenses the whitespace, so rendered output and the (visually-hidden) headings are unchanged. No visual-snapshot impact.

## Testing

- `npm run lint` — no `singleline-html-element-content-newline` warnings remain.
- `npm run test` / typecheck / build unaffected.

## Refactor assessment

Formatting-only; no logic touched. The remaining `vue/one-component-per-file` warnings in `useImageLoader.test.ts` are a separate, non-auto-fixable concern and out of scope.