### PR TITLE
Scope vue/one-component-per-file to source SFCs, not tests

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -168,4 +168,13 @@ export default [
     plugins: sharedPlugins,
     rules: typeAwareRules,
   },
+  {
+    // vue/one-component-per-file (from flat/recommended, which also lints .ts)
+    // guards source SFCs. Tests legitimately define several throwaway
+    // components to exercise composables, so scope it off for them.
+    files: ['**/*.test.ts', '**/*.test.tsx'],
+    rules: {
+      'vue/one-component-per-file': 'off',
+    },
+  },
 ];

--- a/src/composables/useAccordionContext.test.ts
+++ b/src/composables/useAccordionContext.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file -- test needs a provider parent + injecting child */
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { defineComponent, nextTick, type Ref, ref } from 'vue';

--- a/src/composables/useImageLoader.test.ts
+++ b/src/composables/useImageLoader.test.ts
@@ -108,31 +108,21 @@ describe('useImageLoader', () => {
 
   describe('onMounted — already-complete image', () => {
     it('sets imageLoaded true if image is already complete with natural height', async () => {
-      let loader: ReturnType<typeof useImageLoader>;
-
-      const TestComponent = defineComponent({
-        setup() {
-          loader = useImageLoader(TEST_SRC_JPG);
-          return loader;
-        },
-        template: '<img ref="imageRef" />',
-      });
-
-      const wrapper = mount(TestComponent, { attachTo: document.body });
+      const { loader, wrapper } = mountWithLoader(TEST_SRC_JPG);
 
       // Simulate an already-loaded image
       const img = wrapper.find('img').element as HTMLImageElement;
       Object.defineProperty(img, 'complete', { value: true, configurable: true });
       Object.defineProperty(img, 'naturalHeight', { value: 100, configurable: true });
-      loader!.imageRef.value = img;
+      loader.imageRef.value = img;
 
       // Re-trigger mounted logic via nextTick
       await nextTick();
       await nextTick();
 
       // The onMounted ran before we set the mock, so this tests the handler path
-      loader!.handleImageLoad();
-      expect(loader!.imageLoaded.value).toBe(true);
+      loader.handleImageLoad();
+      expect(loader.imageLoaded.value).toBe(true);
     });
 
     it('does not set imageLoaded if image complete but naturalHeight is 0 (broken image)', async () => {


### PR DESCRIPTION
## Description

Resolves the remaining 3 lint warnings (`vue/one-component-per-file` in `useImageLoader.test.ts`) at the root, and removes a duplicated test component.

## Root cause

`eslint-plugin-vue`'s `flat/recommended` (spread at the top of `eslint.config.ts`) lints `.ts` files too, not just `.vue`. So `vue/one-component-per-file` — meant to keep **source SFCs** to one component — fires on test files that legitimately define several throwaway components to exercise a composable. That false positive is why `useAccordionContext.test.ts` already carried a file-level `eslint-disable` for it.

## Changes

- **`eslint.config.ts`** — add an override turning `vue/one-component-per-file` **off for `**/*.test.ts`**, centrally, instead of per-file disables.
- **`useAccordionContext.test.ts`** — drop the now-redundant file-level `eslint-disable`.
- **`useImageLoader.test.ts`** — the component at the `onMounted` test was an exact duplicate of the `mountWithLoader` helper; collapse it into a `mountWithLoader()` call (real dedup, and it drops the `loader!` non-null assertions).

## Testing

- `npm run lint` — **0 problems** (was 3 warnings).
- `npm run test` — 327 pass; typecheck clean.

## Refactor assessment

- Config scoping is the correct fix (the rule targets SFCs; tests are exempt by design) — preferred over scattering suppressions.
- The test dedup removes duplicated logic and two non-null assertions. No source/behavior change.