### PR TITLE
Close the mobile menu on outside tap or scroll

### DIFF
--- a/src/components/SiteHeader.test.ts
+++ b/src/components/SiteHeader.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
 import { createMemoryHistory, createRouter } from 'vue-router';
 
 import { navigation, siteConfig } from '@/data/navigation';
@@ -90,6 +91,41 @@ describe('SiteHeader', () => {
 
     expect(wrapper.find('.nav--open').exists()).toBe(false);
     expect(document.activeElement).toBe(wrapper.get('.nav-toggle').element);
+  });
+
+  it('closes when a pointer interaction happens outside the menu', async () => {
+    const { wrapper } = await mountHeader();
+    await wrapper.get('.nav-toggle').trigger('click');
+    await nextTick();  // the outside-pointer listener binds on the next tick
+    expect(wrapper.find('.nav--open').exists()).toBe(true);
+
+    document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    await nextTick();
+
+    expect(wrapper.find('.nav--open').exists()).toBe(false);
+  });
+
+  it('stays open on a pointer interaction inside the menu', async () => {
+    const { wrapper } = await mountHeader();
+    await wrapper.get('.nav-toggle').trigger('click');
+    await nextTick();
+
+    wrapper.get('.nav__link').element.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    await nextTick();
+
+    expect(wrapper.find('.nav--open').exists()).toBe(true);
+  });
+
+  it('closes when the page is scrolled', async () => {
+    const { wrapper } = await mountHeader();
+    await wrapper.get('.nav-toggle').trigger('click');
+    await nextTick();
+    expect(wrapper.find('.nav--open').exists()).toBe(true);
+
+    window.dispatchEvent(new Event('scroll'));
+    await nextTick();
+
+    expect(wrapper.find('.nav--open').exists()).toBe(false);
   });
 
   it('renders the site title as branding, not a page heading', async () => {

--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue';
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 
 import { navigation, siteConfig } from '@/data/navigation';
@@ -43,6 +43,37 @@ const handleNavKeydown = (event: KeyboardEvent) => {
 
 watch(() => route.path, () => {
   if (navOpen.value) closeNav();
+});
+
+// While the menu is open, a tap outside it or any scroll signals the visitor is
+// done with it — dismiss it (Escape and link-select are handled above).
+const handleOutsidePointer = (event: PointerEvent) => {
+  const target = event.target as Node | null;
+  if (target && !navMenu.value?.contains(target) && !navToggle.value?.contains(target)) {
+    closeNav();
+  }
+};
+
+const handleScroll = () => {
+  if (navOpen.value) closeNav();
+};
+
+watch(navOpen, open => {
+  if (!open) {
+    document.removeEventListener('pointerdown', handleOutsidePointer);
+    window.removeEventListener('scroll', handleScroll);
+    return;
+  }
+  // Bind on the next tick so the tap that opened the menu doesn't close it.
+  void nextTick(() => {
+    document.addEventListener('pointerdown', handleOutsidePointer);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+  });
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handleOutsidePointer);
+  window.removeEventListener('scroll', handleScroll);
 });
 </script>
 


### PR DESCRIPTION
## Description

When the mobile menu was open it stayed pinned while the page scrolled freely underneath, closing only via the toggle, Escape, or picking a link. That's an uncommon middle ground — most mobile menus dismiss when you interact with the page. This closes it on an outside tap or a scroll.

## Changes

- `SiteHeader.vue`: while the menu is open, bind a `document` `pointerdown` (closes on a tap outside the menu **and** the toggle) and a `window` `scroll` listener (closes on any scroll). Both call the existing `closeNav()`, so the close animation, Escape, and link-select behave exactly as before.
- Listeners are bound only while open — and one tick *after* opening, so the tap that opened the menu doesn't immediately dismiss it — and removed on close and on unmount.

## Testing

Browser-verified on a mobile viewport:
- Open → **tap outside** → closes.
- Open → **scroll** → closes.
- Open → **tap a nav link** → navigates *and* closes (unchanged).
- Open → **tap the hamburger** → closes (no double-trigger).

Unit tests added for outside-pointer close, scroll close, and staying open on an inside pointer.

## Refactor assessment

Contained to `SiteHeader.vue` + its test. Listeners are scoped to the open state and cleaned up; no globals leak. Desktop is unaffected (the menu never opens there — the toggle is `display: none`).

## Visual regression

No rendered change — behavior only; page snapshots are unaffected.