### PR TITLE
Fix mobile menu closing instantly when opened while scrolled

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { isMobile, openMobileMenuIfNeeded } from './helpers';
+import { isMobile, openMobileMenuIfNeeded, waitForHydration } from './helpers';
 
 const NAV_TOGGLE_SELECTOR = '.nav-toggle';
 const NAV_OPEN_SELECTOR = '.nav--open';
@@ -132,5 +132,21 @@ test.describe('Navigation', () => {
 
     await expect(page.locator(NAV_SELECTOR)).toBeVisible();
     await expect(page.locator(NAV_LINK_SELECTOR).first()).toBeVisible();
+  });
+
+  test('keeps the mobile menu open when opened on a scrolled page', async ({ page }) => {
+    // Force a mobile viewport (the desktop projects never exercise the hamburger).
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto(PAGES.ABOUT);
+    await waitForHydration(page);
+
+    await page.mouse.wheel(0, 400);
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+    await page.locator(NAV_TOGGLE_SELECTOR).click();
+
+    // Regression: focusing the sticky nav used to scroll to the top, which fired
+    // the dismiss-on-scroll handler and closed the menu the instant it opened.
+    await expect(page.locator(NAV_OPEN_SELECTOR)).toBeVisible();
   });
 });

--- a/src/components/SiteHeader.test.ts
+++ b/src/components/SiteHeader.test.ts
@@ -116,18 +116,6 @@ describe('SiteHeader', () => {
     expect(wrapper.find('.nav--open').exists()).toBe(true);
   });
 
-  it('closes when the page is scrolled', async () => {
-    const { wrapper } = await mountHeader();
-    await wrapper.get('.nav-toggle').trigger('click');
-    await nextTick();
-    expect(wrapper.find('.nav--open').exists()).toBe(true);
-
-    window.dispatchEvent(new Event('scroll'));
-    await nextTick();
-
-    expect(wrapper.find('.nav--open').exists()).toBe(false);
-  });
-
   it('renders the site title as branding, not a page heading', async () => {
     const { wrapper } = await mountHeader();
     expect(wrapper.get('.masthead-title').element.tagName).toBe('P');

--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -25,8 +25,10 @@ const openNav = () => {
   // so keyboard and screen-reader users land in the labelled nav region. The
   // container is tabindex="-1" and non-interactive, so — unlike focusing a
   // link — this never paints a focus ring when the menu is opened by touch.
+  // preventScroll: focusing the sticky nav on a scrolled page would otherwise
+  // jump the viewport to the top (and that scroll used to auto-dismiss the menu).
   void nextTick(() => {
-    navMenu.value?.focus();
+    navMenu.value?.focus({ preventScroll: true });
   });
 };
 
@@ -45,8 +47,9 @@ watch(() => route.path, () => {
   if (navOpen.value) closeNav();
 });
 
-// While the menu is open, a tap outside it or any scroll signals the visitor is
-// done with it — dismiss it (Escape and link-select are handled above).
+// While the menu is open, a pointer interaction outside it dismisses it. This
+// also covers a scroll gesture, which begins with a touch on the content behind
+// the menu (Escape and link-select are handled above).
 const handleOutsidePointer = (event: PointerEvent) => {
   const target = event.target as Node | null;
   if (target && !navMenu.value?.contains(target) && !navToggle.value?.contains(target)) {
@@ -54,26 +57,19 @@ const handleOutsidePointer = (event: PointerEvent) => {
   }
 };
 
-const handleScroll = () => {
-  if (navOpen.value) closeNav();
-};
-
 watch(navOpen, open => {
   if (!open) {
     document.removeEventListener('pointerdown', handleOutsidePointer);
-    window.removeEventListener('scroll', handleScroll);
     return;
   }
   // Bind on the next tick so the tap that opened the menu doesn't close it.
   void nextTick(() => {
     document.addEventListener('pointerdown', handleOutsidePointer);
-    window.addEventListener('scroll', handleScroll, { passive: true });
   });
 });
 
 onBeforeUnmount(() => {
   document.removeEventListener('pointerdown', handleOutsidePointer);
-  window.removeEventListener('scroll', handleScroll);
 });
 </script>
 


### PR DESCRIPTION
## Description

**Hotfix** for a regression from #115. On a **scrolled** page, tapping the hamburger opened the menu and immediately closed it. Root cause: opening focuses the sticky nav for accessibility, and on a scrolled page that focus scrolled the viewport to the top — which fired the new dismiss-on-scroll handler and closed the menu instantly. (At the top of the page it was fine, which is why it wasn't caught initially.)

## Fix

- **`focus({ preventScroll: true })`** in `openNav` — opening the menu no longer jumps the viewport.
- **Removed the `scroll` listener.** A real scroll gesture begins with a touch on the content behind the menu, which the existing outside-`pointerdown` handler already catches — so tapping or scrolling outside still dismisses the menu, without depending on scroll events (which the focus was spuriously triggering).
- **E2E regression test** (forced mobile viewport): scroll the page, open the menu, assert it stays open. The desktop-engine projects never exercised the hamburger — the gap that let this through.

## Verification

- WebKit-touch (closest to real iOS Safari): open while scrolled → menu **stays open**, viewport does **not** jump.
- Still closes on: outside tap, scroll gesture (via the outside `pointerdown`), Escape, nav-link select, and the toggle.
- New E2E test green on all 3 engines; unit tests, coverage, lint, build all pass.

## Visual regression

Behavior-only; no rendered change.