### PR TITLE
Show NotFoundView for unknown URLs (fix SPA-redirect timing)

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -97,6 +97,15 @@ test.describe('Navigation', () => {
     await expect(page.locator(`${NOT_FOUND_SELECTOR} h1`)).toContainText('Page Not Found');
   });
 
+  test('follows the 404.html SPA redirect through to the not-found page', async ({ page }) => {
+    // 404.html stores the unknown path and bounces to '/'; main.ts replaces to it.
+    await page.addInitScript(() => sessionStorage.setItem('spa-redirect', '/deep/missing-page'));
+    await page.goto(PAGES.HOME);
+
+    await expect(page.locator(NOT_FOUND_SELECTOR)).toBeVisible();
+    await expect(page).toHaveURL(/\/deep\/missing-page$/);
+  });
+
   test('should maintain navigation state across pages', async ({ page }) => {
     await page.goto(PAGES.HOME);
     await openMobileMenuIfNeeded(page);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,11 +30,12 @@ export const createApp = ViteSSG(
     // Client-side only: SSG pre-render has no session storage or live DOM.
     if (!isClient) return;
 
-    // Handle SPA redirect from 404.html.
+    // SPA redirect from 404.html — replace after the initial navigation resolves,
+    // or the startup route overrides it and the stored path is lost.
     const redirect = sessionStorage.getItem('spa-redirect');
     if (redirect) {
       sessionStorage.removeItem('spa-redirect');
-      void router.replace(redirect);
+      void router.isReady().then(() => router.replace(redirect));
     }
 
     // Add the ready class to body once Vue is fully hydrated. This is a


### PR DESCRIPTION
## Description

Wrong URLs silently landed on the **homepage** instead of the 404 page — NotFoundView was wired up (catch-all route) but never reached.

## Root cause

On GitHub Pages an unknown URL serves `404.html`, which stores the path in `sessionStorage` and bounces to `/`. `main.ts` reads it and `router.replace()`s to it — but that ran **inside the ViteSSG setup callback, before the router's initial navigation**, so the startup route to `/` overrode it. (Confirmed live: the path was stored and read, but the URL stayed `/`.)

## Fix

Defer the replace to `router.isReady().then(() => router.replace(redirect))` — same non-blocking pattern already used for the ready-class — so it applies after the initial navigation resolves.

## Testing

- New E2E test drives the actual handoff (seed `sessionStorage['spa-redirect']`, load `/`, assert NotFoundView + the URL). The existing 404 test only hit the catch-all directly via `goto('/bad')`, so this path was untested.
- typecheck, lint, unit, build, and `navigation.spec` (14/14) all pass.

## Visual regression

Behaviour-only; no rendered change on existing pages.