### PR TITLE
Extract page schema/meta builders and a LightboxHost component

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,24 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Jerome Faria - Sound Artist & Composer</title>
-    <!-- Fallback meta tags (JS will override these) -->
-    <meta name="description" content="Creating at the edges of experimental electronics, film scoring, and live performance since 2004">
+    <!-- Description, Open Graph, Twitter, and canonical are set per-route in usePageHead.ts. -->
     <meta name="author" content="Jerome Faria">
     <meta name="theme-color" content="#0a0a0a">
-    <!-- Open Graph fallbacks -->
-    <meta property="og:title" content="Jerome Faria - Sound Artist & Composer">
-    <meta property="og:description" content="Creating at the edges of experimental electronics, film scoring, and live performance since 2004">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://jeromefaria.com">
-    <meta property="og:site_name" content="Jerome Faria">
-    <meta property="og:image" content="https://jeromefaria.com/images/performance.jpg">
-    <!-- Twitter Card fallbacks -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Jerome Faria - Sound Artist & Composer">
-    <meta name="twitter:description" content="Creating at the edges of experimental electronics, film scoring, and live performance since 2004">
-    <meta name="twitter:image" content="https://jeromefaria.com/images/performance.jpg">
-    <!-- Canonical URL -->
-    <link rel="canonical" href="https://jeromefaria.com">
     <!-- Preconnect to external domains -->
     <link rel="preconnect" href="https://bandcamp.com" crossorigin>
     <link rel="dns-prefetch" href="https://bandcamp.com">

--- a/src/components/LightboxHost.test.ts
+++ b/src/components/LightboxHost.test.ts
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+
+import type { LightboxItem } from '@/types';
+
+import LightboxHost from './LightboxHost.vue';
+
+const images: LightboxItem[] = [
+  { type: 'image', src: '/one.jpg', alt: 'One' },
+  { type: 'image', src: '/two.jpg', alt: 'Two' },
+];
+
+describe('LightboxHost', () => {
+  it('renders no overlay until the lightbox is opened', () => {
+    const wrapper = mount(LightboxHost);
+
+    expect(wrapper.find('.lightbox').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('opens the overlay at the requested item via the exposed openLightbox', async () => {
+    const wrapper = mount(LightboxHost, { attachTo: document.body });
+
+    wrapper.vm.openLightbox(images, 1);
+    await nextTick();
+
+    expect(wrapper.get('.lightbox').attributes('aria-label')).toBe('Image 2 of 2');
+
+    wrapper.unmount();
+  });
+
+  it('tears the overlay down when it emits close', async () => {
+    const wrapper = mount(LightboxHost, { attachTo: document.body });
+
+    wrapper.vm.openLightbox(images, 0);
+    await nextTick();
+    expect(wrapper.find('.lightbox').exists()).toBe(true);
+
+    await wrapper.get('.lightbox__hint--close').trigger('click');
+
+    expect(wrapper.find('.lightbox').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/src/components/LightboxHost.vue
+++ b/src/components/LightboxHost.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import LightboxOverlay from '@/components/LightboxOverlay.vue';
+import { useLightboxWithSwipe } from '@/composables/useLightboxWithSwipe';
+
+const {
+  isOpen,
+  currentItem,
+  currentIndex,
+  items,
+  openLightbox,
+  closeLightbox,
+  goToNext,
+  goToPrev,
+  handleTouchStart,
+  handleTouchEnd,
+} = useLightboxWithSwipe();
+
+// Parents trigger the lightbox through a template ref: `lightbox.openLightbox(...)`.
+defineExpose({ openLightbox });
+</script>
+
+<template>
+  <LightboxOverlay
+    v-if="currentItem"
+    :is-open="isOpen"
+    :current-item="currentItem"
+    :current-index="currentIndex"
+    :total-items="items.length"
+    @close="closeLightbox"
+    @prev="goToPrev"
+    @next="goToNext"
+    @touchstart="handleTouchStart"
+    @touchend="handleTouchEnd"
+  />
+</template>

--- a/src/composables/usePageHead.test.ts
+++ b/src/composables/usePageHead.test.ts
@@ -100,9 +100,9 @@ describe('usePageHead', () => {
       expect(getMeta(config, 'og:site_name')?.content).toBe(siteConfig.title);
     });
 
-    it('sets twitter:card to summary by default', () => {
+    it('sets twitter:card to summary_large_image', () => {
       const config = mountWithPageHead({ title: 'About', description: 'desc' });
-      expect(getMeta(config, 'twitter:card')?.content).toBe('summary');
+      expect(getMeta(config, 'twitter:card')?.content).toBe('summary_large_image');
     });
 
     it('sets twitter:title and twitter:description', () => {
@@ -122,23 +122,12 @@ describe('usePageHead', () => {
     });
   });
 
-  describe('includeImage option', () => {
-    it('does not include og:image or twitter:image by default', () => {
+  describe('social image', () => {
+    it('always includes og:image and twitter:image from the site config', () => {
       const config = mountWithPageHead({ title: 'About', description: 'desc' });
-      expect(getMeta(config, 'og:image')).toBeUndefined();
-      expect(getMeta(config, 'twitter:image')).toBeUndefined();
-    });
-
-    it('includes og:image and twitter:image when includeImage is true', () => {
-      const config = mountWithPageHead({ title: 'About', description: 'desc', includeImage: true });
       const expectedImage = `${siteConfig.url}${siteConfig.image}`;
       expect(getMeta(config, 'og:image')?.content).toBe(expectedImage);
       expect(getMeta(config, 'twitter:image')?.content).toBe(expectedImage);
-    });
-
-    it('sets twitter:card to summary_large_image when includeImage is true', () => {
-      const config = mountWithPageHead({ title: 'About', description: 'desc', includeImage: true });
-      expect(getMeta(config, 'twitter:card')?.content).toBe('summary_large_image');
     });
   });
 

--- a/src/composables/usePageHead.ts
+++ b/src/composables/usePageHead.ts
@@ -8,7 +8,6 @@ interface UsePageHeadOptions {
   description: string;
   ogType?: string;
   schema?: object | null;
-  includeImage?: boolean;
   noIndex?: boolean;
   /** WebP image to preload with high priority (e.g. an above-the-fold hero). */
   preloadImage?: string;
@@ -21,7 +20,6 @@ interface UsePageHeadOptions {
  * @param options.description - Page meta description
  * @param options.ogType - Open Graph type (default: 'website')
  * @param options.schema - JSON-LD structured data schema
- * @param options.includeImage - Include og:image and twitter:image meta tags
  * @param options.noIndex - Add robots noindex meta tag
  */
 export const usePageHead = ({
@@ -29,7 +27,6 @@ export const usePageHead = ({
   description,
   ogType = 'website',
   schema = null,
-  includeImage = false,
   noIndex = false,
   preloadImage,
 }: UsePageHeadOptions): void => {
@@ -39,6 +36,7 @@ export const usePageHead = ({
     : `${title} - ${siteConfig.title}`;
 
   const canonicalUrl = `${siteConfig.url}${route.path}`;
+  const imageUrl = `${siteConfig.url}${siteConfig.image}`;
 
   const meta = [
     { name: 'description', content: description },
@@ -47,18 +45,12 @@ export const usePageHead = ({
     { property: 'og:type', content: ogType },
     { property: 'og:url', content: canonicalUrl },
     { property: 'og:site_name', content: siteConfig.title },
-    { name: 'twitter:card', content: includeImage ? 'summary_large_image' : 'summary' },
+    { property: 'og:image', content: imageUrl },
+    { name: 'twitter:card', content: 'summary_large_image' },
     { name: 'twitter:title', content: fullTitle },
     { name: 'twitter:description', content: description },
+    { name: 'twitter:image', content: imageUrl },
   ];
-
-  if (includeImage) {
-    const imageUrl = `${siteConfig.url}${siteConfig.image}`;
-    meta.push(
-      { property: 'og:image', content: imageUrl },
-      { name: 'twitter:image', content: imageUrl },
-    );
-  }
 
   if (noIndex) {
     meta.push({ name: 'robots', content: 'noindex' });

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -1071,3 +1071,15 @@ export const liveData: LiveData = {
 
 // Export years dynamically from liveData keys (newest first)
 export const liveYears: string[] = Object.keys(liveData).sort((a, b) => b.localeCompare(a));
+
+// Events within each year, sorted by date (most recent first). ISO date
+// strings compare correctly as strings: '2022-07-02' > '2022-03-05'.
+export const sortedLiveData: LiveData = Object.fromEntries(
+  Object.entries(liveData).map(([year, yearData]) => [
+    year,
+    {
+      ...yearData,
+      items: [...yearData.items].sort((a, b) => (b.date ?? '').localeCompare(a.date ?? '')),
+    },
+  ]),
+);

--- a/src/data/pageMeta.ts
+++ b/src/data/pageMeta.ts
@@ -1,0 +1,37 @@
+import { siteConfig } from './navigation';
+
+export interface PageMeta {
+  title: string;
+  description: string;
+  ogType?: string;
+}
+
+// Per-page title/description for usePageHead. The homepage represents the whole
+// site, so its meta derives from siteConfig; the rest carry their own SEO copy.
+export const pageMeta = {
+  home: {
+    title: `${siteConfig.title} - ${siteConfig.tagline}`,
+    description: siteConfig.description,
+  },
+  about: {
+    title: 'About',
+    description: 'Biography and background of Jerome Faria, Portuguese sound artist and electronic music composer.',
+    ogType: 'profile',
+  },
+  works: {
+    title: 'Works',
+    description: 'Discography, film scores, and works by Jerome Faria including solo releases, collaborations, and curatorial projects.',
+  },
+  live: {
+    title: 'Live',
+    description: 'Live performance history of Jerome Faria from 2005 to present, including festivals, concerts, and collaborations.',
+  },
+  contact: {
+    title: 'Contact',
+    description: 'Get in touch with Jerome Faria for commissions, collaborations, performance bookings, and general inquiries.',
+  },
+  press: {
+    title: 'Press',
+    description: 'Press coverage and reviews of Jerome Faria\'s work from The Quietus, Bodyspace, Indie Rock Mag, and more.',
+  },
+} satisfies Record<string, PageMeta>;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -66,3 +66,38 @@ export interface SchemaBook {
   editor: SchemaPerson[];
   contributor: SchemaPerson;
 }
+
+export interface SchemaProfilePerson {
+  '@context': 'https://schema.org';
+  '@type': 'Person';
+  name: string;
+  url: string;
+  jobTitle: string;
+  description: string;
+  image: string;
+  sameAs: string[];
+}
+
+export interface SchemaContactPage {
+  '@context': 'https://schema.org';
+  '@type': 'ContactPage';
+  mainEntity: {
+    '@type': 'Person';
+    name: string;
+    email: string;
+    url: string;
+  };
+}
+
+export interface SchemaMusicGroup {
+  '@type': 'MusicGroup';
+  name: string;
+  url: string;
+  genre: string[];
+  album: SchemaMusicAlbum[];
+}
+
+export interface SchemaWorksGraph {
+  '@context': 'https://schema.org';
+  '@graph': [SchemaMusicGroup, SchemaBook];
+}

--- a/src/utils/pageSchemas.datePublished.test.ts
+++ b/src/utils/pageSchemas.datePublished.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the works data so a solo release without a parseable year exercises the
+// datePublished-omit branch in createWorksPageSchema — unreachable with the real
+// content, where every solo release carries a year. Isolated in its own file so
+// the mock never leaks into the real-data suite (pageSchemas.test.ts).
+vi.mock('@/data/works', () => ({
+  worksData: {
+    solo: {
+      title: 'Solo',
+      id: 'solo',
+      items: [
+        { id: 'dated', title: 'Dated Release', bandcampUrl: 'https://example.bandcamp.com/album/a', meta: 'Released 2020' },
+        { id: 'undated', title: 'Undated Release', bandcampUrl: 'https://example.bandcamp.com/album/b' },
+      ],
+    },
+  },
+}));
+
+import { createWorksPageSchema } from './pageSchemas';
+
+describe('createWorksPageSchema — datePublished derivation', () => {
+  it('sets datePublished from a parseable year and leaves it empty otherwise', () => {
+    const [musicGroup] = createWorksPageSchema()['@graph'];
+    const dated = musicGroup.album.find(album => album.name === 'Dated Release');
+    const undated = musicGroup.album.find(album => album.name === 'Undated Release');
+
+    expect(dated?.datePublished).toBe('2020');
+    expect(undated?.datePublished).toBe('');
+  });
+});

--- a/src/utils/pageSchemas.test.ts
+++ b/src/utils/pageSchemas.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { liveData, liveYears } from '@/data/live';
+import { siteConfig, social } from '@/data/navigation';
+import { worksData } from '@/data/works';
+
+import {
+  createContactPageSchema,
+  createLiveEventsSchema,
+  createPersonSchema,
+  createWorksPageSchema,
+} from './pageSchemas';
+
+describe('createPersonSchema', () => {
+  it('builds a Person from the site config and social links', () => {
+    const schema = createPersonSchema();
+
+    expect(schema['@type']).toBe('Person');
+    expect(schema.name).toBe(siteConfig.author.name);
+    expect(schema.url).toBe(siteConfig.url);
+    expect(schema.jobTitle).toBe(siteConfig.tagline);
+    expect(schema.image).toBe(`${siteConfig.url}${siteConfig.image}`);
+    expect(schema.sameAs).toEqual(social.map(link => link.url));
+  });
+});
+
+describe('createContactPageSchema', () => {
+  it('builds a ContactPage whose mainEntity is the author', () => {
+    const schema = createContactPageSchema();
+
+    expect(schema['@type']).toBe('ContactPage');
+    expect(schema.mainEntity).toMatchObject({
+      '@type': 'Person',
+      name: siteConfig.author.name,
+      email: siteConfig.author.email,
+      url: siteConfig.url,
+    });
+  });
+});
+
+describe('createWorksPageSchema', () => {
+  it('assembles a graph with a MusicGroup and the Glitch book', () => {
+    const schema = createWorksPageSchema();
+    const [musicGroup, book] = schema['@graph'];
+
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@graph']).toHaveLength(2);
+    expect(musicGroup['@type']).toBe('MusicGroup');
+    expect(musicGroup.name).toBe(siteConfig.author.name);
+    expect(book['@type']).toBe('Book');
+    expect(book.name).toBe('Glitch: Designing Imperfection');
+  });
+
+  it('includes only solo releases that carry a Bandcamp reference', () => {
+    const schema = createWorksPageSchema();
+    const [musicGroup] = schema['@graph'];
+    const expectedAlbumCount = (worksData['solo']?.items ?? []).filter(
+      release =>
+        ('bandcampId' in release && release.bandcampId !== undefined) ||
+        ('bandcampUrl' in release && release.bandcampUrl !== undefined),
+    ).length;
+
+    expect(musicGroup.album).toHaveLength(expectedAlbumCount);
+    musicGroup.album.forEach(album => {
+      expect(album['@type']).toBe('MusicAlbum');
+      expect(album.name).toBeTruthy();
+      expect(album.byArtist.name).toBe(siteConfig.author.name);
+    });
+  });
+});
+
+describe('createLiveEventsSchema', () => {
+  it('builds an ItemList covering every performance', () => {
+    const schema = createLiveEventsSchema();
+    const totalEvents = liveYears.reduce(
+      (sum, year) => sum + (liveData[year]?.items.length ?? 0),
+      0,
+    );
+
+    expect(schema['@type']).toBe('ItemList');
+    expect(schema.numberOfItems).toBe(totalEvents);
+    expect(schema.itemListElement).toHaveLength(totalEvents);
+    schema.itemListElement.forEach((element, index) => {
+      expect(element.position).toBe(index + 1);
+      expect(element.item['@type']).toBe('MusicEvent');
+    });
+  });
+
+  it('orders events within the newest year by date, most recent first', () => {
+    const schema = createLiveEventsSchema();
+    const newestYear = liveYears[0];
+    const startDates = schema.itemListElement
+      .map(element => element.item.startDate)
+      .filter(date => date.startsWith(`${newestYear}-`));
+
+    expect(startDates.length).toBeGreaterThan(1);
+    expect(startDates).toEqual([...startDates].sort((a, b) => b.localeCompare(a)));
+  });
+});

--- a/src/utils/pageSchemas.ts
+++ b/src/utils/pageSchemas.ts
@@ -1,0 +1,107 @@
+// Page-level JSON-LD builders, composing the primitives in ./schemaHelpers so
+// the views stay free of structured-data assembly.
+
+import { liveYears, sortedLiveData } from '@/data/live';
+import { siteConfig, social } from '@/data/navigation';
+import { worksData } from '@/data/works';
+import type { BandcampRelease, ExternalRelease } from '@/types';
+import type {
+  SchemaBook,
+  SchemaContactPage,
+  SchemaItemList,
+  SchemaProfilePerson,
+  SchemaWorksGraph,
+} from '@/types/schema';
+
+import { extractYear } from './formatters';
+import { createItemListSchema, createMusicAlbumSchema, createMusicEventSchema } from './schemaHelpers';
+
+/** Person schema for the homepage. */
+export const createPersonSchema = (): SchemaProfilePerson => ({
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: siteConfig.author.name,
+  url: siteConfig.url,
+  jobTitle: siteConfig.tagline,
+  description: siteConfig.description,
+  image: `${siteConfig.url}${siteConfig.image}`,
+  sameAs: social.map(s => s.url),
+});
+
+/** ContactPage schema. */
+export const createContactPageSchema = (): SchemaContactPage => ({
+  '@context': 'https://schema.org',
+  '@type': 'ContactPage',
+  mainEntity: {
+    '@type': 'Person',
+    name: siteConfig.author.name,
+    email: siteConfig.author.email,
+    url: siteConfig.url,
+  },
+});
+
+const glitchBookSchema: SchemaBook = {
+  '@type': 'Book',
+  name: 'Glitch: Designing Imperfection',
+  image: `${siteConfig.url}/images/glitch.jpg`,
+  url: 'https://www.amazon.com/Glitch-Designing-Imperfection-Iman-Moradi/dp/0979966663',
+  datePublished: '2009',
+  isbn: '978-0-9799666-6-8',
+  publisher: {
+    '@type': 'Organization',
+    name: 'Mark Batty Publisher',
+  },
+  editor: [
+    { '@type': 'Person', name: 'Iman Moradi' },
+    { '@type': 'Person', name: 'Ant Scott' },
+    { '@type': 'Person', name: 'Joe Gilmore' },
+    { '@type': 'Person', name: 'Christopher Murphy' },
+  ],
+  contributor: {
+    '@type': 'Person',
+    name: siteConfig.author.name,
+  },
+};
+
+/** Works page: a MusicGroup with its solo albums, plus the Glitch book. */
+export const createWorksPageSchema = (): SchemaWorksGraph => {
+  const soloSection = worksData['solo'];
+  const albums = (soloSection?.items ?? [])
+    .filter((release): release is BandcampRelease | ExternalRelease =>
+      ('bandcampId' in release && release.bandcampId !== undefined) ||
+      ('bandcampUrl' in release && release.bandcampUrl !== undefined))
+    .map(release => {
+      const datePublished = extractYear(release.meta ?? null);
+      const withDate = { ...release, ...(datePublished ? { datePublished } : {}) };
+      return createMusicAlbumSchema(withDate, siteConfig.author.name, siteConfig.url);
+    });
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'MusicGroup',
+        name: siteConfig.author.name,
+        url: siteConfig.url,
+        genre: ['Electronic', 'Experimental', 'Ambient'],
+        album: albums,
+      },
+      glitchBookSchema,
+    ],
+  };
+};
+
+/** Live page: an ItemList of every performance, newest year first. */
+export const createLiveEventsSchema = (): SchemaItemList => {
+  const events = liveYears.flatMap(year => {
+    const yearData = sortedLiveData[year];
+    return (yearData?.items ?? []).map(event =>
+      createMusicEventSchema(event, siteConfig.author.name, `${year}-01-01`));
+  });
+
+  return createItemListSchema(
+    events,
+    `${siteConfig.author.name} Live Performances`,
+    'Live performance history from 2005 to present',
+  );
+};

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -5,15 +5,12 @@ import LightboxOverlay from '@/components/LightboxOverlay.vue';
 import { useLightboxWithSwipe } from '@/composables/useLightboxWithSwipe';
 import { usePageHead } from '@/composables/usePageHead';
 import { aboutSections } from '@/data/about';
+import { pageMeta } from '@/data/pageMeta';
 import type { AboutImage, LightboxImage } from '@/types';
 import { getImageStyles } from '@/utils/imageStyles';
 import { responsiveSrcset } from '@/utils/responsiveImage';
 
-usePageHead({
-  title: 'About',
-  description: 'Biography and background of Jerome Faria, Portuguese sound artist and electronic music composer.',
-  ogType: 'profile',
-});
+usePageHead(pageMeta.about);
 
 const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, goToNext, goToPrev, handleTouchStart, handleTouchEnd } = useLightboxWithSwipe();
 

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 
-import LightboxOverlay from '@/components/LightboxOverlay.vue';
-import { useLightboxWithSwipe } from '@/composables/useLightboxWithSwipe';
+import LightboxHost from '@/components/LightboxHost.vue';
 import { usePageHead } from '@/composables/usePageHead';
 import { aboutSections } from '@/data/about';
 import { pageMeta } from '@/data/pageMeta';
@@ -12,7 +11,7 @@ import { responsiveSrcset } from '@/utils/responsiveImage';
 
 usePageHead(pageMeta.about);
 
-const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, goToNext, goToPrev, handleTouchStart, handleTouchEnd } = useLightboxWithSwipe();
+const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 
 const convertToLightboxImage = (image: AboutImage): LightboxImage => {
   const lightboxImage: LightboxImage = {
@@ -87,7 +86,7 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
             v-for="(image, imageIndex) in section.images"
             :key="imageIndex"
             class="about-image-group__image"
-            @click="openLightbox(allImages, getGlobalIndex(sectionIndex, imageIndex))"
+            @click="lightbox?.openLightbox(allImages, getGlobalIndex(sectionIndex, imageIndex))"
           >
             <picture>
               <source
@@ -126,18 +125,6 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
       </template>
     </article>
 
-    <!-- Lightbox overlay -->
-    <LightboxOverlay
-      v-if="currentItem"
-      :is-open="isOpen"
-      :current-item="currentItem"
-      :current-index="currentIndex"
-      :total-items="items.length"
-      @close="closeLightbox"
-      @prev="goToPrev"
-      @next="goToNext"
-      @touchstart="handleTouchStart"
-      @touchend="handleTouchEnd"
-    />
+    <LightboxHost ref="lightbox" />
   </div>
 </template>

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -2,24 +2,13 @@
 import { useContactForm } from '@/composables/useContactForm';
 import { usePageHead } from '@/composables/usePageHead';
 import { contactContent } from '@/data/contact';
-import { siteConfig } from '@/data/navigation';
+import { pageMeta } from '@/data/pageMeta';
 import { FORM_SUBMIT } from '@/utils/constants';
-
-const contactSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'ContactPage',
-  mainEntity: {
-    '@type': 'Person',
-    name: siteConfig.author.name,
-    email: siteConfig.author.email,
-    url: siteConfig.url,
-  },
-};
+import { createContactPageSchema } from '@/utils/pageSchemas';
 
 usePageHead({
-  title: 'Contact',
-  description: 'Get in touch with Jerome Faria for commissions, collaborations, performance bookings, and general inquiries.',
-  schema: contactSchema,
+  ...pageMeta.contact,
+  schema: createContactPageSchema(),
 });
 
 const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, errors, handleBlur, handleInput, handleSubmit } =

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,26 +2,15 @@
 import { onMounted, ref } from 'vue';
 
 import { usePageHead } from '@/composables/usePageHead';
-import { siteConfig, social } from '@/data/navigation';
-
-const personSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'Person',
-  name: siteConfig.author.name,
-  url: siteConfig.url,
-  jobTitle: siteConfig.tagline,
-  description: siteConfig.description,
-  image: `${siteConfig.url}${siteConfig.image}`,
-  sameAs: social.map(s => s.url),
-};
+import { siteConfig } from '@/data/navigation';
+import { pageMeta } from '@/data/pageMeta';
+import { createPersonSchema } from '@/utils/pageSchemas';
 
 const heroImageSrc = '/images/performance.webp';
 
 usePageHead({
-  title: `${siteConfig.title} - ${siteConfig.tagline}`,
-  description: siteConfig.description,
-  schema: personSchema,
-  includeImage: true,
+  ...pageMeta.home,
+  schema: createPersonSchema(),
   preloadImage: heroImageSrc,
 });
 

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -1,66 +1,22 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-
 import AccordionSection from '@/components/AccordionSection.vue';
 import EventItem from '@/components/EventItem.vue';
 import LightboxOverlay from '@/components/LightboxOverlay.vue';
 import { useAccordion } from '@/composables/useAccordion';
 import { useLightboxWithSwipe } from '@/composables/useLightboxWithSwipe';
 import { usePageHead } from '@/composables/usePageHead';
-import { liveData, liveYears } from '@/data/live';
-import { siteConfig } from '@/data/navigation';
-import type { LiveData } from '@/types';
+import { liveYears, sortedLiveData } from '@/data/live';
+import { pageMeta } from '@/data/pageMeta';
 import { updateHash } from '@/utils/navigation';
-import { createItemListSchema, createMusicEventSchema } from '@/utils/schemaHelpers';
-
-// Sort events within each year by date (most recent first)
-// ISO dates can be compared as strings: '2022-07-02' > '2022-03-05'
-const sortedLiveData = computed<LiveData>(() => {
-  const sorted: LiveData = {};
-  for (const year in liveData) {
-    const yearData = liveData[year];
-    if (yearData) {
-      sorted[year] = {
-        ...yearData,
-        items: [...(yearData.items || [])].sort((a, b) => {
-          const dateA = a.date || '';
-          const dateB = b.date || '';
-          return dateB.localeCompare(dateA); // Descending
-        }),
-      };
-    }
-  }
-  return sorted;
-});
-
-const eventSchemas = computed(() =>
-  liveYears.flatMap(year => {
-    const yearData = sortedLiveData.value[year];
-    return (yearData?.items ?? []).map(event =>
-      createMusicEventSchema(event, siteConfig.author.name, `${year}-01-01`),
-    );
-  }),
-);
-
-const eventsSchema = computed(() =>
-  createItemListSchema(
-    eventSchemas.value,
-    `${siteConfig.author.name} Live Performances`,
-    'Live performance history from 2005 to present',
-  ),
-);
+import { createLiveEventsSchema } from '@/utils/pageSchemas';
 
 usePageHead({
-  title: 'Live',
-  description: 'Live performance history of Jerome Faria from 2005 to present, including festivals, concerts, and collaborations.',
-  schema: eventsSchema.value,
+  ...pageMeta.live,
+  schema: createLiveEventsSchema(),
 });
 
 const findYearForEvent = (eventId: string): string | null =>
-  liveYears.find(year => {
-    const yearData = sortedLiveData.value[year];
-    return yearData?.items?.some(e => e.id === eventId);
-  }) ?? null;
+  liveYears.find(year => sortedLiveData[year]?.items?.some(e => e.id === eventId)) ?? null;
 
 const { openSection, handleToggle } = useAccordion(liveYears[0] ?? '', liveYears, findYearForEvent);
 const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, goToNext, goToPrev, handleTouchStart, handleTouchEnd } = useLightboxWithSwipe();

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import { useTemplateRef } from 'vue';
+
 import AccordionSection from '@/components/AccordionSection.vue';
 import EventItem from '@/components/EventItem.vue';
-import LightboxOverlay from '@/components/LightboxOverlay.vue';
+import LightboxHost from '@/components/LightboxHost.vue';
 import { useAccordion } from '@/composables/useAccordion';
-import { useLightboxWithSwipe } from '@/composables/useLightboxWithSwipe';
 import { usePageHead } from '@/composables/usePageHead';
 import { liveYears, sortedLiveData } from '@/data/live';
 import { pageMeta } from '@/data/pageMeta';
@@ -19,7 +20,7 @@ const findYearForEvent = (eventId: string): string | null =>
   liveYears.find(year => sortedLiveData[year]?.items?.some(e => e.id === eventId)) ?? null;
 
 const { openSection, handleToggle } = useAccordion(liveYears[0] ?? '', liveYears, findYearForEvent);
-const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, goToNext, goToPrev, handleTouchStart, handleTouchEnd } = useLightboxWithSwipe();
+const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 </script>
 
 <template>
@@ -44,23 +45,11 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
           :key="event.id"
           :event="event"
           @update-hash="updateHash"
-          @open-lightbox="openLightbox"
+          @open-lightbox="lightbox?.openLightbox"
         />
       </AccordionSection>
     </article>
 
-    <!-- Lightbox overlay -->
-    <LightboxOverlay
-      v-if="currentItem"
-      :is-open="isOpen"
-      :current-item="currentItem"
-      :current-index="currentIndex"
-      :total-items="items.length"
-      @close="closeLightbox"
-      @prev="goToPrev"
-      @next="goToNext"
-      @touchstart="handleTouchStart"
-      @touchend="handleTouchEnd"
-    />
+    <LightboxHost ref="lightbox" />
   </div>
 </template>

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
 import { useHashScroll } from '@/composables/useHashScroll';
 import { usePageHead } from '@/composables/usePageHead';
+import { pageMeta } from '@/data/pageMeta';
 import { pressQuotes } from '@/data/press';
 
-usePageHead({
-  title: 'Press',
-  description: 'Press coverage and reviews of Jerome Faria\'s work from The Quietus, Bodyspace, Indie Rock Mag, and more.',
-});
+usePageHead(pageMeta.press);
 
 const scrollToHash = (hash: string) => {
   const element = document.getElementById(hash.replace('#', ''));

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import { useTemplateRef } from 'vue';
+
 import AccordionSection from '@/components/AccordionSection.vue';
-import LightboxOverlay from '@/components/LightboxOverlay.vue';
+import LightboxHost from '@/components/LightboxHost.vue';
 import ReleaseItem from '@/components/ReleaseItem.vue';
 import { useAccordion } from '@/composables/useAccordion';
-import { useLightboxWithSwipe } from '@/composables/useLightboxWithSwipe';
 import { usePageHead } from '@/composables/usePageHead';
 import { pageMeta } from '@/data/pageMeta';
 import { worksData, worksSections } from '@/data/works';
@@ -22,7 +23,7 @@ const findSectionForRelease = (releaseId: string): string | null =>
   }) ?? null;
 
 const { openSection, handleToggle } = useAccordion('solo', worksSections, findSectionForRelease);
-const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, goToNext, goToPrev, handleTouchStart, handleTouchEnd } = useLightboxWithSwipe();
+const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 </script>
 
 <template>
@@ -48,23 +49,11 @@ const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, g
           :release="release"
           :text-only="!('coverImage' in release && release.coverImage)"
           @update-hash="updateHash"
-          @open-lightbox="openLightbox"
+          @open-lightbox="lightbox?.openLightbox"
         />
       </AccordionSection>
     </article>
 
-    <!-- Lightbox overlay -->
-    <LightboxOverlay
-      v-if="currentItem"
-      :is-open="isOpen"
-      :current-item="currentItem"
-      :current-index="currentIndex"
-      :total-items="items.length"
-      @close="closeLightbox"
-      @prev="goToPrev"
-      @next="goToNext"
-      @touchstart="handleTouchStart"
-      @touchend="handleTouchEnd"
-    />
+    <LightboxHost ref="lightbox" />
   </div>
 </template>

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -5,74 +5,14 @@ import ReleaseItem from '@/components/ReleaseItem.vue';
 import { useAccordion } from '@/composables/useAccordion';
 import { useLightboxWithSwipe } from '@/composables/useLightboxWithSwipe';
 import { usePageHead } from '@/composables/usePageHead';
-import { siteConfig } from '@/data/navigation';
+import { pageMeta } from '@/data/pageMeta';
 import { worksData, worksSections } from '@/data/works';
-import type { BandcampRelease, ExternalRelease } from '@/types';
-import { extractYear } from '@/utils/formatters';
 import { updateHash } from '@/utils/navigation';
-import { createMusicAlbumSchema } from '@/utils/schemaHelpers';
-
-const soloSection = worksData['solo'];
-const albumSchemas = soloSection
-  ? soloSection.items
-    .filter((r): r is BandcampRelease | ExternalRelease => {
-      return (
-        ('bandcampId' in r && r.bandcampId !== undefined) ||
-          ('bandcampUrl' in r && r.bandcampUrl !== undefined)
-      );
-    })
-    .map(release => {
-      const datePublished = extractYear(release.meta ?? null);
-      const releaseWithDate = { ...release, ...(datePublished ? { datePublished } : {}) };
-      return createMusicAlbumSchema(
-        releaseWithDate,
-        siteConfig.author.name,
-        siteConfig.url,
-      );
-    })
-  : [];
-
-const bookSchema = {
-  '@type': 'Book',
-  name: 'Glitch: Designing Imperfection',
-  image: `${siteConfig.url}/images/glitch.jpg`,
-  url: 'https://www.amazon.com/Glitch-Designing-Imperfection-Iman-Moradi/dp/0979966663',
-  datePublished: '2009',
-  isbn: '978-0-9799666-6-8',
-  publisher: {
-    '@type': 'Organization',
-    name: 'Mark Batty Publisher',
-  },
-  editor: [
-    { '@type': 'Person', name: 'Iman Moradi' },
-    { '@type': 'Person', name: 'Ant Scott' },
-    { '@type': 'Person', name: 'Joe Gilmore' },
-    { '@type': 'Person', name: 'Christopher Murphy' },
-  ],
-  contributor: {
-    '@type': 'Person',
-    name: siteConfig.author.name,
-  },
-};
-
-const creativeWorkSchema = {
-  '@context': 'https://schema.org',
-  '@graph': [
-    {
-      '@type': 'MusicGroup',
-      name: siteConfig.author.name,
-      url: siteConfig.url,
-      genre: ['Electronic', 'Experimental', 'Ambient'],
-      album: albumSchemas,
-    },
-    bookSchema,
-  ],
-};
+import { createWorksPageSchema } from '@/utils/pageSchemas';
 
 usePageHead({
-  title: 'Works',
-  description: 'Discography, film scores, and works by Jerome Faria including solo releases, collaborations, and curatorial projects.',
-  schema: creativeWorkSchema,
+  ...pageMeta.works,
+  schema: createWorksPageSchema(),
 });
 
 const findSectionForRelease = (releaseId: string): string | null =>


### PR DESCRIPTION
## Description

Refactors the page-head / structured-data layer and de-duplicates the lightbox wiring. Two logical commits, no change to rendered content (JSON-LD and meta verified byte-for-byte in the SSG output), plus one outward improvement: every page now ships a large social-share card instead of only the homepage.

## Changes

**1 — Extract page schema builders & centralize page-head metadata**
- New `src/utils/pageSchemas.ts`: per-page JSON-LD builders (`createPersonSchema`, `createContactPageSchema`, `createWorksPageSchema`, `createLiveEventsSchema`) composing the existing `schemaHelpers` primitives; supporting `schema.org` interfaces added to `src/types/schema.ts`. The hardcoded Glitch-book literal moves out of `WorksView`.
- New `src/data/pageMeta.ts`: single source for each page's title/description (homepage derives from `siteConfig`). All six views now source base meta from it.
- `usePageHead` always emits `og:image` + a `summary_large_image` card (dropped the per-page `includeImage` flag); the now-redundant social-meta fallbacks are removed from `index.html`, so `usePageHead` is the single source of description / Open Graph / Twitter / canonical.
- Live-event date sort lifted from `LiveView` into `data/live.ts` (`sortedLiveData`) so the view and `createLiveEventsSchema` share one sorted source and the builder is argument-free like its siblings.

**2 — Extract a `LightboxHost` component**
- `AboutView`, `WorksView`, `LiveView` each destructured the 10-member `useLightboxWithSwipe` API and rendered an identical `LightboxOverlay` block. That now lives in `src/components/LightboxHost.vue`, which owns the composable and exposes `openLightbox`; views render `<LightboxHost ref="lightbox" />` and trigger it via the template ref.

## Refactor assessment

- **Bundled (this PR):** schema-builder extraction, `pageMeta` centralization, social-meta single-sourcing, `LightboxHost`, live-sort → data layer. These co-occur in the same view files and form one coherent page-head/media cleanup.
- **Deferred (follow-ups, parked):** a broader extraction audit surfaced `lightboxAdapters` (image/video → `LightboxItem` converters, 3×), a `toWebp` path helper (fixes an anchored-vs-unanchored inconsistency), `PageShell`, `ExternalLink`, scroll/history-state consolidation, `useContactForm` field-config, `ReleaseCover`, and dead-code removal (`formatSchemaDate`, unused `isImageSection`). Kept out to keep this PR scoped.

## Testing

No visible UI change; verification is structured-data / meta / lightbox behavior.

- **Unit/integration:** `npm run test:coverage` — 343 tests pass. New: `pageSchemas` builders (incl. a mocked-data test for the `datePublished`-omit branch), `LightboxHost` (open/close via exposed `openLightbox`), updated `usePageHead` social-image tests.
- **E2E:** `e2e/lightbox.spec.ts` — 12 tests × Chromium/Firefox/WebKit all green, exercising the real child-emit → `lightbox?.openLightbox` path through the template ref.
- **Rendered output (production build):** confirmed in `dist/` that the JSON-LD is unchanged — Person w/ `jobTitle`, MusicGroup + Book `@graph`, ContactPage, and the 32-event live `ItemList` (same newest-first order). Every page carries `og:image` + `summary_large_image` exactly once, with a correct per-route `canonical` (e.g. `/about`, which the old hardcoded fallback never was).

To verify locally: `npm run build` then check `dist/works.html` / `dist/about.html` for the `application/ld+json` script and the per-route `<link rel="canonical">`.

## Deferred review notes

- `pageSchemas.ts` (branch 83%) and `data/live.ts` retain a few uncovered branches: optional-chaining guards mandated by `noUncheckedIndexedAccess` but unreachable with the static content (removing them would require a non-null assertion, which is disallowed), and the `(b.date ?? '')` sort fallback (every event has a date). The one branch representing real logic — `datePublished` omission — is covered via an isolated mocked-data test. Global branch coverage 89.5% (floor 85%).
