### PR TITLE
Extract toWebp helper and lightbox-item adapters

### DIFF
--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import type { LightboxItem, LiveEvent, LiveImage, LiveVideo } from '@/types';
+import type { LightboxItem, LiveEvent } from '@/types';
 import { formatEventDate } from '@/utils/dateFormatter';
 import { stripHtml } from '@/utils/formatters';
+import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
 import IconArrow from './IconArrow.vue';
 
@@ -33,31 +34,6 @@ const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? '
 // City + country suffix for the venue line (either may be absent for a TBC venue).
 const venueLocation = computed(() =>
   [props.event.venue.city, props.event.venue.country].filter(Boolean).join(', '));
-
-const convertImagesToLightbox = (images: LiveImage[]): LightboxItem[] => {
-  return images.map(img => {
-    const lightboxImage: LightboxItem = {
-      type: 'image' as const,
-      src: img.src,
-      alt: img.alt,
-    };
-    if (img.position) lightboxImage.position = img.position;
-    if (img.scale) lightboxImage.scale = img.scale;
-    if (img.rotate) lightboxImage.rotate = img.rotate;
-    if (img.photographer) lightboxImage.photographer = img.photographer;
-    return lightboxImage;
-  });
-};
-
-const convertVideosToLightbox = (videos: LiveVideo[]): LightboxItem[] => {
-  return videos.map(vid => ({
-    type: 'video' as const,
-    url: vid.url,
-    title: vid.title,
-    platform: vid.platform,
-    ...(vid.author ? { author: vid.author } : {}),
-  }));
-};
 </script>
 
 <template>
@@ -111,7 +87,7 @@ const convertVideosToLightbox = (videos: LiveVideo[]): LightboxItem[] => {
         <button
           v-if="event.images?.length"
           class="link-discrete"
-          @click="emit('open-lightbox', convertImagesToLightbox(event.images), 0)"
+          @click="emit('open-lightbox', event.images.map(toLightboxImage), 0)"
         >
           View {{ event.images.length === 1 ? 'photo' : 'photos' }}
         </button>
@@ -119,7 +95,7 @@ const convertVideosToLightbox = (videos: LiveVideo[]): LightboxItem[] => {
         <button
           v-if="event.videos?.length"
           class="link-discrete"
-          @click="emit('open-lightbox', convertVideosToLightbox(event.videos), 0)"
+          @click="emit('open-lightbox', event.videos.map(toLightboxVideo), 0)"
         >
           View {{ event.videos.length === 1 ? 'video' : 'videos' }}
         </button>

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onMounted, ref } from 'vue';
 
 import type { LightboxItem } from '@/types';
 import { isLightboxImage, isLightboxVideo } from '@/types';
+import { toWebp } from '@/utils/responsiveImage';
 
 import IconArrow from './IconArrow.vue';
 
@@ -122,7 +123,7 @@ onMounted(async () => {
       <!-- Image -->
       <picture v-else-if="isImage && currentItem && isLightboxImage(currentItem)">
         <source
-          :srcset="currentItem.src.replace('.jpg', '.webp')"
+          :srcset="toWebp(currentItem.src)"
           type="image/webp"
         >
         <img

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue';
 import { useAccordionVisibility } from '@/composables/useAccordionContext';
 import { useImageLoader } from '@/composables/useImageLoader';
 import type { LightboxItem, Release } from '@/types';
+import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 import { responsiveSrcset } from '@/utils/responsiveImage';
 
 import BandcampPlayer from './BandcampPlayer.vue';
@@ -54,18 +55,16 @@ const hasCoverImage = computed(() => 'coverImage' in props.release && props.rele
 const hasDescription = computed(() => 'description' in props.release && props.release.description);
 const hasTracklist = computed(() => 'tracklist' in props.release && props.release.tracklist);
 const hasCredits = computed(() => 'credits' in props.release && props.release.credits);
-const hasImages = computed(() => 'images' in props.release && props.release.images);
+// A release's images and videos, mapped to lightbox items.
+const imageLightboxItems = computed<LightboxItem[]>(() => {
+  if (!('images' in props.release) || !props.release.images) return [];
+  return props.release.images.map(toLightboxImage);
+});
+const hasImages = computed(() => imageLightboxItems.value.length > 0);
 
-// A release's videos, mapped to lightbox items.
 const videoLightboxItems = computed<LightboxItem[]>(() => {
   if (!('videos' in props.release) || !props.release.videos) return [];
-  return props.release.videos.map(video => ({
-    type: 'video' as const,
-    url: video.url,
-    title: video.title,
-    platform: video.platform,
-    ...(video.author ? { author: video.author } : {}),
-  }));
+  return props.release.videos.map(toLightboxVideo);
 });
 const hasVideos = computed(() => videoLightboxItems.value.length > 0);
 
@@ -190,22 +189,17 @@ const isBandcampLink = computed(() => {
         v-html="release.credits"
       />
       <p
-        v-if="(hasImages && 'images' in release && release.images.length) || hasVideos"
+        v-if="hasImages || hasVideos"
         class="release-gallery-link"
       >
         <button
-          v-if="hasImages && 'images' in release && release.images.length"
+          v-if="hasImages"
           class="link-discrete"
-          @click="emit('open-lightbox', release.images.map(img => ({
-            type: 'image' as const,
-            src: img.src,
-            alt: img.alt,
-            ...(img.photographer ? { photographer: img.photographer } : {}),
-          })), 0)"
+          @click="emit('open-lightbox', imageLightboxItems, 0)"
         >
           View gallery
         </button>
-        <span v-if="hasImages && 'images' in release && release.images.length && hasVideos"> | </span>
+        <span v-if="hasImages && hasVideos"> | </span>
         <button
           v-if="hasVideos"
           class="link-discrete"

--- a/src/composables/useImageLoader.ts
+++ b/src/composables/useImageLoader.ts
@@ -1,6 +1,8 @@
 import type { ComponentPublicInstance, ComputedRef, Ref } from 'vue';
 import { computed, nextTick, onMounted, ref } from 'vue';
 
+import { toWebp } from '@/utils/responsiveImage';
+
 interface UseImageLoaderReturn {
   imageRef: Ref<HTMLImageElement | null>;
   setImageRef: (el: Element | ComponentPublicInstance | null) => void;
@@ -21,7 +23,7 @@ export const useImageLoader = (src: string): UseImageLoaderReturn => {
   const imageError = ref(false);
   const imageLoaded = ref(false);
 
-  const webpSrc = computed(() => src?.replace(/\.jpg$/, '.webp'));
+  const webpSrc = computed(() => (src ? toWebp(src) : src));
 
   // Callback ref: bound via `:ref` in templates so the composable owns the
   // <img> element. Needed for the already-complete fast-path below to work

--- a/src/utils/lightboxAdapters.test.ts
+++ b/src/utils/lightboxAdapters.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { toLightboxImage, toLightboxVideo } from './lightboxAdapters';
+
+describe('toLightboxImage', () => {
+  it('maps required fields and omits absent optionals', () => {
+    expect(toLightboxImage({ src: '/a.jpg', alt: 'A' })).toEqual({ type: 'image', src: '/a.jpg', alt: 'A' });
+  });
+
+  it('copies optional layout and credit fields when present', () => {
+    const photographer = { name: 'Jane', url: 'https://example.com/jane' };
+
+    expect(
+      toLightboxImage({ src: '/a.jpg', alt: 'A', position: 'top', scale: 1.2, rotate: 3, photographer }),
+    ).toEqual({ type: 'image', src: '/a.jpg', alt: 'A', position: 'top', scale: 1.2, rotate: 3, photographer });
+  });
+});
+
+describe('toLightboxVideo', () => {
+  it('maps required fields and omits an absent author', () => {
+    expect(toLightboxVideo({ url: 'https://v', title: 'V', platform: 'youtube' })).toEqual({
+      type: 'video',
+      url: 'https://v',
+      title: 'V',
+      platform: 'youtube',
+    });
+  });
+
+  it('copies the author credit when present', () => {
+    const author = { name: 'Studio', url: 'https://example.com/studio' };
+
+    expect(toLightboxVideo({ url: 'https://v', title: 'V', platform: 'vimeo', author })).toEqual({
+      type: 'video',
+      url: 'https://v',
+      title: 'V',
+      platform: 'vimeo',
+      author,
+    });
+  });
+});

--- a/src/utils/lightboxAdapters.ts
+++ b/src/utils/lightboxAdapters.ts
@@ -1,0 +1,36 @@
+import type { LightboxImage, LightboxVideo, Photographer } from '@/types/lightbox';
+
+// Superset of the fields the app's image/video data carry (About/Live/Works),
+// so a single adapter serves every call site.
+interface LightboxImageSource {
+  src: string;
+  alt: string;
+  position?: string;
+  scale?: number;
+  rotate?: number;
+  photographer?: Photographer;
+}
+
+interface LightboxVideoSource {
+  url: string;
+  title: string;
+  platform: 'youtube' | 'vimeo';
+  author?: Photographer;
+}
+
+/** Map a domain image to a lightbox image item, copying optional fields when present. */
+export const toLightboxImage = (image: LightboxImageSource): LightboxImage => {
+  const item: LightboxImage = { type: 'image', src: image.src, alt: image.alt };
+  if (image.position) item.position = image.position;
+  if (image.scale) item.scale = image.scale;
+  if (image.rotate) item.rotate = image.rotate;
+  if (image.photographer) item.photographer = image.photographer;
+  return item;
+};
+
+/** Map a domain video to a lightbox video item. */
+export const toLightboxVideo = (video: LightboxVideoSource): LightboxVideo => {
+  const item: LightboxVideo = { type: 'video', url: video.url, title: video.title, platform: video.platform };
+  if (video.author) item.author = video.author;
+  return item;
+};

--- a/src/utils/responsiveImage.test.ts
+++ b/src/utils/responsiveImage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { toWebp } from './responsiveImage';
+
+describe('toWebp', () => {
+  it('swaps a trailing .jpg for .webp', () => {
+    expect(toWebp('/images/live/eme-2008-001.jpg')).toBe('/images/live/eme-2008-001.webp');
+  });
+
+  it('replaces only the extension, not a .jpg earlier in the path', () => {
+    expect(toWebp('/images/.jpg-archive/photo.jpg')).toBe('/images/.jpg-archive/photo.webp');
+  });
+
+  it('leaves non-jpg sources unchanged', () => {
+    expect(toWebp('/images/logo.png')).toBe('/images/logo.png');
+    expect(toWebp('/images/hero.webp')).toBe('/images/hero.webp');
+  });
+});

--- a/src/utils/responsiveImage.ts
+++ b/src/utils/responsiveImage.ts
@@ -9,6 +9,9 @@ const RESPONSIVE_DIR = '/images/responsive';
 const baseName = (imagePath: string): string =>
   imagePath.replace(/^.*\//, '').replace(/\.[a-z]+$/i, '');
 
+/** Swap a `.jpg` source for its `.webp` sibling, anchored to the extension. */
+export const toWebp = (imagePath: string): string => imagePath.replace(/\.jpg$/, '.webp');
+
 /**
  * Builds a WebP `srcset` from an image's pre-generated responsive widths, or
  * null when it has none — in which case callers fall back to the full-resolution

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -7,7 +7,7 @@ import { aboutSections } from '@/data/about';
 import { pageMeta } from '@/data/pageMeta';
 import type { AboutImage, LightboxImage } from '@/types';
 import { getImageStyles } from '@/utils/imageStyles';
-import { responsiveSrcset } from '@/utils/responsiveImage';
+import { responsiveSrcset, toWebp } from '@/utils/responsiveImage';
 
 usePageHead(pageMeta.about);
 
@@ -96,7 +96,7 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
                 type="image/webp"
               >
               <source
-                :srcset="image.src.replace('.jpg', '.webp')"
+                :srcset="toWebp(image.src)"
                 type="image/webp"
               >
               <img

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -5,31 +5,19 @@ import LightboxHost from '@/components/LightboxHost.vue';
 import { usePageHead } from '@/composables/usePageHead';
 import { aboutSections } from '@/data/about';
 import { pageMeta } from '@/data/pageMeta';
-import type { AboutImage, LightboxImage } from '@/types';
 import { getImageStyles } from '@/utils/imageStyles';
+import { toLightboxImage } from '@/utils/lightboxAdapters';
 import { responsiveSrcset, toWebp } from '@/utils/responsiveImage';
 
 usePageHead(pageMeta.about);
 
 const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 
-const convertToLightboxImage = (image: AboutImage): LightboxImage => {
-  const lightboxImage: LightboxImage = {
-    type: 'image' as const,
-    src: image.src,
-    alt: image.alt,
-  };
-  if (image.photographer) {
-    lightboxImage.photographer = image.photographer;
-  }
-  return lightboxImage;
-};
-
 // All image-group images, flattened to lightbox items.
 const allImages = computed(() => {
   return aboutSections
     .filter(section => section.type === 'image-group' && 'images' in section)
-    .flatMap(section => section.images.map(convertToLightboxImage));
+    .flatMap(section => section.images.map(toLightboxImage));
 });
 
 // Pre-compute section starting indices for O(1) lookup


### PR DESCRIPTION
## Description

First of the parked-audit follow-ups: two small media-utility extractions. No visible change; behavior verified by unit tests and the existing lightbox E2E suite.

## Changes

**1 — `toWebp` helper**
The `.jpg`→`.webp` swap was open-coded in three places with two different semantics — `useImageLoader` anchored on `/\.jpg$/`, while `LightboxOverlay` and `AboutView` used an unanchored `.replace('.jpg', …)` that would mis-replace a `.jpg` occurring earlier in a path. Centralized as `toWebp()` in `responsiveImage.ts`; all three callers route through it (also normalizing the latent inconsistency).

**2 — Lightbox-item adapters**
The domain-image → `LightboxImage` builder was hand-rolled in three places (`AboutView`, `EventItem`, `ReleaseItem`) and had drifted in field coverage; the video builder was duplicated in two. Centralized in `src/utils/lightboxAdapters.ts` (`toLightboxImage` / `toLightboxVideo`, copying the superset of optional fields). `ReleaseItem`'s inline template `.map()` becomes an `imageLightboxItems` computed mirroring `videoLightboxItems`, which also collapses the gallery-button guards.

## Refactor assessment
- **Bundled:** both are media-path/conversion utilities, compose naturally, and are pure functions — low risk, high dedup value.
- **Behavior note:** `AboutView` lightbox images now carry `position/scale/rotate` (the superset adapter copies them), where the old local converter dropped them. `LightboxOverlay` doesn't read those fields, so there is no rendering change — just consistency across call sites.
- **Deferred:** remaining audit items (`PageShell`, `ExternalLink`, scroll/history consolidation, `useContactForm` config, `ReleaseCover`, dead-code removals) stay as separate follow-ups.

## Testing
- `npm run test:coverage` — 350 tests pass. New: `responsiveImage.test.ts` (incl. an anchored-vs-mid-path case pinning the bug fix) and `lightboxAdapters.test.ts` (present/absent optionals on both adapters).
- `e2e/lightbox.spec.ts` exercises the gallery/video open paths through the refactored `open-lightbox` emissions.
- Global branch coverage 90.59% (floor 85%); `EventItem`/`ReleaseItem` branch coverage improved.
- `npm run build` succeeds; Works/Live pages still render the View gallery/photos/videos controls.
