### PR TITLE
Extract shared PageShell and ExternalLink components

### DIFF
--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -5,6 +5,7 @@ import type { LightboxItem, LiveEvent } from '@/types';
 import { formatEventDate, stripHtml } from '@/utils/formatters';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
+import ExternalLink from './ExternalLink.vue';
 import IconArrow from './IconArrow.vue';
 
 const props = defineProps<{
@@ -48,14 +49,12 @@ const venueLocation = computed(() =>
             :href="`#${event.id}`"
             @click.prevent="emit('update-hash', event.id)"
           >{{ titleText }}</a>
-          <a
+          <ExternalLink
             v-if="titleHref && titleHrefIsExternal"
             class="event-title-ref"
             :href="titleHref"
-            target="_blank"
-            rel="noopener noreferrer"
             :aria-label="`${titleText} website (opens in a new tab)`"
-          ><IconArrow direction="up-right" /></a>
+          ><IconArrow direction="up-right" /></ExternalLink>
           <RouterLink
             v-else-if="titleHref"
             class="event-title-ref"

--- a/src/components/ExternalLink.test.ts
+++ b/src/components/ExternalLink.test.ts
@@ -1,0 +1,32 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import ExternalLink from './ExternalLink.vue';
+
+const mountLink = (props: Record<string, unknown>, slot = 'Visit') =>
+  mount(ExternalLink, { props: { href: 'https://example.com', ...props }, slots: { default: slot } });
+
+describe('ExternalLink', () => {
+  it('opens in a new tab with a safe rel', () => {
+    const anchor = mountLink({}).get('a');
+
+    expect(anchor.attributes('href')).toBe('https://example.com');
+    expect(anchor.attributes('target')).toBe('_blank');
+    expect(anchor.attributes('rel')).toBe('noopener noreferrer');
+  });
+
+  it('appends a visually-hidden new-tab cue by default', () => {
+    const wrapper = mountLink({});
+
+    expect(wrapper.get('a').text()).toContain('Visit');
+    expect(wrapper.get('.visually-hidden').text()).toBe('(opens in a new tab)');
+    expect(wrapper.get('a').attributes('aria-label')).toBeUndefined();
+  });
+
+  it('uses aria-label and omits the visible cue when one is given', () => {
+    const wrapper = mountLink({ ariaLabel: 'Jane on Bandcamp (opens in a new tab)' }, 'Bandcamp');
+
+    expect(wrapper.get('a').attributes('aria-label')).toBe('Jane on Bandcamp (opens in a new tab)');
+    expect(wrapper.find('.visually-hidden').exists()).toBe(false);
+  });
+});

--- a/src/components/ExternalLink.vue
+++ b/src/components/ExternalLink.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+// A link that opens in a new tab with safe rel. By default it appends a
+// visually-hidden "(opens in a new tab)" cue; pass `ariaLabel` when the caller
+// already conveys that in a full accessible name (avoids a double announcement).
+defineProps<{
+  href: string;
+  ariaLabel?: string;
+}>();
+</script>
+
+<template>
+  <a
+    :href="href"
+    target="_blank"
+    rel="noopener noreferrer"
+    :aria-label="ariaLabel"
+  >
+    <slot />
+    <span
+      v-if="!ariaLabel"
+      class="visually-hidden"
+    > (opens in a new tab)</span>
+  </a>
+</template>

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -5,6 +5,7 @@ import type { LightboxItem } from '@/types';
 import { isLightboxImage, isLightboxVideo } from '@/types';
 import { toWebp } from '@/utils/responsiveImage';
 
+import ExternalLink from './ExternalLink.vue';
 import IconArrow from './IconArrow.vue';
 
 const props = defineProps<{
@@ -149,12 +150,12 @@ onMounted(async () => {
           v-if="credit"
           class="lightbox__credit"
         >
-          {{ credit.prefix }} <a
+          {{ credit.prefix }} <ExternalLink
             v-if="credit.url"
             :href="credit.url"
-            target="_blank"
-            rel="noopener noreferrer"
-          >{{ credit.name }}<span class="visually-hidden"> (opens in a new tab)</span></a>
+          >
+            {{ credit.name }}
+          </ExternalLink>
           <span v-else>{{ credit.name }}</span>
         </div>
 

--- a/src/components/PageShell.vue
+++ b/src/components/PageShell.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+// The shared page frame: the semantic <article> and its visually-hidden
+// heading. Callers keep their own .container-wide wrapper and any siblings
+// (e.g. a lightbox host) so nothing needs to move into a slot.
+defineProps<{
+  dataPage: string;
+  title: string;
+}>();
+</script>
+
+<template>
+  <article
+    class="page"
+    :data-page="dataPage"
+  >
+    <h1 class="visually-hidden">
+      {{ title }}
+    </h1>
+    <slot />
+  </article>
+</template>

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -8,6 +8,7 @@ import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 import { responsiveSrcset } from '@/utils/responsiveImage';
 
 import BandcampPlayer from './BandcampPlayer.vue';
+import ExternalLink from './ExternalLink.vue';
 
 const props = withDefaults(defineProps<{
   release: Release;
@@ -91,11 +92,9 @@ const isBandcampLink = computed(() => {
     />
 
     <!-- External Link Cover -->
-    <a
+    <ExternalLink
       v-else-if="coverVisible && hasExternalUrl && hasCoverImage && !imageError && 'externalUrl' in release"
       :href="release.externalUrl"
-      target="_blank"
-      rel="noopener noreferrer"
       class="release-cover"
       :class="{ 'release-cover--bandcamp': isBandcampLink }"
     >
@@ -122,8 +121,7 @@ const isBandcampLink = computed(() => {
           @error="handleImageError"
         >
       </picture>
-      <span class="visually-hidden"> (opens in a new tab)</span>
-    </a>
+    </ExternalLink>
 
     <!-- Static Cover (no link) -->
     <div

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -3,6 +3,8 @@ import { RouterLink } from 'vue-router';
 
 import { navigation, siteConfig, social } from '@/data/navigation';
 
+import ExternalLink from './ExternalLink.vue';
+
 const currentYear = new Date().getFullYear();
 </script>
 
@@ -23,16 +25,14 @@ const currentYear = new Date().getFullYear();
           </RouterLink>
         </nav>
         <div class="social-links">
-          <a
+          <ExternalLink
             v-for="item in social"
             :key="item.name"
             :href="item.url"
-            target="_blank"
-            rel="noopener noreferrer"
             :aria-label="`${siteConfig.author.name} on ${item.name} (opens in a new tab)`"
           >
             {{ item.name }}
-          </a>
+          </ExternalLink>
         </div>
         <p class="footer__copyright">
           &copy; {{ currentYear }} <RouterLink to="/contact">

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -2,6 +2,7 @@
 import { computed, useTemplateRef } from 'vue';
 
 import LightboxHost from '@/components/LightboxHost.vue';
+import PageShell from '@/components/PageShell.vue';
 import { usePageHead } from '@/composables/usePageHead';
 import { aboutSections } from '@/data/about';
 import { pageMeta } from '@/data/pageMeta';
@@ -41,13 +42,10 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
 
 <template>
   <div class="container-wide">
-    <article
-      class="page"
+    <PageShell
       data-page="about"
+      title="About"
     >
-      <h1 class="visually-hidden">
-        About
-      </h1>
       <template
         v-for="(section, sectionIndex) in aboutSections"
         :key="section.id"
@@ -112,7 +110,7 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
           >
         </figure>
       </template>
-    </article>
+    </PageShell>
 
     <LightboxHost ref="lightbox" />
   </div>

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import PageShell from '@/components/PageShell.vue';
 import { useContactForm } from '@/composables/useContactForm';
 import { usePageHead } from '@/composables/usePageHead';
 import { contactContent } from '@/data/contact';
@@ -17,13 +18,10 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, errors, 
 
 <template>
   <div class="container-wide">
-    <article
-      class="page"
+    <PageShell
       data-page="contact"
+      title="Contact"
     >
-      <h1 class="visually-hidden">
-        Contact
-      </h1>
       <!-- Introduction -->
       <div
         v-show="!showSuccess"
@@ -201,6 +199,6 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, errors, 
           {{ isSubmitting ? 'Sending...' : contactContent.form.submitText }}
         </button>
       </form>
-    </article>
+    </PageShell>
   </div>
 </template>

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -4,6 +4,7 @@ import { useTemplateRef } from 'vue';
 import AccordionSection from '@/components/AccordionSection.vue';
 import EventItem from '@/components/EventItem.vue';
 import LightboxHost from '@/components/LightboxHost.vue';
+import PageShell from '@/components/PageShell.vue';
 import { useAccordion } from '@/composables/useAccordion';
 import { usePageHead } from '@/composables/usePageHead';
 import { liveYears, sortedLiveData } from '@/data/live';
@@ -25,13 +26,10 @@ const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 
 <template>
   <div class="container-wide">
-    <article
-      class="page"
+    <PageShell
       data-page="live"
+      title="Live"
     >
-      <h1 class="visually-hidden">
-        Live
-      </h1>
       <AccordionSection
         v-for="year in liveYears"
         :id="year"
@@ -48,7 +46,7 @@ const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
           @open-lightbox="lightbox?.openLightbox"
         />
       </AccordionSection>
-    </article>
+    </PageShell>
 
     <LightboxHost ref="lightbox" />
   </div>

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import PageShell from '@/components/PageShell.vue';
 import { useHashScroll } from '@/composables/useHashScroll';
 import { usePageHead } from '@/composables/usePageHead';
 import { pageMeta } from '@/data/pageMeta';
@@ -16,13 +17,10 @@ useHashScroll(scrollToHash);
 
 <template>
   <div class="container-wide">
-    <article
-      class="page"
+    <PageShell
       data-page="press"
+      title="Press"
     >
-      <h1 class="visually-hidden">
-        Press
-      </h1>
       <blockquote
         v-for="item in pressQuotes"
         :id="item.id"
@@ -39,6 +37,6 @@ useHashScroll(scrollToHash);
           <template v-else>{{ item.source }}</template>
         </strong>
       </blockquote>
-    </article>
+    </PageShell>
   </div>
 </template>

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ExternalLink from '@/components/ExternalLink.vue';
 import PageShell from '@/components/PageShell.vue';
 import { useHashScroll } from '@/composables/useHashScroll';
 import { usePageHead } from '@/composables/usePageHead';
@@ -28,12 +29,10 @@ useHashScroll(scrollToHash);
       >
         <p v-html="item.quote" />
         <strong>
-          <a
+          <ExternalLink
             v-if="item.url"
             :href="item.url"
-            target="_blank"
-            rel="noopener noreferrer"
-          >{{ item.source }}<span class="visually-hidden"> (opens in a new tab)</span></a>
+          >{{ item.source }}</ExternalLink>
           <template v-else>{{ item.source }}</template>
         </strong>
       </blockquote>

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -3,6 +3,7 @@ import { useTemplateRef } from 'vue';
 
 import AccordionSection from '@/components/AccordionSection.vue';
 import LightboxHost from '@/components/LightboxHost.vue';
+import PageShell from '@/components/PageShell.vue';
 import ReleaseItem from '@/components/ReleaseItem.vue';
 import { useAccordion } from '@/composables/useAccordion';
 import { usePageHead } from '@/composables/usePageHead';
@@ -28,13 +29,10 @@ const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 
 <template>
   <div class="container-wide">
-    <article
-      class="page"
+    <PageShell
       data-page="works"
+      title="Works"
     >
-      <h1 class="visually-hidden">
-        Works
-      </h1>
       <AccordionSection
         v-for="sectionKey in worksSections"
         :id="sectionKey"
@@ -52,7 +50,7 @@ const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
           @open-lightbox="lightbox?.openLightbox"
         />
       </AccordionSection>
-    </article>
+    </PageShell>
 
     <LightboxHost ref="lightbox" />
   </div>


### PR DESCRIPTION
## Description

Two shared-component extractions from the parked audit. No visible change; DOM and a11y preserved (verified by visual-regression + axe E2E).

## Changes

**1 — `PageShell`**
About/Works/Live/Press/Contact each repeated the same `<article class="page" data-page> + visually-hidden <h1>` frame. Extracted into `PageShell` (`data-page` + `title` props, default slot). Callers keep their own `.container-wide` wrapper and siblings (e.g. the lightbox host), so **content depth is unchanged and nothing re-indents** — the diff is the scaffold lines only.

**2 — `ExternalLink`**
`target="_blank" rel="noopener noreferrer"` + an "opens in a new tab" cue was repeated across five sites (SiteFooter, ReleaseItem, EventItem, LightboxOverlay, PressView) with inconsistent delivery — a visible `visually-hidden` suffix vs a custom `aria-label`. `ExternalLink` standardizes it: appends the visually-hidden suffix by default, or defers to a caller-supplied `aria-label` (the SiteFooter/EventItem variants) to avoid a double announcement. Fallthrough attrs (e.g. `ReleaseItem`'s `class="release-cover"`) land on the root `<a>`.

## Refactor assessment
- **Bundled:** both are pure view-layer component extractions with no behavior change.
- **a11y note:** output is preserved per site — visible-suffix links render the identical hidden cue from the component; aria-label links keep their exact label and omit the suffix.
- **Deferred:** remaining audit items (scroll/history consolidation, `useContactForm` config, `ReleaseCover`) continue as separate follow-ups.

## Testing
- `npm run test:coverage` — 340 tests pass. New: `ExternalLink.test.ts` (both variants: default cue vs aria-label).
- `e2e/accessibility.spec.ts` (axe) + `e2e/navigation.spec.ts` green on chromium locally; full matrix + Visual Regression run in CI.
- Type-check, lint, and production build clean.
