### PR TITLE
Extract scroll helpers and centralize hash-state/section lookup

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,6 +1,8 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, type Locator, type Page } from '@playwright/test';
 
+// Mirror of LAYOUT.BREAKPOINT_MD (src/utils/constants.ts) / $breakpoint-md
+// (src/styles/_variables.scss). e2e can't import from src, so keep in sync.
 export const MOBILE_BREAKPOINT = 768;
 export const MIN_TOUCH_TARGET_SIZE = 44;
 

--- a/src/components/AccordionSection.vue
+++ b/src/components/AccordionSection.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import { provideAccordionExpanded } from '@/composables/useAccordionContext';
-import { ID_PREFIX, LAYOUT, TIMING } from '@/utils/constants';
+import { ID_PREFIX, LAYOUT } from '@/utils/constants';
+import { afterAccordionAnimation, scrollToElement } from '@/utils/scroll';
 
 const props = withDefaults(defineProps<{
   title: string;
@@ -35,10 +36,7 @@ const getHeaderOffset = () => {
 
 const scrollToSection = () => {
   if (!sectionRef.value) return;
-
-  const rect = sectionRef.value.getBoundingClientRect();
-  const targetY = rect.top + window.scrollY - getHeaderOffset();
-  window.scrollTo({ top: targetY, behavior: 'instant' });
+  scrollToElement(sectionRef.value, { offset: getHeaderOffset(), behavior: 'instant' });
 };
 
 const toggle = () => {
@@ -47,11 +45,9 @@ const toggle = () => {
 
   if (!willExpand) return;
 
-  void nextTick(() => {
-    setTimeout(() => {
-      scrollToSection();
-      contentRef.value?.focus({ preventScroll: true });
-    }, TIMING.ACCORDION_ANIMATION);
+  afterAccordionAnimation(() => {
+    scrollToSection();
+    contentRef.value?.focus({ preventScroll: true });
   });
 };
 </script>

--- a/src/composables/useAccordion.ts
+++ b/src/composables/useAccordion.ts
@@ -1,7 +1,8 @@
 import type { Ref } from 'vue';
-import { nextTick, ref } from 'vue';
+import { ref } from 'vue';
 
-import { ID_PREFIX, TIMING } from '@/utils/constants';
+import { ID_PREFIX } from '@/utils/constants';
+import { afterAccordionAnimation, prefersReducedMotion, scrollToElement } from '@/utils/scroll';
 
 import { useHashScroll } from './useHashScroll';
 
@@ -24,17 +25,13 @@ export const useAccordion = (
 ): UseAccordionReturn => {
   const openSection = ref<string | null>(initialSection);
 
-  const scrollToElement = (id: string): void => {
-    void nextTick(() => {
-      setTimeout(() => {
-        const element = document.getElementById(id);
-        if (element) {
-          const scrollMargin = parseFloat(getComputedStyle(element).scrollMarginTop) || 0;
-          const targetY = element.getBoundingClientRect().top + window.scrollY - scrollMargin;
-          const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-          window.scrollTo({ top: targetY, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
-        }
-      }, TIMING.ACCORDION_ANIMATION);
+  const scrollToHashTarget = (id: string): void => {
+    afterAccordionAnimation(() => {
+      const element = document.getElementById(id);
+      if (!element) return;
+
+      const offset = parseFloat(getComputedStyle(element).scrollMarginTop) || 0;
+      scrollToElement(element, { offset, behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
     });
   };
 
@@ -45,7 +42,7 @@ export const useAccordion = (
 
     if (validSections.includes(id)) {
       openSection.value = id;
-      if (shouldScroll) scrollToElement(`${ID_PREFIX.TRIGGER}${id}`);
+      if (shouldScroll) scrollToHashTarget(`${ID_PREFIX.TRIGGER}${id}`);
       return;
     }
 
@@ -55,7 +52,7 @@ export const useAccordion = (
     if (!parentSection) return;
 
     openSection.value = parentSection;
-    if (shouldScroll) scrollToElement(id);
+    if (shouldScroll) scrollToHashTarget(id);
   };
 
   // Open (and scroll to) the hash target on load and on hash changes.

--- a/src/composables/useAccordion.ts
+++ b/src/composables/useAccordion.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue';
 import { ref } from 'vue';
 
 import { ID_PREFIX } from '@/utils/constants';
+import { clearHash, updateHash } from '@/utils/navigation';
 import { afterAccordionAnimation, prefersReducedMotion, scrollToElement } from '@/utils/scroll';
 
 import { useHashScroll } from './useHashScroll';
@@ -63,7 +64,7 @@ export const useAccordion = (
       openSection.value = sectionId;
       // Update URL hash when opening a section
       if (!isInitialLoad.value) {
-        window.history.replaceState(null, '', `#${ID_PREFIX.SECTION}${sectionId}`);
+        updateHash(`${ID_PREFIX.SECTION}${sectionId}`);
       }
       return;
     }
@@ -71,7 +72,7 @@ export const useAccordion = (
       openSection.value = null;
       // Clear hash when closing
       if (!isInitialLoad.value) {
-        window.history.replaceState(null, '', window.location.pathname);
+        clearHash();
       }
     }
   };

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { updateHash } from './navigation';
+import { clearHash, findSectionContainingId, updateHash } from './navigation';
 
 describe('updateHash', () => {
   afterEach(() => {
@@ -22,5 +22,39 @@ describe('updateHash', () => {
     updateHash('solo');
 
     expect(pushState).not.toHaveBeenCalled();
+  });
+});
+
+describe('clearHash', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('replaces the URL with the bare pathname', () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState').mockImplementation(() => undefined);
+
+    clearHash();
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', window.location.pathname);
+  });
+});
+
+describe('findSectionContainingId', () => {
+  const data = {
+    solo: { items: [{ id: 'a' }, { id: 'b' }] },
+    live: { items: [{ id: 'c' }] },
+    empty: {},
+  };
+
+  it('returns the key of the section whose items contain the id', () => {
+    expect(findSectionContainingId(['solo', 'live'], data, 'c')).toBe('live');
+  });
+
+  it('returns null when no section contains the id', () => {
+    expect(findSectionContainingId(['solo', 'live'], data, 'missing')).toBeNull();
+  });
+
+  it('skips sections that have no items', () => {
+    expect(findSectionContainingId(['empty', 'solo'], data, 'a')).toBe('solo');
   });
 });

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -5,3 +5,19 @@
 export const updateHash = (id: string): void => {
   window.history.replaceState(null, '', `#${id}`);
 };
+
+/** Clear the URL hash without triggering navigation. */
+export const clearHash = (): void => {
+  window.history.replaceState(null, '', window.location.pathname);
+};
+
+/**
+ * Find the key of the section whose items contain the given id.
+ * @returns the section key, or null when no section contains it
+ */
+export const findSectionContainingId = (
+  sectionKeys: string[],
+  data: Record<string, { items?: { id: string }[] }>,
+  id: string,
+): string | null =>
+  sectionKeys.find(key => data[key]?.items?.some(item => item.id === id)) ?? null;

--- a/src/utils/scroll.test.ts
+++ b/src/utils/scroll.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TIMING } from '@/utils/constants';
+
+import { afterAccordionAnimation, prefersReducedMotion, scrollToElement } from './scroll';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('prefersReducedMotion', () => {
+  it('reflects the reduce media query', () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true } as MediaQueryList);
+    expect(prefersReducedMotion()).toBe(true);
+
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: false } as MediaQueryList);
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});
+
+describe('scrollToElement', () => {
+  const elementAtTop = (top: number): HTMLElement => {
+    const element = document.createElement('div');
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({ top } as DOMRect);
+    return element;
+  };
+
+  it('scrolls to the element top minus the given offset', () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    scrollToElement(elementAtTop(250), { offset: 40, behavior: 'instant' });
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 210, behavior: 'instant' });
+  });
+
+  it('defaults to no offset and smooth behavior', () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    scrollToElement(elementAtTop(500));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 500, behavior: 'smooth' });
+  });
+});
+
+describe('afterAccordionAnimation', () => {
+  it('defers the callback rather than running it synchronously', () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+
+    afterAccordionAnimation(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('runs the callback after the accordion timing settles', async () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+
+    afterAccordionAnimation(callback);
+    await vi.advanceTimersByTimeAsync(TIMING.ACCORDION_ANIMATION);
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+});

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -1,0 +1,26 @@
+import { nextTick } from 'vue';
+
+import { TIMING } from '@/utils/constants';
+
+interface ScrollOptions {
+  /** Pixels to subtract from the target (e.g. a sticky header height). */
+  offset?: number;
+  behavior?: ScrollBehavior;
+}
+
+export const prefersReducedMotion = (): boolean =>
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/** Scroll so `element` sits at the top of the viewport, minus `offset`. */
+export const scrollToElement = (
+  element: HTMLElement,
+  { offset = 0, behavior = 'smooth' }: ScrollOptions = {},
+): void => {
+  const targetY = element.getBoundingClientRect().top + window.scrollY - offset;
+  window.scrollTo({ top: targetY, behavior });
+};
+
+/** Run a callback once an accordion's open animation has settled. */
+export const afterAccordionAnimation = (callback: () => void): void => {
+  void nextTick(() => setTimeout(callback, TIMING.ACCORDION_ANIMATION));
+};

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -9,7 +9,7 @@ import { useAccordion } from '@/composables/useAccordion';
 import { usePageHead } from '@/composables/usePageHead';
 import { liveYears, sortedLiveData } from '@/data/live';
 import { pageMeta } from '@/data/pageMeta';
-import { updateHash } from '@/utils/navigation';
+import { findSectionContainingId, updateHash } from '@/utils/navigation';
 import { createLiveEventsSchema } from '@/utils/pageSchemas';
 
 usePageHead({
@@ -18,7 +18,7 @@ usePageHead({
 });
 
 const findYearForEvent = (eventId: string): string | null =>
-  liveYears.find(year => sortedLiveData[year]?.items?.some(e => e.id === eventId)) ?? null;
+  findSectionContainingId(liveYears, sortedLiveData, eventId);
 
 const { openSection, handleToggle } = useAccordion(liveYears[0] ?? '', liveYears, findYearForEvent);
 const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -9,7 +9,7 @@ import { useAccordion } from '@/composables/useAccordion';
 import { usePageHead } from '@/composables/usePageHead';
 import { pageMeta } from '@/data/pageMeta';
 import { worksData, worksSections } from '@/data/works';
-import { updateHash } from '@/utils/navigation';
+import { findSectionContainingId, updateHash } from '@/utils/navigation';
 import { createWorksPageSchema } from '@/utils/pageSchemas';
 
 usePageHead({
@@ -18,10 +18,7 @@ usePageHead({
 });
 
 const findSectionForRelease = (releaseId: string): string | null =>
-  worksSections.find(section => {
-    const sectionData = worksData[section];
-    return sectionData?.items?.some(r => r.id === releaseId);
-  }) ?? null;
+  findSectionContainingId(worksSections, worksData, releaseId);
 
 const { openSection, handleToggle } = useAccordion('solo', worksSections, findSectionForRelease);
 const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');


### PR DESCRIPTION
## Description

Two utility consolidations from the parked audit — scroll helpers and hash-state/section-lookup — plus a small e2e doc-link. No behavior change.

## Changes

**1 — `scroll.ts`**
`useAccordion` and `AccordionSection` both computed `rect.top + scrollY - offset` → `window.scrollTo`, and both deferred it via the same `nextTick + setTimeout(ACCORDION_ANIMATION)` wrapper. Extracted `scrollToElement`, `afterAccordionAnimation`, and `prefersReducedMotion` into `scroll.ts`; both callers route through them, keeping their distinct offsets (scroll-margin vs header height) and behaviors (smooth/auto vs instant). PressView's `scrollIntoView` is a genuinely different mechanism and left as-is.

**2 — `navigation.ts` centralization**
`useAccordion` open-coded `window.history.replaceState` twice next to the `updateHash` util meant to own it, and `WorksView`/`LiveView` each hand-rolled the same "find the section whose items contain this id" lookup. Added `clearHash` and `findSectionContainingId`; all callers route through them. Also comment-linked the e2e `MOBILE_BREAKPOINT` to its source constants (`LAYOUT.BREAKPOINT_MD` / `$breakpoint-md`), since e2e can't import from `src`.

## Refactor assessment
- **Bundled:** both are behavior-preserving util extractions in the accordion/navigation layer.
- **Not forced:** PressView's `scrollIntoView` differs enough that unifying it would change scroll mechanics for marginal gain — deliberately left.
- **Deferred:** `useContactForm` config and `ReleaseCover` remain as follow-ups.

## Testing
- `npm run test:coverage` — 349 tests pass. New: `scroll.test.ts` (offset math, defaults, deferred timing) and `clearHash` / `findSectionContainingId` cases in `navigation.test.ts`.
- Accordion open/scroll behavior covered by `e2e/accordion.spec.ts` (runs in CI matrix).
- Type-check, lint, coverage, and production build clean.
