### PR TITLE
Extract a ReleaseCover component

### DIFF
--- a/src/components/ReleaseCover.test.ts
+++ b/src/components/ReleaseCover.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import ReleaseCover from './ReleaseCover.vue';
+
+const mountCover = (props: Record<string, unknown> = {}) =>
+  mount(ReleaseCover, { props: { src: '/images/cover.jpg', alt: 'Album cover', ...props } });
+
+describe('ReleaseCover', () => {
+  it('renders a static div cover when no href is given', () => {
+    const wrapper = mountCover();
+
+    expect(wrapper.find('div.release-cover--static').exists()).toBe(true);
+    expect(wrapper.find('a').exists()).toBe(false);
+    expect(wrapper.get('img').attributes('src')).toBe('/images/cover.jpg');
+  });
+
+  it('renders an external-link cover when given an href', () => {
+    const link = mountCover({ href: 'https://example.bandcamp.com/album/x', bandcamp: true }).get('a.release-cover');
+
+    expect(link.attributes('href')).toBe('https://example.bandcamp.com/album/x');
+    expect(link.attributes('target')).toBe('_blank');
+    expect(link.classes()).toContain('release-cover--bandcamp');
+  });
+
+  it('emits error when the cover image fails to load', async () => {
+    const wrapper = mountCover();
+
+    await wrapper.get('img').trigger('error');
+
+    expect(wrapper.emitted('error')).toHaveLength(1);
+  });
+});

--- a/src/components/ReleaseCover.vue
+++ b/src/components/ReleaseCover.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useImageLoader } from '@/composables/useImageLoader';
+import { responsiveSrcset } from '@/utils/responsiveImage';
+
+import ExternalLink from './ExternalLink.vue';
+
+const props = defineProps<{
+  src: string;
+  alt: string;
+  href?: string | undefined;
+  bandcamp?: boolean;
+}>();
+
+const emit = defineEmits<{ error: [] }>();
+
+const { setImageRef, imageLoaded, webpSrc, handleImageLoad, handleImageError } = useImageLoader(props.src);
+
+// Responsive WebP srcset (cover displays ~200px), null when no variants exist.
+const coverSrcset = computed(() => responsiveSrcset(props.src));
+
+// Surface a load failure so the parent can fall back to a text-only layout.
+const onError = (): void => {
+  handleImageError();
+  emit('error');
+};
+
+const wrapperClass = computed(() => ({
+  'release-cover': true,
+  'release-cover--static': !props.href,
+  'release-cover--bandcamp': Boolean(props.href) && Boolean(props.bandcamp),
+}));
+</script>
+
+<template>
+  <component
+    :is="href ? ExternalLink : 'div'"
+    :href="href"
+    :class="wrapperClass"
+  >
+    <picture>
+      <source
+        v-if="coverSrcset"
+        :srcset="coverSrcset"
+        sizes="(min-width: 768px) 200px, 90vw"
+        type="image/webp"
+      >
+      <source
+        :srcset="webpSrc"
+        type="image/webp"
+      >
+      <img
+        :ref="setImageRef"
+        :src="src"
+        :alt="alt"
+        loading="lazy"
+        decoding="async"
+        :class="{ 'is-loaded': imageLoaded }"
+        @load="handleImageLoad"
+        @error="onError"
+      >
+    </picture>
+  </component>
+</template>

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 import { useAccordionVisibility } from '@/composables/useAccordionContext';
-import { useImageLoader } from '@/composables/useImageLoader';
 import type { LightboxItem, Release } from '@/types';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
-import { responsiveSrcset } from '@/utils/responsiveImage';
 
 import BandcampPlayer from './BandcampPlayer.vue';
-import ExternalLink from './ExternalLink.vue';
+import ReleaseCover from './ReleaseCover.vue';
 
 const props = withDefaults(defineProps<{
   release: Release;
@@ -22,33 +20,13 @@ const emit = defineEmits<{
   'open-lightbox': [items: LightboxItem[], index: number];
 }>();
 
-const getCoverImage = (release: Release): string | undefined => {
-  if ('coverImage' in release) {
-    return release.coverImage;
-  }
-  return undefined;
-};
-
-const {
-  setImageRef,
-  imageError,
-  imageLoaded,
-  webpSrc,
-  handleImageLoad,
-  handleImageError,
-} = useImageLoader(getCoverImage(props.release) ?? '');
-
 // Defer cover loading until the release's accordion section is first opened —
 // collapsed sections sit at zero height near the viewport, defeating native
 // lazy-loading.
 const coverVisible = useAccordionVisibility();
 
-// Responsive WebP srcset for the cover (displayed ~200px), falling back to the
-// full-resolution source when no variants exist.
-const coverSrcset = computed(() => {
-  const cover = getCoverImage(props.release);
-  return cover ? responsiveSrcset(cover) : null;
-});
+// Set when the cover image fails to load, so we fall back to a text-only layout.
+const coverErrored = ref(false);
 
 const hasBandcampId = computed(() => 'bandcampId' in props.release && props.release.bandcampId);
 const hasExternalUrl = computed(() => 'externalUrl' in props.release && props.release.externalUrl);
@@ -81,7 +59,7 @@ const isBandcampLink = computed(() => {
   <article
     :id="release.id"
     class="release"
-    :class="{ 'release--text-only': textOnly || imageError }"
+    :class="{ 'release--text-only': textOnly || coverErrored }"
   >
     <!-- Bandcamp Player -->
     <BandcampPlayer
@@ -91,67 +69,15 @@ const isBandcampLink = computed(() => {
       :album-title="release.title"
     />
 
-    <!-- External Link Cover -->
-    <ExternalLink
-      v-else-if="coverVisible && hasExternalUrl && hasCoverImage && !imageError && 'externalUrl' in release"
-      :href="release.externalUrl"
-      class="release-cover"
-      :class="{ 'release-cover--bandcamp': isBandcampLink }"
-    >
-      <picture>
-        <source
-          v-if="coverSrcset"
-          :srcset="coverSrcset"
-          sizes="(min-width: 768px) 200px, 90vw"
-          type="image/webp"
-        >
-        <source
-          :srcset="webpSrc"
-          type="image/webp"
-        >
-        <img
-          v-if="'coverImage' in release"
-          :ref="setImageRef"
-          :src="release.coverImage"
-          :alt="`${release.title} cover`"
-          loading="lazy"
-          decoding="async"
-          :class="{ 'is-loaded': imageLoaded }"
-          @load="handleImageLoad"
-          @error="handleImageError"
-        >
-      </picture>
-    </ExternalLink>
-
-    <!-- Static Cover (no link) -->
-    <div
-      v-else-if="coverVisible && hasCoverImage && !imageError"
-      class="release-cover release-cover--static"
-    >
-      <picture>
-        <source
-          v-if="coverSrcset"
-          :srcset="coverSrcset"
-          sizes="(min-width: 768px) 200px, 90vw"
-          type="image/webp"
-        >
-        <source
-          :srcset="webpSrc"
-          type="image/webp"
-        >
-        <img
-          v-if="'coverImage' in release"
-          :ref="setImageRef"
-          :src="release.coverImage"
-          :alt="`${release.title} cover`"
-          loading="lazy"
-          decoding="async"
-          :class="{ 'is-loaded': imageLoaded }"
-          @load="handleImageLoad"
-          @error="handleImageError"
-        >
-      </picture>
-    </div>
+    <!-- Cover — rendered as an external link when the release has one -->
+    <ReleaseCover
+      v-else-if="coverVisible && hasCoverImage && !coverErrored && 'coverImage' in release"
+      :src="release.coverImage"
+      :alt="`${release.title} cover`"
+      :href="hasExternalUrl && 'externalUrl' in release ? release.externalUrl : undefined"
+      :bandcamp="isBandcampLink"
+      @error="coverErrored = true"
+    />
 
     <!-- Release Details -->
     <div class="release-details">


### PR DESCRIPTION
## Description
Extracts a `ReleaseCover` component from the parked audit — the last substantive Tier-2 item. No behavior change; the cover render is verified by unit tests and CI Visual Regression.

## Change
`ReleaseItem` rendered two byte-identical responsive `<picture>` blocks (one wrapped in an external link, one in a plain `div`) and owned `useImageLoader` solely for them. `ReleaseCover` now owns the loader + picture + wrapper choice (via an optional `href` prop → `ExternalLink` vs `div`), and emits `error` so the parent can still fall back to a text-only layout. The two cover branches collapse to a single `<ReleaseCover>`, and `ReleaseItem` sheds its image-loading concern.

## Refactor assessment
- **Preserved fast-path:** `useImageLoader`'s `setImageRef` callback-ref (the cached-image `complete` check) moves intact into `ReleaseCover` with the `<img>`.
- **Error handling:** the parent's `imageError` (used by its cover guards + the `release--text-only` class) becomes a `coverErrored` ref set from `ReleaseCover`'s `@error`, emitted synchronously on the `<img>` error so the text-only fallback timing is unchanged.
- **exactOptionalPropertyTypes:** `href?: string | undefined` on the prop so the parent can pass `undefined` for the static (non-link) case.

## Testing
- 352 tests pass. New: `ReleaseCover.test.ts` (static vs link wrapper, bandcamp class, error emit). Existing `ReleaseItem.test.ts` (13) still verifies cover render, `is-loaded`, error→text-only, static/bandcamp variants — unchanged.
- Note: covers are lazy (`useAccordionVisibility`) so they're client-rendered on accordion open, not in the SSG HTML — CI Visual Regression exercises the rendered cover.
- Type-check, lint, coverage, production build clean.
