### PR TITLE
Extract a MediaLinks component

### DIFF
--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -89,7 +89,7 @@ describe('EventItem', () => {
           { src: '/images/live/a-002.jpg', alt: 'B' },
         ],
       });
-      const button = wrapper.get('.event-photos-link button');
+      const button = wrapper.get('.media-links button');
       expect(button.text()).toBe('View photos');
     });
 
@@ -99,7 +99,7 @@ describe('EventItem', () => {
         images: [{ src: '/images/live/a-001.jpg', alt: 'A', photographer: { name: 'Someone' } }],
       });
 
-      await wrapper.get('.event-photos-link button').trigger('click');
+      await wrapper.get('.media-links button').trigger('click');
       const payload = wrapper.emitted('open-lightbox')?.[0];
 
       expect(payload?.[1]).toBe(0);
@@ -110,7 +110,7 @@ describe('EventItem', () => {
 
     it('renders no media control when the event has neither images nor videos', () => {
       const wrapper = mountEvent(plainEvent);
-      expect(wrapper.find('.event-photos-link').exists()).toBe(false);
+      expect(wrapper.find('.media-links').exists()).toBe(false);
     });
 
     it('shows a "View video" control and emits the converted video on click', async () => {
@@ -118,7 +118,7 @@ describe('EventItem', () => {
         ...plainEvent,
         videos: [{ url: 'https://player.vimeo.com/video/1', title: 'Live set', platform: 'vimeo', author: { name: 'Hugo Olim', url: 'https://vimeo.com/hugoolim' } }],
       });
-      const button = wrapper.get('.event-photos-link button');
+      const button = wrapper.get('.media-links button');
       expect(button.text()).toBe('View video');
 
       await button.trigger('click');
@@ -139,12 +139,12 @@ describe('EventItem', () => {
           { url: 'https://player.vimeo.com/video/2', title: 'Two', platform: 'vimeo' },
         ],
       });
-      const buttons = wrapper.findAll('.event-photos-link button');
+      const buttons = wrapper.findAll('.media-links button');
 
       expect(buttons).toHaveLength(2);
       expect(buttons[0].text()).toBe('View photo');
       expect(buttons[1].text()).toBe('View videos');
-      expect(wrapper.get('.event-photos-link').text()).toContain('|');
+      expect(wrapper.get('.media-links').text()).toContain('|');
     });
   });
 

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -7,6 +7,7 @@ import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
 import ExternalLink from './ExternalLink.vue';
 import IconArrow from './IconArrow.vue';
+import MediaLinks from './MediaLinks.vue';
 
 const props = defineProps<{
   event: LiveEvent;
@@ -34,6 +35,10 @@ const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? '
 // City + country suffix for the venue line (either may be absent for a TBC venue).
 const venueLocation = computed(() =>
   [props.event.venue.city, props.event.venue.country].filter(Boolean).join(', '));
+
+const imageLightboxItems = computed<LightboxItem[]>(() => props.event.images?.map(toLightboxImage) ?? []);
+const videoLightboxItems = computed<LightboxItem[]>(() => props.event.videos?.map(toLightboxVideo) ?? []);
+const imageLabel = computed(() => `View ${imageLightboxItems.value.length === 1 ? 'photo' : 'photos'}`);
 </script>
 
 <template>
@@ -78,26 +83,12 @@ const venueLocation = computed(() =>
         class="event-description"
         v-html="event.description"
       />
-      <p
-        v-if="event.images?.length || event.videos?.length"
-        class="event-photos-link"
-      >
-        <button
-          v-if="event.images?.length"
-          class="link-discrete"
-          @click="emit('open-lightbox', event.images.map(toLightboxImage), 0)"
-        >
-          View {{ event.images.length === 1 ? 'photo' : 'photos' }}
-        </button>
-        <span v-if="event.images?.length && event.videos?.length"> | </span>
-        <button
-          v-if="event.videos?.length"
-          class="link-discrete"
-          @click="emit('open-lightbox', event.videos.map(toLightboxVideo), 0)"
-        >
-          View {{ event.videos.length === 1 ? 'video' : 'videos' }}
-        </button>
-      </p>
+      <MediaLinks
+        :images="imageLightboxItems"
+        :videos="videoLightboxItems"
+        :image-label="imageLabel"
+        @open-lightbox="(items, index) => emit('open-lightbox', items, index)"
+      />
     </div>
   </article>
 </template>

--- a/src/components/MediaLinks.test.ts
+++ b/src/components/MediaLinks.test.ts
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import type { LightboxItem } from '@/types';
+
+import MediaLinks from './MediaLinks.vue';
+
+const image: LightboxItem = { type: 'image', src: '/a.jpg', alt: 'A' };
+const video: LightboxItem = { type: 'video', url: 'https://v', title: 'V', platform: 'youtube' };
+
+const mountLinks = (props: Partial<{ images: LightboxItem[]; videos: LightboxItem[]; imageLabel: string }>) =>
+  mount(MediaLinks, { props: { images: [], videos: [], imageLabel: 'View gallery', ...props } });
+
+describe('MediaLinks', () => {
+  it('renders nothing when there are no images or videos', () => {
+    expect(mountLinks({}).find('.media-links').exists()).toBe(false);
+  });
+
+  it('shows the image label and emits open-lightbox with the images', async () => {
+    const wrapper = mountLinks({ images: [image] });
+    const button = wrapper.get('button');
+
+    expect(button.text()).toBe('View gallery');
+    await button.trigger('click');
+
+    expect(wrapper.emitted('open-lightbox')?.[0]).toEqual([[image], 0]);
+  });
+
+  it('pluralizes the video label and separates the two buttons', () => {
+    const buttons = mountLinks({ images: [image], videos: [video, video] }).findAll('button');
+
+    expect(buttons).toHaveLength(2);
+    expect(buttons[1].text()).toBe('View videos');
+  });
+
+  it('uses the singular video label for a single video', () => {
+    expect(mountLinks({ videos: [video] }).get('button').text()).toBe('View video');
+  });
+});

--- a/src/components/MediaLinks.vue
+++ b/src/components/MediaLinks.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { LightboxItem } from '@/types';
+
+defineProps<{
+  images: LightboxItem[];
+  videos: LightboxItem[];
+  imageLabel: string;
+}>();
+
+const emit = defineEmits<{
+  'open-lightbox': [items: LightboxItem[], index: number];
+}>();
+</script>
+
+<template>
+  <p
+    v-if="images.length || videos.length"
+    class="media-links"
+  >
+    <button
+      v-if="images.length"
+      class="link-discrete"
+      @click="emit('open-lightbox', images, 0)"
+    >
+      {{ imageLabel }}
+    </button>
+    <span v-if="images.length && videos.length"> | </span>
+    <button
+      v-if="videos.length"
+      class="link-discrete"
+      @click="emit('open-lightbox', videos, 0)"
+    >
+      View {{ videos.length === 1 ? 'video' : 'videos' }}
+    </button>
+  </p>
+</template>

--- a/src/components/ReleaseItem.test.ts
+++ b/src/components/ReleaseItem.test.ts
@@ -144,7 +144,7 @@ describe('ReleaseItem', () => {
     };
     const wrapper = mountRelease(publication);
 
-    await wrapper.get('.release-gallery-link button').trigger('click');
+    await wrapper.get('.media-links button').trigger('click');
     const payload = wrapper.emitted('open-lightbox')?.[0];
 
     expect(payload?.[1]).toBe(0);
@@ -168,7 +168,7 @@ describe('ReleaseItem', () => {
       ],
     };
     const wrapper = mountRelease(withVideo);
-    const button = wrapper.get('.release-gallery-link button');
+    const button = wrapper.get('.media-links button');
     expect(button.text()).toBe('View video');
 
     await button.trigger('click');
@@ -201,11 +201,11 @@ describe('ReleaseItem', () => {
       ],
     };
     const wrapper = mountRelease(withBoth);
-    const buttons = wrapper.findAll('.release-gallery-link button');
+    const buttons = wrapper.findAll('.media-links button');
 
     expect(buttons).toHaveLength(2);
     expect(buttons[0].text()).toBe('View gallery');
     expect(buttons[1].text()).toBe('View videos');
-    expect(wrapper.get('.release-gallery-link').text()).toContain('|');
+    expect(wrapper.get('.media-links').text()).toContain('|');
   });
 });

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -6,6 +6,7 @@ import type { LightboxItem, Release } from '@/types';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
 import BandcampPlayer from './BandcampPlayer.vue';
+import MediaLinks from './MediaLinks.vue';
 import ReleaseCover from './ReleaseCover.vue';
 
 const props = withDefaults(defineProps<{
@@ -39,13 +40,11 @@ const imageLightboxItems = computed<LightboxItem[]>(() => {
   if (!('images' in props.release) || !props.release.images) return [];
   return props.release.images.map(toLightboxImage);
 });
-const hasImages = computed(() => imageLightboxItems.value.length > 0);
 
 const videoLightboxItems = computed<LightboxItem[]>(() => {
   if (!('videos' in props.release) || !props.release.videos) return [];
   return props.release.videos.map(toLightboxVideo);
 });
-const hasVideos = computed(() => videoLightboxItems.value.length > 0);
 
 const isBandcampLink = computed(() => {
   if ('externalUrl' in props.release && props.release.externalUrl) {
@@ -112,26 +111,12 @@ const isBandcampLink = computed(() => {
         class="release-credits"
         v-html="release.credits"
       />
-      <p
-        v-if="hasImages || hasVideos"
-        class="release-gallery-link"
-      >
-        <button
-          v-if="hasImages"
-          class="link-discrete"
-          @click="emit('open-lightbox', imageLightboxItems, 0)"
-        >
-          View gallery
-        </button>
-        <span v-if="hasImages && hasVideos"> | </span>
-        <button
-          v-if="hasVideos"
-          class="link-discrete"
-          @click="emit('open-lightbox', videoLightboxItems, 0)"
-        >
-          View {{ videoLightboxItems.length === 1 ? 'video' : 'videos' }}
-        </button>
-      </p>
+      <MediaLinks
+        :images="imageLightboxItems"
+        :videos="videoLightboxItems"
+        image-label="View gallery"
+        @open-lightbox="(items, index) => emit('open-lightbox', items, index)"
+      />
     </div>
   </article>
 </template>

--- a/src/styles/_pages.scss
+++ b/src/styles/_pages.scss
@@ -402,9 +402,8 @@
 // Photo Gallery Links (Works & Live pages)
 // =============================================================================
 
-// Photo gallery link — discrete and subtle
-.event-photos-link,
-.release-gallery-link {
+// Media links (View gallery/photos/videos) — discrete and subtle
+.media-links {
   margin-top: $spacing-2;
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Description
Extracts a `MediaLinks` component — the last of the parked audit's extractions. No behavior change.

## Change
`ReleaseItem` and `EventItem` rendered the same gallery/video control block — two `link-discrete` buttons with a `|` separator and a singular/plural video label — and their wrapper classes (`release-gallery-link` / `event-photos-link`) already shared a single SCSS rule. `MediaLinks` now owns that markup (`images`/`videos` as `LightboxItem[]` + an `imageLabel` prop, emits `open-lightbox`), and the wrapper unifies to one `media-links` class.

## Refactor assessment
- **Justified at 2 sites** because the SCSS already treated both wrappers as one (comma selector) — the markup duplication mirrored an existing style duplication.
- Callers pass already-adapted `LightboxItem[]` (from the earlier `lightboxAdapters` work); `EventItem` gains `imageLightboxItems`/`videoLightboxItems` computeds to match `ReleaseItem`.

## Testing
- 356 tests pass. New `MediaLinks.test.ts` (empty state, image/video labels, plural, emit). `ReleaseItem`/`EventItem` tests updated to the `.media-links` selector; behavior assertions unchanged.
- Verified in `dist/`: `media-links` markup renders, old classes gone. Type-check, lint, build clean.
