### PR TITLE
Rename terse variables and collapse redundant blocks

### DIFF
--- a/scripts/async-css.js
+++ b/scripts/async-css.js
@@ -7,7 +7,7 @@ const distDir = 'dist';
 async function makeCSSAsync() {
   try {
     const files = await readdir(distDir);
-    const htmlFiles = files.filter(f => f.endsWith('.html'));
+    const htmlFiles = files.filter(file => file.endsWith('.html'));
 
     for (const file of htmlFiles) {
       const filePath = join(distDir, file);

--- a/scripts/generate-responsive-images.mjs
+++ b/scripts/generate-responsive-images.mjs
@@ -20,8 +20,8 @@ const OUT = join(PUBLIC, 'images/responsive');
 // Extract '/images/<name>.jpg' occurrences after a given key in a data file.
 const extract = (file, key) => {
   const text = readFileSync(join(root, 'src/data', file), 'utf8');
-  const re = new RegExp(`${key}:\\s*'(/images/[a-z0-9-]+\\.jpg)'`, 'g');
-  return [...text.matchAll(re)].map(m => m[1]);
+  const imagePattern = new RegExp(`${key}:\\s*'(/images/[a-z0-9-]+\\.jpg)'`, 'g');
+  return [...text.matchAll(imagePattern)].map(match => match[1]);
 };
 
 const covers = [...new Set(extract('works.ts', 'coverImage'))].map(src => ({ src, widths: [320, 640, 960] }));

--- a/scripts/optimize-images.js
+++ b/scripts/optimize-images.js
@@ -7,7 +7,7 @@ const QUALITY = 80
 
 async function optimizeImages() {
   const files = await readdir(IMAGES_DIR)
-  const jpgFiles = files.filter(f => extname(f).toLowerCase() === '.jpg')
+  const jpgFiles = files.filter(file => extname(file).toLowerCase() === '.jpg')
 
   console.log(`Converting ${jpgFiles.length} images to WebP...`)
 

--- a/scripts/subset-fonts.mjs
+++ b/scripts/subset-fonts.mjs
@@ -27,17 +27,17 @@ const collectChars = () => {
       if (entry.isDirectory()) {
         walk(path);
       } else if (/\.(ts|vue)$/.test(entry.name) && !/\.test\.ts$/.test(entry.name)) {
-        for (const ch of readFileSync(path, 'utf8')) chars.add(ch);
+        for (const character of readFileSync(path, 'utf8')) chars.add(character);
       }
     }
   };
   walk(join(root, 'src'));
-  for (const ch of readFileSync(join(root, 'index.html'), 'utf8')) chars.add(ch);
+  for (const character of readFileSync(join(root, 'index.html'), 'utf8')) chars.add(character);
 
   // Safety margin: all of Basic Latin + Latin-1 Supplement, so ordinary future
   // copy (English + Portuguese) never needs a re-subset.
-  for (let cp = 0x20; cp <= 0x7e; cp += 1) chars.add(String.fromCodePoint(cp));
-  for (let cp = 0xa0; cp <= 0xff; cp += 1) chars.add(String.fromCodePoint(cp));
+  for (let codePoint = 0x20; codePoint <= 0x7e; codePoint += 1) chars.add(String.fromCodePoint(codePoint));
+  for (let codePoint = 0xa0; codePoint <= 0xff; codePoint += 1) chars.add(String.fromCodePoint(codePoint));
   return chars;
 };
 
@@ -47,12 +47,12 @@ const text = [...chars].join('');
 // 2. Report any used character the source font cannot provide (would silently
 //    fall back to a system font on the page).
 const source = create(readFileSync(join(FONT_DIR, WEIGHTS[400])));
-const missing = [...chars].filter(ch => {
-  const cp = ch.codePointAt(0);
-  return cp > 0x20 && !source.hasGlyphForCodePoint(cp);
+const missing = [...chars].filter(character => {
+  const codePoint = character.codePointAt(0);
+  return codePoint > 0x20 && !source.hasGlyphForCodePoint(codePoint);
 });
 if (missing.length) {
-  const list = missing.map(ch => `${ch} U+${ch.codePointAt(0).toString(16).toUpperCase().padStart(4, '0')}`).join('  ');
+  const list = missing.map(character => `${character} U+${character.codePointAt(0).toString(16).toUpperCase().padStart(4, '0')}`).join('  ');
   console.warn(`⚠️  ${missing.length} used character(s) not in the source font (will fall back):\n   ${list}`);
 }
 

--- a/src/components/BandcampPlayer.test.ts
+++ b/src/components/BandcampPlayer.test.ts
@@ -44,14 +44,14 @@ describe('BandcampPlayer', () => {
 
     it('renders the play button', () => {
       const wrapper = mountPlayer();
-      const btn = wrapper.find('.bandcamp-player__button');
-      expect(btn.exists()).toBe(true);
+      const playButton = wrapper.find('.bandcamp-player__button');
+      expect(playButton.exists()).toBe(true);
     });
 
     it('play button has an accessible aria-label', () => {
       const wrapper = mountPlayer();
-      const btn = wrapper.find('.bandcamp-player__button');
-      expect(btn.attributes('aria-label')).toBe(`Play ${DEFAULT_PROPS.albumTitle}`);
+      const playButton = wrapper.find('.bandcamp-player__button');
+      expect(playButton.attributes('aria-label')).toBe(`Play ${DEFAULT_PROPS.albumTitle}`);
     });
   });
 
@@ -114,9 +114,9 @@ describe('BandcampPlayer', () => {
     it('uses the correct Bandcamp embed URL', async () => {
       const wrapper = mountPlayer();
       await wrapper.find('.bandcamp-player').trigger('click');
-      const src = wrapper.find('iframe').attributes('src');
-      expect(src).toContain(DEFAULT_PROPS.albumId);
-      expect(src).toContain('bandcamp.com/EmbeddedPlayer');
+      const iframeSrc = wrapper.find('iframe').attributes('src');
+      expect(iframeSrc).toContain(DEFAULT_PROPS.albumId);
+      expect(iframeSrc).toContain('bandcamp.com/EmbeddedPlayer');
     });
 
     it('has a descriptive title attribute', async () => {

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -19,8 +19,8 @@ const emit = defineEmits<{
   close: [];
   prev: [];
   next: [];
-  touchstart: [e: TouchEvent];
-  touchend: [e: TouchEvent];
+  touchstart: [event: TouchEvent];
+  touchend: [event: TouchEvent];
 }>();
 
 const isVideo = computed(() => props.currentItem !== null && isLightboxVideo(props.currentItem));
@@ -30,20 +30,16 @@ const isImage = computed(() => props.currentItem !== null && isLightboxImage(pro
 // "Video by" for a video's author. Null when the current item has neither.
 const credit = computed(() => {
   const item = props.currentItem;
-  if (item && isLightboxImage(item) && item.photographer) {
-    return { prefix: 'Photo by', ...item.photographer };
-  }
-  if (item && isLightboxVideo(item) && item.author) {
-    return { prefix: 'Video by', ...item.author };
-  }
+  if (item && isLightboxImage(item) && item.photographer) return { prefix: 'Photo by', ...item.photographer };
+  if (item && isLightboxVideo(item) && item.author) return { prefix: 'Video by', ...item.author };
   return null;
 });
 
 const handleClose = () => emit('close');
 const handlePrev = () => emit('prev');
 const handleNext = () => emit('next');
-const handleTouchStart = (e: TouchEvent) => emit('touchstart', e);
-const handleTouchEnd = (e: TouchEvent) => emit('touchend', e);
+const handleTouchStart = (event: TouchEvent) => emit('touchstart', event);
+const handleTouchEnd = (event: TouchEvent) => emit('touchend', event);
 
 // Accessible name for the dialog, reflecting current media/position
 const dialogLabel = computed(() => {

--- a/src/composables/useImageLoader.test.ts
+++ b/src/composables/useImageLoader.test.ts
@@ -111,10 +111,10 @@ describe('useImageLoader', () => {
       const { loader, wrapper } = mountWithLoader(TEST_SRC_JPG);
 
       // Simulate an already-loaded image
-      const img = wrapper.find('img').element as HTMLImageElement;
-      Object.defineProperty(img, 'complete', { value: true, configurable: true });
-      Object.defineProperty(img, 'naturalHeight', { value: 100, configurable: true });
-      loader.imageRef.value = img;
+      const imageElement = wrapper.find('img').element as HTMLImageElement;
+      Object.defineProperty(imageElement, 'complete', { value: true, configurable: true });
+      Object.defineProperty(imageElement, 'naturalHeight', { value: 100, configurable: true });
+      loader.imageRef.value = imageElement;
 
       // Re-trigger mounted logic via nextTick
       await nextTick();
@@ -128,10 +128,10 @@ describe('useImageLoader', () => {
     it('does not set imageLoaded if image complete but naturalHeight is 0 (broken image)', async () => {
       const { loader, wrapper } = mountWithLoader(TEST_SRC_JPG);
 
-      const img = wrapper.find('img').element as HTMLImageElement;
-      Object.defineProperty(img, 'complete', { value: true, configurable: true });
-      Object.defineProperty(img, 'naturalHeight', { value: 0, configurable: true });
-      loader.imageRef.value = img;
+      const imageElement = wrapper.find('img').element as HTMLImageElement;
+      Object.defineProperty(imageElement, 'complete', { value: true, configurable: true });
+      Object.defineProperty(imageElement, 'naturalHeight', { value: 0, configurable: true });
+      loader.imageRef.value = imageElement;
 
       await nextTick();
       await nextTick();
@@ -144,9 +144,9 @@ describe('useImageLoader', () => {
   describe('setImageRef', () => {
     it('stores an HTMLImageElement in imageRef', () => {
       const { loader } = mountWithLoader(TEST_SRC_JPG);
-      const img = document.createElement('img');
-      loader.setImageRef(img);
-      expect(loader.imageRef.value).toBe(img);
+      const imageElement = document.createElement('img');
+      loader.setImageRef(imageElement);
+      expect(loader.imageRef.value).toBe(imageElement);
     });
 
     it('resets imageRef to null when passed null', () => {

--- a/src/composables/useImageLoader.ts
+++ b/src/composables/useImageLoader.ts
@@ -5,7 +5,7 @@ import { toWebp } from '@/utils/responsiveImage';
 
 interface UseImageLoaderReturn {
   imageRef: Ref<HTMLImageElement | null>;
-  setImageRef: (el: Element | ComponentPublicInstance | null) => void;
+  setImageRef: (element: Element | ComponentPublicInstance | null) => void;
   imageError: Ref<boolean>;
   imageLoaded: Ref<boolean>;
   webpSrc: ComputedRef<string | undefined>;
@@ -28,8 +28,8 @@ export const useImageLoader = (src: string): UseImageLoaderReturn => {
   // Callback ref: bound via `:ref` in templates so the composable owns the
   // <img> element. Needed for the already-complete fast-path below to work
   // when a cached image never re-fires `load` after hydration.
-  const setImageRef = (el: Element | ComponentPublicInstance | null): void => {
-    imageRef.value = el instanceof HTMLImageElement ? el : null;
+  const setImageRef = (element: Element | ComponentPublicInstance | null): void => {
+    imageRef.value = element instanceof HTMLImageElement ? element : null;
   };
 
   onMounted(async () => {

--- a/src/composables/useSwipeNavigation.ts
+++ b/src/composables/useSwipeNavigation.ts
@@ -4,8 +4,8 @@ import { ref } from 'vue';
 import { TOUCH } from '@/utils/constants';
 
 export interface UseSwipeNavigationReturn {
-  handleTouchStart: (e: TouchEvent) => void;
-  handleTouchEnd: (e: TouchEvent) => void;
+  handleTouchStart: (event: TouchEvent) => void;
+  handleTouchEnd: (event: TouchEvent) => void;
 }
 
 interface TouchPosition {
@@ -26,8 +26,8 @@ export const useSwipeNavigation = (
 ): UseSwipeNavigationReturn => {
   const touchStart: Ref<TouchPosition> = ref({ x: 0, y: 0, time: 0 });
 
-  const handleTouchStart = (e: TouchEvent): void => {
-    const touch = e.touches[0];
+  const handleTouchStart = (event: TouchEvent): void => {
+    const touch = event.touches[0];
     if (!touch) return;
 
     touchStart.value = {
@@ -37,8 +37,8 @@ export const useSwipeNavigation = (
     };
   };
 
-  const handleTouchEnd = (e: TouchEvent): void => {
-    const touch = e.changedTouches[0];
+  const handleTouchEnd = (event: TouchEvent): void => {
+    const touch = event.changedTouches[0];
     if (!touch) return;
 
     const deltaX = touch.clientX - touchStart.value.x;

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,13 +16,9 @@ export const createApp = ViteSSG(
   {
     routes,
     scrollBehavior(to, _from, savedPosition) {
-      if (savedPosition) {
-        return savedPosition;
-      }
+      if (savedPosition) return savedPosition;
       // If there's a hash, don't scroll - let the component handle it
-      if (to.hash) {
-        return false;
-      }
+      if (to.hash) return false;
       return { top: 0 };
     },
   },

--- a/src/utils/pageSchemas.ts
+++ b/src/utils/pageSchemas.ts
@@ -25,7 +25,7 @@ export const createPersonSchema = (): SchemaProfilePerson => ({
   jobTitle: siteConfig.tagline,
   description: siteConfig.description,
   image: `${siteConfig.url}${siteConfig.image}`,
-  sameAs: social.map(s => s.url),
+  sameAs: social.map(link => link.url),
 });
 
 export const createContactPageSchema = (): SchemaContactPage => ({

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -22,26 +22,24 @@ export const createMusicEventSchema = (
   event: LiveEvent,
   performerName: string,
   fallbackDate = '',
-): SchemaMusicEvent => {
-  return {
-    '@type': 'MusicEvent',
-    name: stripHtml(event.title),
-    startDate: event.date || fallbackDate,
-    location: {
-      '@type': 'Place',
-      name: event.venue.name ?? '',
-      address: {
-        '@type': 'PostalAddress',
-        addressLocality: event.venue.city ?? '',
-        addressCountry: event.venue.country,
-      },
+): SchemaMusicEvent => ({
+  '@type': 'MusicEvent',
+  name: stripHtml(event.title),
+  startDate: event.date || fallbackDate,
+  location: {
+    '@type': 'Place',
+    name: event.venue.name ?? '',
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: event.venue.city ?? '',
+      addressCountry: event.venue.country,
     },
-    performer: {
-      '@type': 'Person',
-      name: performerName,
-    },
-  };
-};
+  },
+  performer: {
+    '@type': 'Person',
+    name: performerName,
+  },
+});
 
 /**
  * Create an ItemList schema

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -15,11 +15,10 @@ usePageHead(pageMeta.about);
 
 const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 
-const allImages = computed(() => {
-  return aboutSections
+const allImages = computed(() =>
+  aboutSections
     .filter(isImageSection)
-    .flatMap(section => section.images.map(toLightboxImage));
-});
+    .flatMap(section => section.images.map(toLightboxImage)));
 
 // Pre-compute section starting indices for O(1) lookup
 const sectionStartIndices = computed(() => {
@@ -34,9 +33,8 @@ const sectionStartIndices = computed(() => {
 });
 
 // Global index of an image — O(1) via the precomputed section starts.
-const getGlobalIndex = (sectionIndex: number, imageIndex: number): number => {
-  return (sectionStartIndices.value[sectionIndex] ?? 0) + imageIndex;
-};
+const getGlobalIndex = (sectionIndex: number, imageIndex: number): number =>
+  (sectionStartIndices.value[sectionIndex] ?? 0) + imageIndex;
 </script>
 
 <template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -17,15 +17,15 @@ usePageHead({
 const heroImageLoaded = ref(false);
 
 onMounted(() => {
-  const img = new Image();
-  img.onload = () => {
+  const heroImage = new Image();
+  heroImage.onload = () => {
     heroImageLoaded.value = true;
   };
   // Reveal the hero even if the image fails, so the loader never spins forever.
-  img.onerror = () => {
+  heroImage.onerror = () => {
     heroImageLoaded.value = true;
   };
-  img.src = heroImageSrc;
+  heroImage.src = heroImageSrc;
 });
 </script>
 


### PR DESCRIPTION
## Description
Applies the descriptive-name and no-unnecessary-block conventions codebase-wide. Pure style; no behavior change (net −12 lines).

## Changes
**Renames** — abbreviated → descriptive:
- `el`→`element` (`useImageLoader`), `img`→`heroImage` (`HomeView`), `re`→`imagePattern` + `m`→`match` (`generate-responsive-images`), `cp`→`codePoint` + `ch`→`character` (`subset-fonts`), `f`→`file` (`async-css`, `optimize-images`), `s`→`link` (`pageSchemas`), `e`→`event` (`useSwipeNavigation`, `LightboxOverlay`).
- Test locals: `img`→`imageElement`, `btn`→`playButton`, `src`→`iframeSrc`.

**Block collapses** — to the style the repo already uses elsewhere:
- Brace-less single-statement guards (`main.ts` scroll behavior, `LightboxOverlay` credit).
- Implicit arrow/object returns (`schemaHelpers.createMusicEventSchema`, `AboutView` `allImages`/`getGlobalIndex`).

**Deliberately left:** sort comparators `(a, b)` — no meaningful descriptive name for two arbitrary operands; verbose names would read worse. And genuinely multi-statement blocks (try/catch, multi-branch watches) untouched.

## Testing
356 tests pass; type-check, lint, production build clean; both non-build scripts (`optimize-images`, `subset-fonts`) syntax-checked.
