### PR TITLE
Address remaining code-quality findings to reach grade A

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -37,23 +37,12 @@ try {
   console.log(`Branches:   ${totals.branches.pct}% (threshold: ${THRESHOLDS.branches}%)`);
   console.log('━'.repeat(50));
 
-  const failures = [];
-
-  if (totals.lines.pct < THRESHOLDS.lines) {
-    failures.push(`Lines: ${totals.lines.pct}% < ${THRESHOLDS.lines}%`);
-  }
-
-  if (totals.statements.pct < THRESHOLDS.statements) {
-    failures.push(`Statements: ${totals.statements.pct}% < ${THRESHOLDS.statements}%`);
-  }
-
-  if (totals.functions.pct < THRESHOLDS.functions) {
-    failures.push(`Functions: ${totals.functions.pct}% < ${THRESHOLDS.functions}%`);
-  }
-
-  if (totals.branches.pct < THRESHOLDS.branches) {
-    failures.push(`Branches: ${totals.branches.pct}% < ${THRESHOLDS.branches}%`);
-  }
+  const failures = Object.entries(THRESHOLDS)
+    .filter(([metric, threshold]) => totals[metric].pct < threshold)
+    .map(([metric, threshold]) => {
+      const label = metric.charAt(0).toUpperCase() + metric.slice(1);
+      return `${label}: ${totals[metric].pct}% < ${threshold}%`;
+    });
 
   if (failures.length > 0) {
     console.error('\n❌ Coverage thresholds not met:');

--- a/src/components/BandcampPlayer.vue
+++ b/src/components/BandcampPlayer.vue
@@ -1,22 +1,13 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import { useImageLoader } from '@/composables/useImageLoader';
 
-const props = defineProps({
-  albumId: {
-    type: String,
-    required: true,
-  },
-  coverImage: {
-    type: String,
-    required: true,
-  },
-  albumTitle: {
-    type: String,
-    required: true,
-  },
-});
+const props = defineProps<{
+  albumId: string;
+  coverImage: string;
+  albumTitle: string;
+}>();
 
 const {
   setImageRef,
@@ -29,6 +20,11 @@ const {
 
 const showPlayer = ref(false);
 const isLoaded = ref(false);
+
+// Bandcamp embed styling — large player, dark theme (bg #000, links #fff) to match the site.
+const BANDCAMP_EMBED_PARAMS = 'size=large/bgcol=000000/linkcol=ffffff/minimal=true/transparent=true';
+const embedUrl = computed(() =>
+  `https://bandcamp.com/EmbeddedPlayer/album=${props.albumId}/${BANDCAMP_EMBED_PARAMS}/`);
 
 const loadPlayer = () => {
   if (showPlayer.value) return;
@@ -83,7 +79,7 @@ const handleIframeLoad = () => {
     </div>
     <iframe
       v-if="showPlayer"
-      :src="`https://bandcamp.com/EmbeddedPlayer/album=${albumId}/size=large/bgcol=000000/linkcol=ffffff/minimal=true/transparent=true/`"
+      :src="embedUrl"
       seamless
       sandbox="allow-scripts allow-same-origin allow-popups"
       :title="`${albumTitle} - Bandcamp player`"

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 
 import { useAccordionVisibility } from '@/composables/useAccordionContext';
 import type { LightboxItem, Release } from '@/types';
+import { hasBandcampId, hasCoverImage, hasCredits, hasDescription, hasExternalUrl, hasImages, hasTracklist, hasVideos } from '@/types';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
 import BandcampPlayer from './BandcampPlayer.vue';
@@ -29,28 +30,14 @@ const coverVisible = useAccordionVisibility();
 // Set when the cover image fails to load, so we fall back to a text-only layout.
 const coverErrored = ref(false);
 
-const hasBandcampId = computed(() => 'bandcampId' in props.release && props.release.bandcampId);
-const hasExternalUrl = computed(() => 'externalUrl' in props.release && props.release.externalUrl);
-const hasCoverImage = computed(() => 'coverImage' in props.release && props.release.coverImage);
-const hasDescription = computed(() => 'description' in props.release && props.release.description);
-const hasTracklist = computed(() => 'tracklist' in props.release && props.release.tracklist);
-const hasCredits = computed(() => 'credits' in props.release && props.release.credits);
-const imageLightboxItems = computed<LightboxItem[]>(() => {
-  if (!('images' in props.release) || !props.release.images) return [];
-  return props.release.images.map(toLightboxImage);
-});
+const imageLightboxItems = computed<LightboxItem[]>(() =>
+  hasImages(props.release) ? props.release.images.map(toLightboxImage) : []);
 
-const videoLightboxItems = computed<LightboxItem[]>(() => {
-  if (!('videos' in props.release) || !props.release.videos) return [];
-  return props.release.videos.map(toLightboxVideo);
-});
+const videoLightboxItems = computed<LightboxItem[]>(() =>
+  hasVideos(props.release) ? props.release.videos.map(toLightboxVideo) : []);
 
-const isBandcampLink = computed(() => {
-  if ('externalUrl' in props.release && props.release.externalUrl) {
-    return props.release.externalUrl.includes('bandcamp.com');
-  }
-  return false;
-});
+const isBandcampLink = computed(() =>
+  hasExternalUrl(props.release) && props.release.externalUrl.includes('bandcamp.com'));
 </script>
 
 <template>
@@ -60,7 +47,7 @@ const isBandcampLink = computed(() => {
     :class="{ 'release--text-only': textOnly || coverErrored }"
   >
     <BandcampPlayer
-      v-if="coverVisible && hasBandcampId && hasCoverImage && 'bandcampId' in release && 'coverImage' in release"
+      v-if="coverVisible && hasBandcampId(release) && hasCoverImage(release)"
       :album-id="release.bandcampId"
       :cover-image="release.coverImage"
       :album-title="release.title"
@@ -68,10 +55,10 @@ const isBandcampLink = computed(() => {
 
     <!-- Cover — rendered as an external link when the release has one -->
     <ReleaseCover
-      v-else-if="coverVisible && hasCoverImage && !coverErrored && 'coverImage' in release"
+      v-else-if="coverVisible && hasCoverImage(release) && !coverErrored"
       :src="release.coverImage"
       :alt="`${release.title} cover`"
-      :href="hasExternalUrl && 'externalUrl' in release ? release.externalUrl : undefined"
+      :href="hasExternalUrl(release) ? release.externalUrl : undefined"
       :bandcamp="isBandcampLink"
       @error="coverErrored = true"
     />
@@ -92,11 +79,11 @@ const isBandcampLink = computed(() => {
         v-html="release.meta"
       />
       <p
-        v-if="hasDescription && 'description' in release"
+        v-if="hasDescription(release)"
         class="release-description"
         v-html="release.description"
       />
-      <ol v-if="hasTracklist && 'tracklist' in release && release.tracklist.length">
+      <ol v-if="hasTracklist(release) && release.tracklist.length">
         <li
           v-for="(track, index) in release.tracklist"
           :key="index"
@@ -104,7 +91,7 @@ const isBandcampLink = computed(() => {
         />
       </ol>
       <p
-        v-if="hasCredits && 'credits' in release"
+        v-if="hasCredits(release)"
         class="release-credits"
         v-html="release.credits"
       />

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -192,9 +192,3 @@ export const aboutSections: AboutSection[] = [
     ],
   },
 ];
-
-// Legacy export for backward compatibility (if needed elsewhere)
-export const aboutContent = aboutSections
-  .filter((section): section is { id: string; content: string; type?: 'short-bio' } => 'content' in section)
-  .map(section => section.content)
-  .join('\n\n');

--- a/src/types/works.ts
+++ b/src/types/works.ts
@@ -78,6 +78,35 @@ export interface Image {
   };
 }
 
+// Field-presence guards for the Release union, so callers narrow once instead of
+// repeating `'x' in release && release.x` at every use site.
+export const hasBandcampId = (release: Release): release is Release & { bandcampId: string } =>
+  'bandcampId' in release && Boolean(release.bandcampId);
+
+export const hasBandcampUrl = (release: Release): release is Release & { bandcampUrl: string } =>
+  'bandcampUrl' in release && Boolean(release.bandcampUrl);
+
+export const hasExternalUrl = (release: Release): release is Release & { externalUrl: string } =>
+  'externalUrl' in release && Boolean(release.externalUrl);
+
+export const hasCoverImage = (release: Release): release is Release & { coverImage: string } =>
+  'coverImage' in release && Boolean(release.coverImage);
+
+export const hasTracklist = (release: Release): release is Release & { tracklist: string[] } =>
+  'tracklist' in release && Boolean(release.tracklist);
+
+export const hasDescription = (release: Release): release is Release & { description: string } =>
+  'description' in release && Boolean(release.description);
+
+export const hasCredits = (release: Release): release is Release & { credits: string } =>
+  'credits' in release && Boolean(release.credits);
+
+export const hasImages = (release: Release): release is Release & { images: Image[] } =>
+  'images' in release && Boolean(release.images);
+
+export const hasVideos = (release: Release): release is Release & { videos: VideoItem[] } =>
+  'videos' in release && Boolean(release.videos);
+
 export interface WorksSection {
   title: string;
   id: string;

--- a/src/utils/pageSchemas.ts
+++ b/src/utils/pageSchemas.ts
@@ -4,7 +4,7 @@
 import { liveYears, sortedLiveData } from '@/data/live';
 import { siteConfig, social } from '@/data/navigation';
 import { worksData } from '@/data/works';
-import type { BandcampRelease, ExternalRelease } from '@/types';
+import { hasBandcampId, hasBandcampUrl } from '@/types';
 import type {
   SchemaBook,
   SchemaContactPage,
@@ -66,9 +66,7 @@ const glitchBookSchema: SchemaBook = {
 export const createWorksPageSchema = (): SchemaWorksGraph => {
   const soloSection = worksData['solo'];
   const albums = (soloSection?.items ?? [])
-    .filter((release): release is BandcampRelease | ExternalRelease =>
-      ('bandcampId' in release && release.bandcampId !== undefined) ||
-      ('bandcampUrl' in release && release.bandcampUrl !== undefined))
+    .filter(release => hasBandcampId(release) || hasBandcampUrl(release))
     .map(release => {
       const datePublished = extractYear(release.meta ?? null);
       const withDate = { ...release, ...(datePublished ? { datePublished } : {}) };


### PR DESCRIPTION
## Description
Clears the remaining code-quality audit findings so the codebase reaches a straight **A** on the CLAUDE.md rules. Net −7 lines; no behavior change.

## Changes
1. **`Release` union guards (rule 4 — the one med smell).** Added field-presence guards (`hasBandcampId`, `hasCoverImage`, `hasCredits`, `hasDescription`, `hasExternalUrl`, `hasImages`, `hasTracklist`, `hasVideos`) to `types/works.ts` — consistent with the existing `isLightboxImage`/`isImageSection` pattern. `ReleaseItem` and `pageSchemas` now narrow through them, removing ~9 repeated `'x' in release && release.x` structural checks (including the template double-narrowing like `hasCoverImage && 'coverImage' in release`).
2. **`BandcampPlayer` (rule 3 — magic string).** Switched Options-style `defineProps({…})` to type-based `defineProps<{…}>()` (matches every other component), and hoisted the embed URL's baked-in styling params into a named `BANDCAMP_EMBED_PARAMS` constant with a comment.
3. **Dead code (rule 4).** Removed the unused self-labeled "legacy" `aboutContent` export from `data/about.ts` (imported nowhere).
4. **Duplication (rule 4).** Collapsed `check-coverage.js`'s four repeated threshold `if`-blocks into one `Object.entries(THRESHOLDS)` loop.

## Testing
- Type-check ✅ (guard narrowing verified in templates + the `pageSchemas` filter), lint ✅, **356 tests** ✅, production build ✅, `check-coverage` script re-verified (thresholds met).
- `e2e/lightbox.spec.ts` + `e2e/accessibility.spec.ts` green on chromium — the guard-driven `ReleaseItem` renders covers/galleries/tracklists/credits correctly; full matrix + Visual Regression run in CI.
