### PR TITLE
Drop two unnecessary comments

### DIFF
--- a/src/components/BandcampPlayer.vue
+++ b/src/components/BandcampPlayer.vue
@@ -21,7 +21,6 @@ const {
 const showPlayer = ref(false);
 const isLoaded = ref(false);
 
-// Bandcamp embed styling — large player, dark theme (bg #000, links #fff) to match the site.
 const BANDCAMP_EMBED_PARAMS = 'size=large/bgcol=000000/linkcol=ffffff/minimal=true/transparent=true';
 const embedUrl = computed(() =>
   `https://bandcamp.com/EmbeddedPlayer/album=${props.albumId}/${BANDCAMP_EMBED_PARAMS}/`);

--- a/src/types/works.ts
+++ b/src/types/works.ts
@@ -78,8 +78,6 @@ export interface Image {
   };
 }
 
-// Field-presence guards for the Release union, so callers narrow once instead of
-// repeating `'x' in release && release.x` at every use site.
 export const hasBandcampId = (release: Release): release is Release & { bandcampId: string } =>
   'bandcampId' in release && Boolean(release.bandcampId);
 


### PR DESCRIPTION
Removes two superfluous comments added in #131: the `Release`-guard comment in `types/works.ts` (the guard names are self-documenting; the sibling `isLightboxImage`/`isImageSection` guards have none) and the `BandcampPlayer` embed comment (redundant with the named `BANDCAMP_EMBED_PARAMS` constant + self-describing value). No behavior change.