### PR TITLE
test: backfill coverage gaps and ratchet the regression floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vue 3 + TypeScript portfolio website for [www.jeromefaria.com](https://www.jerom
 - **Frontend**: Vue 3 (Composition API), TypeScript (strict mode)
 - **Build**: Vite with SSG (Static Site Generation)
 - **Styling**: SCSS with BEM methodology
-- **Testing**: Vitest (unit — ~95% coverage across the whole `src` tree), Playwright E2E (Chromium, Firefox, WebKit), axe-core accessibility
+- **Testing**: Vitest (unit — ~99% coverage across the whole `src` tree), Playwright E2E (Chromium, Firefox, WebKit), axe-core accessibility
 - **CI/CD**: GitHub Actions with quality gates
 - **Performance**: Lighthouse CI with performance budgets
 
@@ -52,7 +52,7 @@ npm run test:ui
 npm run test:coverage
 ```
 
-**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; the view and component tests assert behaviour (hash-driven accordion opening, link processing, focus trapping, image load/error fallbacks) rather than render counts, and UI paths are also exercised by the Playwright E2E suite. CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs. Current coverage is ~98% lines / 96% statements / 93% functions / 87% branches, with the floor set just below at Lines 96%, Statements 95%, Functions 91%, Branches 85%.
+**Coverage**: The whole `src` tree is instrumented (`all: true`), so the reported percentage reflects the entire codebase rather than only the files a test imports. The logic layer (composables, utils) is ~100% covered; the view and component tests assert behaviour (hash-driven accordion opening, link processing, focus trapping, image load/error fallbacks) rather than render counts, and UI paths are also exercised by the Playwright E2E suite. CI enforces a regression **floor** (`scripts/check-coverage.js`) that ratchets upward as coverage climbs. Current coverage is ~99% lines / 98% statements / 97% functions / 92% branches, with the floor set just below at Lines 99%, Statements 97%, Functions 96%, Branches 91%.
 
 ### E2E Tests
 

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -17,10 +17,10 @@ const __dirname = dirname(__filename);
 // (composables/utils) is ~100%; views and components are being backfilled with
 // unit tests, so raise these numbers as coverage climbs.
 const THRESHOLDS = {
-  lines: 96,
-  statements: 95,
-  functions: 91,
-  branches: 85,
+  lines: 99,
+  statements: 97,
+  functions: 96,
+  branches: 91,
 };
 
 const COVERAGE_SUMMARY_PATH = join(__dirname, '../coverage/coverage-summary.json');

--- a/src/views/ContactView.test.ts
+++ b/src/views/ContactView.test.ts
@@ -47,6 +47,24 @@ describe('ContactView', () => {
     expect(error.text()).toBe('Name is required');
   });
 
+  it('validates email and message on blur and accepts optional subject input', async () => {
+    const wrapper = await mountView(ContactView);
+
+    const email = wrapper.get('#email');
+    await email.trigger('blur');
+    expect(email.attributes('aria-invalid')).toBe('true');
+    expect(wrapper.get('#email-error').text()).toBe('Email is required');
+
+    const message = wrapper.get('#message');
+    await message.trigger('blur');
+    expect(message.attributes('aria-invalid')).toBe('true');
+    expect(wrapper.get('#message-error').text()).toBe('Message is required');
+
+    const subject = wrapper.get('#subject');
+    await subject.setValue('Commission enquiry');
+    expect((subject.element as HTMLInputElement).value).toBe('Commission enquiry');
+  });
+
   it('shows the success message after a successful submit', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response);
     const wrapper = await mountView(ContactView);

--- a/src/views/PressView.test.ts
+++ b/src/views/PressView.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { createHead } from '@unhead/vue/client';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+import { createMemoryHistory, createRouter } from 'vue-router';
 
 import { pressQuotes } from '@/data/press';
 import { mountView } from '@/test-support/viewHarness';
@@ -6,6 +10,27 @@ import { mountView } from '@/test-support/viewHarness';
 import PressView from './PressView.vue';
 
 describe('PressView', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('scrolls the targeted quote into view when the hash changes', async () => {
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+    });
+    await router.push('/');
+    await router.isReady();
+    mount(PressView, { global: { plugins: [router, createHead()] }, attachTo: document.body });
+    await nextTick(); // useHashScroll clears isInitialLoad after the first tick
+
+    await router.push({ hash: `#${pressQuotes[0].id}` });
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
   it('renders a blockquote for every press quote, keyed by id', async () => {
     const wrapper = await mountView(PressView);
     const quotes = wrapper.findAll('blockquote');


### PR DESCRIPTION
## Description
Closes the two remaining meaningful unit-coverage gaps left after today's refactor/extraction backlog (#120–#132), then raises the CI regression floor to lock in the gains so they can't silently erode.

## Changes
- **ContactView** — new test drives email + message blur validation and optional-subject input. Takes the view from 80% → 100% statements / 94.6% branches.
- **PressView** — new test asserts the hash-driven `scrollIntoView`. `useHashScroll` runs with `immediate: false`, so the initial hash is not processed; the test mounts with a controllable memory router and pushes a hash change *after* mount (once `isInitialLoad` clears) to fire the handler.
- **Coverage floor** (`scripts/check-coverage.js`) — ratcheted from `96/95/91/85` → `99/97/96/91`, sitting just below current coverage (99.36 / 98.16 / 97.29 / 92.09) with ~1-point noise margin.
- **README** — coverage note updated to match the new numbers and floor.

## Refactor assessment
No production code touched — test-only additions plus a config/doc bump. No extraction candidates surfaced; the two new tests reuse the existing `mountView` harness (PressView additionally mounts inline because the harness intentionally doesn't expose its router).

## Remaining uncovered (deliberately not chased)
The residual gaps are defensive / edge branches whose tests would be contrived for negative value: element-not-found guards (`useAccordion` 32–34/40/46/56), no-focusable-element focus-trap fallback (`LightboxOverlay` 68–70), dateless-event / null-title branches (`EventItem` 33/73), nav-close animation timer (`SiteHeader` 18), and `||`/`??` fallbacks on always-present data (`LiveView`, `WorksView`, `live.ts`, `pageSchemas`, `App.vue`).

## Testing
1. `git fetch && gh pr checkout <this-PR>`
2. `npm ci`
3. `npm run test:coverage` — Vitest passes; the summary prints **Lines 99.36 / Statements 98.16 / Functions 97.29 / Branches 92.09**, all above the new floors.
4. `node scripts/check-coverage.js` — prints "✅ All coverage thresholds met!" against thresholds 99/97/96/91.
5. Optionally revert either new test and re-run step 4 to confirm the floor now fails a regression it previously tolerated.

## Acceptance Criteria
- [x] Meaningful coverage gaps (ContactView, PressView) closed with behavioural tests
- [x] Regression floor raised to just below current coverage
- [x] README coverage note reflects current numbers and floor
- [x] Full local gate green (type-check, lint, coverage, build)