### PR TITLE
refactor: collapse the Release union into one capability-typed interface

### DIFF
--- a/src/components/ReleaseItem.test.ts
+++ b/src/components/ReleaseItem.test.ts
@@ -1,14 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 
-import type {
-  BandcampRelease,
-  CollaborationRelease,
-  ExternalRelease,
-  MasteringCredit,
-  PublicationRelease,
-  Release,
-} from '@/types';
+import type { Release } from '@/types';
 
 import BandcampPlayer from './BandcampPlayer.vue';
 import ReleaseItem from './ReleaseItem.vue';
@@ -16,7 +9,7 @@ import ReleaseItem from './ReleaseItem.vue';
 const mountRelease = (release: Release, textOnly = false) =>
   mount(ReleaseItem, { props: { release, textOnly } });
 
-const bandcamp: BandcampRelease = {
+const bandcamp: Release = {
   id: 'overlapse',
   title: 'Overlapse',
   meta: 'Digital — BRØQN, 2012',
@@ -27,7 +20,7 @@ const bandcamp: BandcampRelease = {
   credits: 'Music by Jerome Faria.',
 };
 
-const external: ExternalRelease = {
+const external: Release = {
   id: 'ect',
   title: 'ECT',
   meta: 'Digital — Test Tube, 2005',
@@ -37,7 +30,7 @@ const external: ExternalRelease = {
   credits: 'Music by Jerome Faria.',
 };
 
-const staticCover: CollaborationRelease = {
+const staticCover: Release = {
   id: 'depolarized',
   title: 'Depolarized',
   meta: 'Digital — BRØQN, 2012',
@@ -45,7 +38,7 @@ const staticCover: CollaborationRelease = {
   credits: 'Music by Jerome Faria and Nelson P. Ferreira.',
 };
 
-const textOnlyRelease: MasteringCredit = {
+const textOnlyRelease: Release = {
   id: 'master-open',
   title: 'Open',
   meta: 'Hugo Calcio, 2021',
@@ -67,7 +60,7 @@ describe('ReleaseItem', () => {
   });
 
   it('flags an external cover that links to Bandcamp with a modifier class', () => {
-    const bandcampExternal: ExternalRelease = {
+    const bandcampExternal: Release = {
       id: 'bc-ext',
       title: 'BC External',
       meta: 'Digital, 2020',
@@ -129,7 +122,7 @@ describe('ReleaseItem', () => {
   });
 
   it('emits open-lightbox with converted images from the gallery button', async () => {
-    const publication: PublicationRelease = {
+    const publication: Release = {
       id: 'glitch',
       title: 'Glitch',
       meta: 'Book, 2009',
@@ -153,7 +146,7 @@ describe('ReleaseItem', () => {
   });
 
   it('emits open-lightbox with converted videos from the video button', async () => {
-    const withVideo: CollaborationRelease = {
+    const withVideo: Release = {
       id: 'altar',
       title: 'ALTAR',
       meta: 'Digital/Cassette, 2024',
@@ -186,7 +179,7 @@ describe('ReleaseItem', () => {
   });
 
   it('pluralizes the video button and separates it from the gallery link', () => {
-    const withBoth: PublicationRelease = {
+    const withBoth: Release = {
       id: 'glitch',
       title: 'Glitch',
       meta: 'Book, 2009',

--- a/src/types/works.ts
+++ b/src/types/works.ts
@@ -1,67 +1,5 @@
 import type { Photographer } from './lightbox';
 
-export interface BaseRelease {
-  id: string;
-  title: string;
-  meta: string;
-  credits?: string;
-  videos?: VideoItem[];
-}
-
-export interface BandcampRelease extends BaseRelease {
-  bandcampId: string;
-  coverImage: string;
-  bandcampUrl: string;
-  tracklist: string[];
-  credits: string;
-}
-
-export interface ExternalRelease extends BaseRelease {
-  coverImage: string;
-  externalUrl: string;
-  tracklist: string[];
-  credits: string;
-}
-
-export interface FilmScore extends BaseRelease {
-  coverImage: string;
-  description: string;
-  credits: string;
-  tracklist?: string[];
-}
-
-export interface PublicationRelease extends BaseRelease {
-  coverImage: string;
-  externalUrl: string;
-  description: string;
-  credits: string;
-  images: Image[];
-}
-
-export interface CompilationTrack {
-  id: string;
-  title: string;
-  meta: string;
-}
-
-export interface MasteringCredit {
-  id: string;
-  title: string;
-  meta: string;
-  externalUrl?: string;
-}
-
-export interface CollaborationRelease extends BaseRelease {
-  bandcampId?: string;
-  coverImage?: string;
-  bandcampUrl?: string;
-  tracklist?: string[];
-  credits: string;
-  description?: string;
-}
-
-export type Release = BandcampRelease | ExternalRelease | FilmScore | PublicationRelease | CompilationTrack | MasteringCredit | CollaborationRelease;
-
 export interface VideoItem {
   url: string;
   title: string;
@@ -78,32 +16,47 @@ export interface Image {
   };
 }
 
+export interface Release {
+  id: string;
+  title: string;
+  meta: string;
+  bandcampId?: string;
+  bandcampUrl?: string;
+  externalUrl?: string;
+  coverImage?: string;
+  tracklist?: string[];
+  description?: string;
+  credits?: string;
+  images?: Image[];
+  videos?: VideoItem[];
+}
+
 export const hasBandcampId = (release: Release): release is Release & { bandcampId: string } =>
-  'bandcampId' in release && Boolean(release.bandcampId);
+  Boolean(release.bandcampId);
 
 export const hasBandcampUrl = (release: Release): release is Release & { bandcampUrl: string } =>
-  'bandcampUrl' in release && Boolean(release.bandcampUrl);
+  Boolean(release.bandcampUrl);
 
 export const hasExternalUrl = (release: Release): release is Release & { externalUrl: string } =>
-  'externalUrl' in release && Boolean(release.externalUrl);
+  Boolean(release.externalUrl);
 
 export const hasCoverImage = (release: Release): release is Release & { coverImage: string } =>
-  'coverImage' in release && Boolean(release.coverImage);
+  Boolean(release.coverImage);
 
 export const hasTracklist = (release: Release): release is Release & { tracklist: string[] } =>
-  'tracklist' in release && Boolean(release.tracklist);
+  Boolean(release.tracklist);
 
 export const hasDescription = (release: Release): release is Release & { description: string } =>
-  'description' in release && Boolean(release.description);
+  Boolean(release.description);
 
 export const hasCredits = (release: Release): release is Release & { credits: string } =>
-  'credits' in release && Boolean(release.credits);
+  Boolean(release.credits);
 
 export const hasImages = (release: Release): release is Release & { images: Image[] } =>
-  'images' in release && Boolean(release.images);
+  Boolean(release.images);
 
 export const hasVideos = (release: Release): release is Release & { videos: VideoItem[] } =>
-  'videos' in release && Boolean(release.videos);
+  Boolean(release.videos);
 
 export interface WorksSection {
   title: string;


### PR DESCRIPTION
## Description
First of five data-structure improvements. Collapses the 7-member `Release` union into a single interface with optional capability fields, keeping the existing `has*` capability guards.

## Why
Investigation of the two consumers showed neither branches on release *kind*:
- `ReleaseItem.vue` renders entirely by capability — `hasBandcampId && hasCoverImage` → player, `hasCoverImage` → cover, `hasTracklist`, `hasDescription`, `hasCredits`, `hasImages/hasVideos`.
- `pageSchemas.ts` filters by `hasBandcampId(release) || hasBandcampUrl(release)`.

The union's 7 members were never distinguished as kinds — they only enumerated which fields co-occur. A `kind` discriminant would have been the wrong abstraction (the template would have to enumerate every kind carrying a given field). The capability guards are the correct model, so the honest simplification is to collapse the union *around* them.

## Changes
- `src/types/works.ts` — replace `BaseRelease` + 7 member interfaces with one `Release` interface (identity fields required, capability fields optional). Guards unchanged in behaviour; each simplified to drop the now-redundant `'field' in release` check (every field is declared on the single interface). **−54 net lines.**
- `src/components/ReleaseItem.test.ts` — fixture annotations retargeted from the removed member names to `Release`.

## Refactor assessment
Type-only change; no data values touched (the `worksData` literals are unchanged and still satisfy the looser type), so no golden `deepEqual` migration test applies here. No further extraction surfaced.

## Testing
No behavioural change — this is compiler-guarded. To verify:
1. `gh pr checkout <this-PR> && npm ci`
2. `npm run build` — type-checks and builds (the real safety net: every guard consumer still narrows correctly).
3. `npm run test:coverage` — full suite green; coverage unchanged at 99.36 / 98.16 / 97.29 / 92.09 (ReleaseItem render tests exercise every capability branch).
4. Load `/works` — every release still renders its player / cover / tracklist / credits / gallery exactly as before.

## Acceptance Criteria
- [x] `Release` is a single interface; the 7 member types are gone
- [x] Capability guards retained and simplified
- [x] No runtime or data-value change
- [x] Full local gate green (tsc, lint, coverage, build)