### PR TITLE
feat: open external links in a new tab with a page-level cue

### DIFF
--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue';
 import { useAccordionVisibility } from '@/composables/useAccordionContext';
 import type { LightboxItem, Release } from '@/types';
 import { hasBandcampId, hasCoverImage, hasCredits, hasDescription, hasExternalUrl, hasImages, hasTracklist, hasVideos } from '@/types';
+import { externalizeLinks } from '@/utils/externalizeLinks';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
 import BandcampPlayer from './BandcampPlayer.vue';
@@ -80,7 +81,7 @@ const isBandcampLink = computed(() =>
       <p
         v-if="hasDescription(release)"
         class="release-description"
-        v-html="release.description"
+        v-html="externalizeLinks(release.description)"
       />
       <ol v-if="hasTracklist(release) && release.tracklist.length">
         <li
@@ -92,7 +93,7 @@ const isBandcampLink = computed(() =>
       <p
         v-if="hasCredits(release)"
         class="release-credits"
-        v-html="release.credits"
+        v-html="externalizeLinks(release.credits)"
       />
       <MediaLinks
         :images="imageLightboxItems"

--- a/src/components/ReleaseMeta.test.ts
+++ b/src/components/ReleaseMeta.test.ts
@@ -1,0 +1,49 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import ReleaseMeta from './ReleaseMeta.vue';
+
+describe('ReleaseMeta', () => {
+  it('opens a linked label in a new tab with a safe rel', () => {
+    const wrapper = mount(ReleaseMeta, {
+      props: {
+        meta: {
+          kind: 'music',
+          mediums: ['Digital'],
+          editions: [{ label: { text: 'Enough Records', url: 'https://enoughrecords.scene.org/' } }],
+          year: 2004,
+        },
+      },
+    });
+    const anchor = wrapper.get('a');
+
+    expect(anchor.attributes('href')).toBe('https://enoughrecords.scene.org/');
+    expect(anchor.attributes('target')).toBe('_blank');
+    expect(anchor.attributes('rel')).toBe('noopener noreferrer');
+  });
+
+  it('renders a plain-text label without an anchor', () => {
+    const wrapper = mount(ReleaseMeta, {
+      props: { meta: { kind: 'music', mediums: ['Digital'], editions: [{ label: { text: 'BRØQN' } }], year: 2012 } },
+    });
+
+    expect(wrapper.find('a').exists()).toBe(false);
+    expect(wrapper.text()).toContain('BRØQN');
+  });
+
+  it('wraps a compilation title in an emphasis element', () => {
+    const wrapper = mount(ReleaseMeta, {
+      props: {
+        meta: {
+          kind: 'compilation',
+          compilation: { text: 'Dark Vault', url: 'https://example.com/dv' },
+          mediums: ['MP3'],
+          editions: [{ label: { text: 'Enough Records' } }],
+          year: 2004,
+        },
+      },
+    });
+
+    expect(wrapper.get('em a').attributes('href')).toBe('https://example.com/dv');
+  });
+});

--- a/src/components/ReleaseMeta.vue
+++ b/src/components/ReleaseMeta.vue
@@ -5,7 +5,9 @@ import type { MetaLink, ReleaseMeta } from '@/types/works';
 import { buildMetaSegments } from '@/utils/metaSegments';
 
 const renderLink = (link: MetaLink): VNode | string =>
-  link.url ? h('a', { href: link.url }, link.text) : link.text;
+  link.url
+    ? h('a', { href: link.url, target: '_blank', rel: 'noopener noreferrer' }, link.text)
+    : link.text;
 
 export default defineComponent({
   name: 'ReleaseMeta',

--- a/src/utils/externalizeLinks.test.ts
+++ b/src/utils/externalizeLinks.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { externalizeLinks } from './externalizeLinks';
+
+describe('externalizeLinks', () => {
+  it('opens external anchors in a new tab with a safe rel', () => {
+    expect(externalizeLinks('Music by <a href="https://aires.bandcamp.com/">Aires</a>.'))
+      .toBe('Music by <a href="https://aires.bandcamp.com/" target="_blank" rel="noopener noreferrer">Aires</a>.');
+  });
+
+  it('marks every external anchor in the string', () => {
+    const html = '<a href="https://a.com">A</a> and <a href="https://b.com">B</a>';
+    const result = externalizeLinks(html);
+
+    expect(result.match(/target="_blank"/g)).toHaveLength(2);
+  });
+
+  it('leaves relative and hash links untouched', () => {
+    const html = '<a href="/works">Works</a> and <a href="#anchor">Anchor</a>';
+
+    expect(externalizeLinks(html)).toBe(html);
+  });
+
+  it('returns plain text unchanged', () => {
+    expect(externalizeLinks('Music by Jerome Faria.')).toBe('Music by Jerome Faria.');
+  });
+});

--- a/src/utils/externalizeLinks.ts
+++ b/src/utils/externalizeLinks.ts
@@ -1,0 +1,7 @@
+// Rewrites external anchors in trusted prose HTML (credits, descriptions) so
+// they open in a new tab with a safe rel, matching the structured meta links.
+// This runs at render time — unlike a mounted directive — so the attributes are
+// present in the pre-rendered SSG output, not only after client hydration. The
+// content is our own static data, so a targeted string rewrite is safe here.
+export const externalizeLinks = (html: string): string =>
+  html.replace(/<a href="(https?:\/\/[^"]*)">/gi, '<a href="$1" target="_blank" rel="noopener noreferrer">');

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -30,6 +30,9 @@ const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
       data-page="works"
       title="Works"
     >
+      <p class="visually-hidden">
+        External links open in a new tab.
+      </p>
       <AccordionSection
         v-for="sectionKey in worksSections"
         :id="sectionKey"


### PR DESCRIPTION
## Description
Phase 2 of the meta rework. Unifies external-link behaviour across the works page — **behaviour change, so opening for review rather than auto-merging.**

## What changes
- **Structured meta links** (label, compilation, director, venue, publisher, artist, ISBN — rendered by `ReleaseMeta`) now open in a new tab with `rel="noopener noreferrer"`.
- **Prose links** in `credits`/`description` (54 anchors, `v-html`) get the same treatment via `externalizeLinks`, a render-time string rewrite.
- **One page-level cue** — a visually-hidden "External links open in a new tab." note on the works page — instead of a per-link "(opens in a new tab)" on all ~72 links.

## Why a render-time transform, not a directive
A `mounted` directive only runs client-side, so the attributes would be missing from the pre-rendered SSG HTML and appear only after hydration. `externalizeLinks` runs during render, so `target`/`rel` are in `dist/works.html` directly — verified. Content is our own trusted static data, so a targeted string rewrite is safe.

## Why page-level cue, not per-link
The works page is link-dense (the Glitch card alone has ~30 links). `ExternalLink`'s per-link visually-hidden cue would make a screen reader announce "opens in a new tab" 70+ times per page. A single page-level note is the link-dense-page convention. `ExternalLink` (with its per-link cue) stays as-is for the sparse live page — both now open external links in a new tab; only the cue strategy differs by density.

## No visual change
`target`/`rel` are invisible; the cue is visually-hidden. The only user-visible difference is the new-tab behaviour on click — hence review rather than auto-merge.

## Testing
1. `gh pr checkout <this-PR> && npm ci && npm run build`
2. In `dist/works.html`, confirm meta and prose anchors carry `target="_blank" rel="noopener noreferrer"`, and the visually-hidden note is present.
3. `npm run dev`, open `/works`, click any label/credit link → opens in a new tab. Internal links (title `#permalink`) still open same-tab.
4. `npm run test:coverage` — 360 pass; coverage 99.55 / 98.53 / 97.83 / 92.4.

## Decisions for you
- Page-level cue vs per-link (built page-level per our discussion).
- Same-tab title permalinks left untouched (internal).
- Live page keeps `ExternalLink`'s per-link cue (sparse) — flag if you'd rather unify the cue strategy site-wide.

## Acceptance Criteria
- [x] All works-page external links open in a new tab with safe rel, in the SSG output
- [x] Single page-level a11y note; no per-link cue on the dense page
- [x] Internal/hash links untouched
- [x] Full local gate green