### PR TITLE
refactor: drop unused image transform fields from the live and lightbox paths

### DIFF
--- a/src/types/lightbox.ts
+++ b/src/types/lightbox.ts
@@ -11,9 +11,6 @@ export interface LightboxImage {
   type: 'image';
   src: string;
   alt: string;
-  position?: string;
-  scale?: number;
-  rotate?: number;
   photographer?: Photographer;
 }
 

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -3,9 +3,6 @@ import type { Photographer } from './lightbox';
 export interface LiveImage {
   src: string;
   alt: string;
-  position?: string;
-  scale?: number;
-  rotate?: number;
   photographer?: Photographer;
 }
 

--- a/src/utils/lightboxAdapters.test.ts
+++ b/src/utils/lightboxAdapters.test.ts
@@ -7,12 +7,12 @@ describe('toLightboxImage', () => {
     expect(toLightboxImage({ src: '/a.jpg', alt: 'A' })).toEqual({ type: 'image', src: '/a.jpg', alt: 'A' });
   });
 
-  it('copies optional layout and credit fields when present', () => {
+  it('copies the photographer credit when present', () => {
     const photographer = { name: 'Jane', url: 'https://example.com/jane' };
 
     expect(
-      toLightboxImage({ src: '/a.jpg', alt: 'A', position: 'top', scale: 1.2, rotate: 3, photographer }),
-    ).toEqual({ type: 'image', src: '/a.jpg', alt: 'A', position: 'top', scale: 1.2, rotate: 3, photographer });
+      toLightboxImage({ src: '/a.jpg', alt: 'A', photographer }),
+    ).toEqual({ type: 'image', src: '/a.jpg', alt: 'A', photographer });
   });
 });
 

--- a/src/utils/lightboxAdapters.ts
+++ b/src/utils/lightboxAdapters.ts
@@ -5,9 +5,6 @@ import type { LightboxImage, LightboxVideo, Photographer } from '@/types/lightbo
 interface LightboxImageSource {
   src: string;
   alt: string;
-  position?: string;
-  scale?: number;
-  rotate?: number;
   photographer?: Photographer;
 }
 
@@ -18,12 +15,9 @@ interface LightboxVideoSource {
   author?: Photographer;
 }
 
-/** Map a domain image to a lightbox image item, copying optional fields when present. */
+/** Map a domain image to a lightbox image item, copying the credit when present. */
 export const toLightboxImage = (image: LightboxImageSource): LightboxImage => {
   const item: LightboxImage = { type: 'image', src: image.src, alt: image.alt };
-  if (image.position) item.position = image.position;
-  if (image.scale) item.scale = image.scale;
-  if (image.rotate) item.rotate = image.rotate;
   if (image.photographer) item.photographer = image.photographer;
   return item;
 };


### PR DESCRIPTION
## Description
Phase 3, part 1. Removes `position/scale/rotate` where they are dead, keeping them where they are used.

## Findings
- **Alive — kept:** the About grid styles each image from `about.ts`'s `position/scale/rotate` via `getImageStyles` (`AboutView.vue`). Legitimate per-image display tuning. `AboutImage`, `getImageStyles`, and `ImageWithTransforms` are untouched.
- **Dead — removed:** `LightboxImage` declared the three fields and `toLightboxImage` copied them, but `LightboxOverlay` never renders them (the lightbox shows the full, untransformed image). And `LiveImage` declared them although **0 of 134** live images set any, and `EventItem` never applies `getImageStyles`.

So this isn't "move CSS out of data" (About genuinely needs per-image tuning) — it's removing never-read plumbing.

## Changes
- `types/live.ts` — drop `position/scale/rotate` from `LiveImage`.
- `types/lightbox.ts` — drop them from `LightboxImage`.
- `utils/lightboxAdapters.ts` — drop them from `LightboxImageSource` and stop copying them.
- `utils/lightboxAdapters.test.ts` — the copy test now asserts only the photographer credit.

## Output is unchanged
- `tsc` confirms nothing else referenced the removed fields.
- The About page still emits its inline `object-position`/`transform` styles in `dist/about.html` (25 instances, unchanged) — the only place these values were ever rendered.

## Testing
1. `gh pr checkout <this-PR> && npm ci && npm run build`
2. Load `/about` — image crops/scales render exactly as before.
3. `npm run test:coverage` — 360 pass; coverage 99.39 / 98.25 / 97.4 / 92.1.

## Acceptance Criteria
- [x] Dead `position/scale/rotate` removed from live + lightbox paths
- [x] About's per-image tuning kept and verified unchanged
- [x] Full local gate green