### PR TITLE
refactor: hoist repeated per-image alt to an event-level imageAlt

### DIFF
--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -108,6 +108,22 @@ describe('EventItem', () => {
       ]);
     });
 
+    it('falls back to the event imageAlt when an image has no alt of its own', async () => {
+      const wrapper = mountEvent({
+        ...plainEvent,
+        imageAlt: 'Event-level description',
+        images: [{ src: '/images/live/a-001.jpg' }, { src: '/images/live/a-002.jpg', alt: 'Override' }],
+      });
+
+      await wrapper.get('.media-links button').trigger('click');
+      const payload = wrapper.emitted('open-lightbox')?.[0];
+
+      expect((payload?.[0] as Array<{ alt: string }>).map(item => item.alt)).toEqual([
+        'Event-level description',
+        'Override',
+      ]);
+    });
+
     it('renders no media control when the event has neither images nor videos', () => {
       const wrapper = mountEvent(plainEvent);
       expect(wrapper.find('.media-links').exists()).toBe(false);

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -36,7 +36,9 @@ const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? '
 const venueLocation = computed(() =>
   [props.event.venue.city, props.event.venue.country].filter(Boolean).join(', '));
 
-const imageLightboxItems = computed<LightboxItem[]>(() => props.event.images?.map(toLightboxImage) ?? []);
+const imageLightboxItems = computed<LightboxItem[]>(() =>
+  props.event.images?.map(image =>
+    toLightboxImage({ ...image, alt: image.alt ?? props.event.imageAlt ?? '' })) ?? []);
 const videoLightboxItems = computed<LightboxItem[]>(() => props.event.videos?.map(toLightboxVideo) ?? []);
 const imageLabel = computed(() => `View ${imageLightboxItems.value.length === 1 ? 'photo' : 'photos'}`);
 </script>

--- a/src/data/live.test.ts
+++ b/src/data/live.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { liveData } from './live';
+
+// The event-level image alt exactly as each was written per-image before it was
+// hoisted to the event. Guards the hoist (and future edits) against drift.
+const IMAGE_ALT: Record<string, string> = {
+  'showcase-casa-amarela': 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
+  'fim-de-emissao-45': 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
+  'cca-no-desterro': 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
+  'amess-teatro-baltazar-dias': 'Jerome Faria performing with Amess at Teatro Municipal Baltazar Dias, Funchal, 2022',
+  'amess-museu-franco': 'Jerome Faria performing with Amess at Museu Henrique e Francisco Franco, Funchal, 2022',
+  'jejum-11': 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
+  'nariz-entupido': 'Jerome Faria and CAVERNANCIA performing at Nariz Entupido, SMUP, Parede, 2021',
+  'aragao-funchal': 'Aragão theatre production at Teatro Municipal Baltazar Dias, Funchal, 2021',
+  'heineken-series': 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
+  'fica-na-cidade': 'Jerome Faria performing at Fica na Cidade, Praça de Colombo, Funchal, 2015',
+  'caligari-live-2': 'Jerome Faria performing The Cabinet of Dr. Caligari at Scat Music Club, Funchal, 2013',
+  'caligari-live': 'Jerome Faria performing at Cidades Eletrónicas: The Cabinet of Dr. Caligari, Casa das Mudas, Calheta, 2013',
+  'madeiradig-2011': 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
+  'migractions-2011': 'Jerome Faria and Hugo Olim performing at Festival Migractions, Théâtre de L\'Opprimé, Paris, 2011',
+  'olhares-de-outono-2010': 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
+  'madeiradig-2009': 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
+  'eme-olhares-2009': 'Resampling White Noise laptop meeting at EME.LL / Olhares de Outono, Mosteiro São Bento da Vitória, Porto, 2009',
+  'eme-2008': 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
+  'storung-2008': 'Jerome Faria performing at Störung Festival, La Farinera del Clot, Barcelona, 2008',
+  'stfu-porto': 'Jerome Faria performing at STFU Porto, Fábrica do Som, Porto, 2007',
+  'madeiradig-2007': 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
+  'madeiradig-2005': 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
+};
+
+const events = Object.values(liveData).flatMap(section => section.items);
+
+describe('liveData image alts', () => {
+  it('has an imageAlt snapshot for exactly the image-bearing events', () => {
+    const withImages = events.filter(event => event.images?.length).map(event => event.id).sort();
+    expect(withImages).toEqual(Object.keys(IMAGE_ALT).sort());
+  });
+
+  it('preserves each event-level image alt after hoisting', () => {
+    for (const event of events) {
+      if (event.images?.length) {
+        expect(event.imageAlt, `id="${event.id}"`).toBe(IMAGE_ALT[event.id]);
+      }
+    }
+  });
+});

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -31,60 +31,50 @@ export const liveData: LiveData = {
         date: '2025-06-14',
         venue: { name: 'Cooperativa Mula', url: 'https://www.instagram.com/cooperativamula/', city: 'Barreiro', country: 'Portugal' },
         description: 'NOx (with <a href="https://cavernancia.bandcamp.com/">Pedro Roque</a>). With <a href="https://copodagua.bandcamp.com/">Copo d\'Água</a>, TiaAvô, Rebolation All-Stars.',
+        imageAlt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
         images: [
           {
             src: '/images/live/showcase-casa-amarela-001.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-002.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-003.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-004.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-005.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-006.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-007.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-008.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-010.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-011.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
           {
             src: '/images/live/showcase-casa-amarela-012.jpg',
-            alt: 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
             photographer: { name: 'Ricardo Almeida', url: 'https://www.instagram.com/ricardojosealmeida/' },
           },
         ],
@@ -95,45 +85,38 @@ export const liveData: LiveData = {
         date: '2025-01-17',
         venue: { name: 'Desterro', url: 'https://darc.pt', city: 'Lisbon', country: 'Portugal' },
         description: 'Solo performance. With Ai Feith, W.T.V.R.',
+        imageAlt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
         images: [
           {
             src: '/images/live/fim-de-emissao-45-001.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
           {
             src: '/images/live/fim-de-emissao-45-002.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
           {
             src: '/images/live/fim-de-emissao-45-003.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
           {
             src: '/images/live/fim-de-emissao-45-004.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
           {
             src: '/images/live/fim-de-emissao-45-005.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
           {
             src: '/images/live/fim-de-emissao-45-006.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
           {
             src: '/images/live/fim-de-emissao-45-007.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
           {
             src: '/images/live/fim-de-emissao-45-008.jpg',
-            alt: 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
             photographer: { name: 'Pedro Roque', url: 'https://eyesofmadness-photography.blogspot.com/' },
           },
         ],
@@ -157,80 +140,66 @@ export const liveData: LiveData = {
         date: '2024-05-02',
         venue: { name: 'Desterro', url: 'https://darc.pt', city: 'Lisbon', country: 'Portugal' },
         description: 'NOx (with <a href="https://cavernancia.bandcamp.com/">Pedro Roque</a>). With <a href="https://copodagua.bandcamp.com/">Copo d\'Água</a>, <a href="https://soundcloud.com/djprivilegio">DJ Privilégio</a>, <a href="https://casaamarela.bandcamp.com/album/shimano">Gallo\'84</a>.',
+        imageAlt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
         images: [
           {
             src: '/images/live/cca-no-desterro-001.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Daniela Jácome', url: 'https://www.instagram.com/danielajacomeph/' },
           },
           {
             src: '/images/live/cca-no-desterro-002.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Daniela Jácome', url: 'https://www.instagram.com/danielajacomeph/' },
           },
           {
             src: '/images/live/cca-no-desterro-003.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Daniela Jácome', url: 'https://www.instagram.com/danielajacomeph/' },
           },
           {
             src: '/images/live/cca-no-desterro-004.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Daniela Jácome', url: 'https://www.instagram.com/danielajacomeph/' },
           },
           {
             src: '/images/live/cca-no-desterro-005.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Daniela Jácome', url: 'https://www.instagram.com/danielajacomeph/' },
           },
           {
             src: '/images/live/cca-no-desterro-006.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-007.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-008.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-009.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-010.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-011.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-012.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-013.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-014.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/cca-no-desterro-015.jpg',
-            alt: 'NOx performing at CCA no Desterro, Desterro, Lisbon, 2024',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
         ],
@@ -255,20 +224,18 @@ export const liveData: LiveData = {
         date: '2022-07-02',
         venue: { name: 'Teatro Municipal Baltazar Dias', url: 'https://www.teatromunicipal.pt/', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://www.instagram.com/amess.music/">Amess</a>.',
+        imageAlt: 'Jerome Faria performing with Amess at Teatro Municipal Baltazar Dias, Funchal, 2022',
         images: [
           {
             src: '/images/live/amess-teatro-baltazar-dias-001.jpg',
-            alt: 'Jerome Faria performing with Amess at Teatro Municipal Baltazar Dias, Funchal, 2022',
             photographer: { name: 'Óscar Silva', url: 'https://www.instagram.com/oscar_silva95/' },
           },
           {
             src: '/images/live/amess-teatro-baltazar-dias-002.jpg',
-            alt: 'Jerome Faria performing with Amess at Teatro Municipal Baltazar Dias, Funchal, 2022',
             photographer: { name: 'Óscar Silva', url: 'https://www.instagram.com/oscar_silva95/' },
           },
           {
             src: '/images/live/amess-teatro-baltazar-dias-003.jpg',
-            alt: 'Jerome Faria performing with Amess at Teatro Municipal Baltazar Dias, Funchal, 2022',
             photographer: { name: 'Óscar Silva', url: 'https://www.instagram.com/oscar_silva95/' },
           },
         ],
@@ -279,30 +246,26 @@ export const liveData: LiveData = {
         date: '2022-03-18',
         venue: { name: 'Museu Henrique e Francisco Franco', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=3', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://www.instagram.com/amess.music/">Amess</a>.',
+        imageAlt: 'Jerome Faria performing with Amess at Museu Henrique e Francisco Franco, Funchal, 2022',
         images: [
           {
             src: '/images/live/amess-museu-franco-001.jpg',
-            alt: 'Jerome Faria performing with Amess at Museu Henrique e Francisco Franco, Funchal, 2022',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/amess-museu-franco-002.jpg',
-            alt: 'Jerome Faria performing with Amess at Museu Henrique e Francisco Franco, Funchal, 2022',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/amess-museu-franco-003.jpg',
-            alt: 'Jerome Faria performing with Amess at Museu Henrique e Francisco Franco, Funchal, 2022',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/amess-museu-franco-004.jpg',
-            alt: 'Jerome Faria performing with Amess at Museu Henrique e Francisco Franco, Funchal, 2022',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/amess-museu-franco-005.jpg',
-            alt: 'Jerome Faria performing with Amess at Museu Henrique e Francisco Franco, Funchal, 2022',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
         ],
@@ -312,75 +275,62 @@ export const liveData: LiveData = {
         title: 'Jejum #11',
         date: '2022-03-05',
         venue: { name: 'Rua das Gaivotas 6', url: 'https://ruadasgaivotas6.pt/', city: 'Lisbon', country: 'Portugal' },
+        imageAlt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
         images: [
           {
             src: '/images/live/jejum-11-001.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-002.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-003.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-004.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-005.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-006.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-007.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-008.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-009.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-010.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-011.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-013.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-014.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/jejum-11-015.jpg',
-            alt: 'Jerome Faria performing at Jejum #11, Rua das Gaivotas 6, Lisbon, 2022',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
         ],
@@ -404,25 +354,22 @@ export const liveData: LiveData = {
         date: '2021-10-22',
         venue: { name: 'SMUP', url: 'https://www.smup.pt/', city: 'Parede', country: 'Portugal' },
         description: 'Duo with <a href="https://cavernancia.bandcamp.com/">CAVERNANCIA</a>. <a href="https://thisco.bandcamp.com/">THISCO</a> / SPH anniversary celebration.',
+        imageAlt: 'Jerome Faria and CAVERNANCIA performing at Nariz Entupido, SMUP, Parede, 2021',
         images: [
           {
             src: '/images/live/nariz-entupido-001.jpg',
-            alt: 'Jerome Faria and CAVERNANCIA performing at Nariz Entupido, SMUP, Parede, 2021',
             photographer: { name: 'Ricardo Nogueira', url: 'https://www.instagram.com/nogueirafoto/' },
           },
           {
             src: '/images/live/nariz-entupido-002.jpg',
-            alt: 'Jerome Faria and CAVERNANCIA performing at Nariz Entupido, SMUP, Parede, 2021',
             photographer: { name: 'Ricardo Nogueira', url: 'https://www.instagram.com/nogueirafoto/' },
           },
           {
             src: '/images/live/nariz-entupido-003.jpg',
-            alt: 'Jerome Faria and CAVERNANCIA performing at Nariz Entupido, SMUP, Parede, 2021',
             photographer: { name: 'Ricardo Nogueira', url: 'https://www.instagram.com/nogueirafoto/' },
           },
           {
             src: '/images/live/nariz-entupido-004.jpg',
-            alt: 'Jerome Faria and CAVERNANCIA performing at Nariz Entupido, SMUP, Parede, 2021',
             photographer: { name: 'Ricardo Nogueira', url: 'https://www.instagram.com/nogueirafoto/' },
           },
         ],
@@ -433,10 +380,10 @@ export const liveData: LiveData = {
         date: '2021-09-22',
         venue: { name: 'Teatro Municipal Baltazar Dias', url: 'https://www.teatromunicipal.pt/', city: 'Funchal', country: 'Portugal' },
         description: 'Theatre production. Live music & interpretation.',
+        imageAlt: 'Aragão theatre production at Teatro Municipal Baltazar Dias, Funchal, 2021',
         images: [
           {
             src: '/images/live/aragao-funchal-001.jpg',
-            alt: 'Aragão theatre production at Teatro Municipal Baltazar Dias, Funchal, 2021',
             photographer: { name: 'Mário André Pereira' },
           },
         ],
@@ -460,55 +407,46 @@ export const liveData: LiveData = {
         date: '2015-09-18',
         venue: { name: 'Musicbox', url: 'https://www.musicboxlisboa.com/', city: 'Lisbon', country: 'Portugal' },
         description: 'With <a href="https://www.mmlxii.com/">William Basinski</a>, <a href="https://zigurartists.bandcamp.com/album/forgetting-is-a-liability">Mr. Herbert Quain</a>, <a href="https://www.viberate.com/artist/cruz-767/">Cruz</a>.',
+        imageAlt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
         images: [
           {
             src: '/images/live/heineken-series-001.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-002.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-003.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-004.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-005.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-006.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-007.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-008.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-009.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
           {
             src: '/images/live/heineken-series-010.jpg',
-            alt: 'Jerome Faria performing at Heineken Series, Musicbox, Lisbon, 2015',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
         ],
@@ -519,10 +457,10 @@ export const liveData: LiveData = {
         date: '2015-06-05',
         venue: { name: 'Praça de Colombo', city: 'Funchal', country: 'Portugal' },
         description: 'With <a href="https://trengosoundsystem.bandcamp.com/">Tren Go! Sound System</a>.',
+        imageAlt: 'Jerome Faria performing at Fica na Cidade, Praça de Colombo, Funchal, 2015',
         images: [
           {
             src: '/images/live/fica-na-cidade-001.jpg',
-            alt: 'Jerome Faria performing at Fica na Cidade, Praça de Colombo, Funchal, 2015',
             photographer: { name: 'Fica na Cidade' },
           },
         ],
@@ -553,10 +491,10 @@ export const liveData: LiveData = {
         date: '2013-09-13',
         venue: { name: 'Scat Music Club', city: 'Funchal', country: 'Portugal' },
         description: 'Live score for Robert Wiene\'s 1920 expressionist silent film. With <a href="https://nunoandtheend.bandcamp.com/">Nuno Filipe</a>.',
+        imageAlt: 'Jerome Faria performing The Cabinet of Dr. Caligari at Scat Music Club, Funchal, 2013',
         images: [
           {
             src: '/images/live/caligari-live-2-001.jpg',
-            alt: 'Jerome Faria performing The Cabinet of Dr. Caligari at Scat Music Club, Funchal, 2013',
             photographer: { name: 'Pedro Jafuno', url: 'https://www.instagram.com/jafuno/' },
           },
         ],
@@ -567,10 +505,10 @@ export const liveData: LiveData = {
         date: '2013-05-11',
         venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'Premiere of live score for Robert Wiene\'s 1920 expressionist silent film. With <a href="https://nunoandtheend.bandcamp.com/">Nuno Filipe</a>.',
+        imageAlt: 'Jerome Faria performing at Cidades Eletrónicas: The Cabinet of Dr. Caligari, Casa das Mudas, Calheta, 2013',
         images: [
           {
             src: '/images/live/caligari-cidades-2013-001.jpg',
-            alt: 'Jerome Faria performing at Cidades Eletrónicas: The Cabinet of Dr. Caligari, Casa das Mudas, Calheta, 2013',
           },
         ],
       },
@@ -607,35 +545,30 @@ export const liveData: LiveData = {
         date: '2011-12-02',
         venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'Duo with <a href="https://12k.com/">Taylor Deupree</a>. With <a href="https://sunblind.net/">Tim Hecker</a>, <a href="https://pointnever.com/">Oneohtrix Point Never</a>, <a href="https://ktl10.bandcamp.com/">KTL</a>, <a href="https://deafcenter.bandcamp.com/">Deaf Center</a>, <a href="https://www.leeranaldo.com/">Lee Ranaldo</a> & Manuel Mota, <a href="https://nadja.bandcamp.com/">Nadja</a>, <a href="https://akionda.net/">Aki Onda</a>.',
+        imageAlt: 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
         images: [
           {
             src: '/images/live/madeiradig-2011-001.jpg',
-            alt: 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
             photographer: { name: 'Valentina Araújo' },
           },
           {
             src: '/images/live/madeiradig-2011-002.jpg',
-            alt: 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
             photographer: { name: 'Valentina Araújo' },
           },
           {
             src: '/images/live/madeiradig-2011-003.jpg',
-            alt: 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
             photographer: { name: 'Valentina Araújo' },
           },
           {
             src: '/images/live/madeiradig-2011-004.jpg',
-            alt: 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
             photographer: { name: 'Valentina Araújo' },
           },
           {
             src: '/images/live/madeiradig-2011-005.jpg',
-            alt: 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
             photographer: { name: 'Valentina Araújo' },
           },
           {
             src: '/images/live/madeiradig-2011-006.jpg',
-            alt: 'Jerome Faria and Taylor Deupree performing at MADEIRADIG, Casa das Mudas, Calheta, 2011',
             photographer: { name: 'Valentina Araújo' },
           },
         ],
@@ -646,15 +579,14 @@ export const liveData: LiveData = {
         date: '2011-05-23',
         venue: { name: 'Théâtre de L\'Opprimé', url: 'https://www.theatredelopprime.com/', city: 'Paris', country: 'France' },
         description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>.',
+        imageAlt: 'Jerome Faria and Hugo Olim performing at Festival Migractions, Théâtre de L\'Opprimé, Paris, 2011',
         images: [
           {
             src: '/images/live/migractions-2011-001.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at Festival Migractions, Théâtre de L\'Opprimé, Paris, 2011',
             photographer: { name: 'Sue-Elie Andrade-Dé', url: 'https://cargocollective.com/sueelieandradede' },
           },
           {
             src: '/images/live/migractions-2011-002.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at Festival Migractions, Théâtre de L\'Opprimé, Paris, 2011',
             photographer: { name: 'Sue-Elie Andrade-Dé', url: 'https://cargocollective.com/sueelieandradede' },
           },
         ],
@@ -671,40 +603,34 @@ export const liveData: LiveData = {
         title: 'Olhares de Outono',
         venue: { name: 'Passos Manuel', url: 'https://passosmanuel.net/', city: 'Porto', country: 'Portugal' },
         description: 'Artist talk and performance. With <a href="https://oval.bandcamp.com/">Oval</a>, <a href="https://simonfisherturner.bandcamp.com/">Simon Fisher Turner</a>, Paul Farrington, André Gonçalves.',
+        imageAlt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
         images: [
           {
             src: '/images/live/olhares-de-outono-2010-001.jpg',
-            alt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
             photographer: { name: 'Olhares de Outono' },
           },
           {
             src: '/images/live/olhares-de-outono-2010-002.jpg',
-            alt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
             photographer: { name: 'Olhares de Outono' },
           },
           {
             src: '/images/live/olhares-de-outono-2010-003.jpg',
-            alt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
             photographer: { name: 'Olhares de Outono' },
           },
           {
             src: '/images/live/olhares-de-outono-2010-004.jpg',
-            alt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
             photographer: { name: 'Olhares de Outono' },
           },
           {
             src: '/images/live/olhares-de-outono-2010-005.jpg',
-            alt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
             photographer: { name: 'Olhares de Outono' },
           },
           {
             src: '/images/live/olhares-de-outono-2010-006.jpg',
-            alt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
             photographer: { name: 'Olhares de Outono' },
           },
           {
             src: '/images/live/olhares-de-outono-2010-007.jpg',
-            alt: 'Jerome Faria performing at Olhares de Outono, Passos Manuel, Porto, 2010',
             photographer: { name: 'Olhares de Outono' },
           },
         ],
@@ -721,35 +647,30 @@ export const liveData: LiveData = {
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
         venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>. With <a href="https://www.alvanoto.com/">Alva Noto</a>, <a href="https://murcof.com/">Murcof</a>, <a href="https://felixkubin.bandcamp.com/">Felix Kubin</a>, <a href="https://www.discogs.com/artist/31633-Christ">Christ.</a>, <a href="https://zavoloka.com/">Zavoloka</a> & <a href="https://laetitiamorais.com/">Laetitia Morais</a>, <a href="https://gigantiq.bandcamp.com/">Gigantiq</a>, <a href="http://www.jade-enterprises.at/">Jade</a>.',
+        imageAlt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
         images: [
           {
             src: '/images/live/madeiradig-2009-001.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/madeiradig-2009-002.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/madeiradig-2009-003.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/madeiradig-2009-004.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/madeiradig-2009-005.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
           {
             src: '/images/live/madeiradig-2009-006.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
             photographer: { name: 'Miguel Apolinário', url: 'https://www.instagram.com/miguel_apolinario777/' },
           },
         ],
@@ -774,30 +695,26 @@ export const liveData: LiveData = {
         date: '2009-11-21',
         venue: { name: 'Mosteiro São Bento da Vitória', url: 'https://www.tnsj.pt/en/edificios/mosteiro-de-sao-bento-da-vitoria/', city: 'Porto', country: 'Portugal' },
         description: 'Resampling White Noise — 16-performer laptop meeting. With <a href="https://scannerdot.bandcamp.com/">Scanner</a>, <a href="https://at-c.org/">@c</a>, <a href="https://www.vitorjoaquim.pt/">Vitor Joaquim</a>, <a href="https://carlossantos.bandcamp.com/">Carlos Santos</a>, <a href="https://www.carvalhais.org/">Miguel Carvalhais</a>, <a href="http://pedrotudela.org/">Pedro Tudela</a>, Pedro Almeida, <a href="https://opcabpol.bandcamp.com/">João Ricardo</a>, <a href="https://ivanfranco.wordpress.com/">Ivan Franco</a>, <a href="https://nunomoita.bandcamp.com/">Nuno Moita</a>, <a href="https://www.andregoncalves.info/">André Gonçalves</a>, <a href="https://cronica.bandcamp.com/album/musicamorosa">The Beautiful Schizophonic</a>, Rui Costa, <a href="https://andre-sier.com/">André Sier</a>, <a href="https://blog.albagcorral.com/">Alba Corral</a>, <a href="https://laetitiamorais.com/">Laetitia Morais</a>, <a href="https://vimeo.com/hugoolim">Hugo Olim</a>.',
+        imageAlt: 'Resampling White Noise laptop meeting at EME.LL / Olhares de Outono, Mosteiro São Bento da Vitória, Porto, 2009',
         images: [
           {
             src: '/images/live/eme-olhares-2009-001.jpg',
-            alt: 'Resampling White Noise laptop meeting at EME.LL / Olhares de Outono, Mosteiro São Bento da Vitória, Porto, 2009',
             photographer: { name: 'Vítor Joaquim', url: 'https://www.vitorjoaquim.pt/' },
           },
           {
             src: '/images/live/eme-olhares-2009-002.jpg',
-            alt: 'Resampling White Noise laptop meeting at EME.LL / Olhares de Outono, Mosteiro São Bento da Vitória, Porto, 2009',
             photographer: { name: 'Vítor Joaquim', url: 'https://www.vitorjoaquim.pt/' },
           },
           {
             src: '/images/live/eme-olhares-2009-003.jpg',
-            alt: 'Resampling White Noise laptop meeting at EME.LL / Olhares de Outono, Mosteiro São Bento da Vitória, Porto, 2009',
             photographer: { name: 'Vítor Joaquim', url: 'https://www.vitorjoaquim.pt/' },
           },
           {
             src: '/images/live/eme-olhares-2009-004.jpg',
-            alt: 'Resampling White Noise laptop meeting at EME.LL / Olhares de Outono, Mosteiro São Bento da Vitória, Porto, 2009',
             photographer: { name: 'Vítor Joaquim', url: 'https://www.vitorjoaquim.pt/' },
           },
           {
             src: '/images/live/eme-olhares-2009-005.jpg',
-            alt: 'Resampling White Noise laptop meeting at EME.LL / Olhares de Outono, Mosteiro São Bento da Vitória, Porto, 2009',
             photographer: { name: 'Vítor Joaquim', url: 'https://www.vitorjoaquim.pt/' },
           },
         ],
@@ -821,45 +738,38 @@ export const liveData: LiveData = {
         date: '2008-10-01',
         venue: { name: 'Teatro Ibérico', url: 'https://teatroiberico.org/', city: 'Lisbon', country: 'Portugal' },
         description: 'With <a href="https://thesightbelow.bandcamp.com/">The Sight Below</a>, <a href="https://greghaines.bandcamp.com/">Greg Haines</a>, <a href="https://hauschka.bandcamp.com/">Hauschka</a>, <a href="https://frankbretschneider.bandcamp.com/">Frank Bretschneider</a>, <a href="https://soundcloud.com/sanso-xtro">Sanso-Xtro</a>, <a href="https://annatroisi.org/">Anna Troisi</a>, <a href="https://www.tinafrank.net/">Tina Frank</a>, <a href="https://carstengoertz.cc/">Carsten Goertz</a>, <a href="https://andre-sier.com/">André Sier</a>, <a href="https://www.andregoncalves.info/">André Gonçalves</a>, <a href="https://margaridagarcia.bandcamp.com/">Garcia</a>, Machas, <a href="https://davidmaranha.bandcamp.com/">Maranha</a> e <a href="https://manuelmota.bandcamp.com/">Mota</a>, Safe & Sound, <a href="https://cronica.bandcamp.com/album/musicamorosa">The Beautiful Schizophonic</a>.',
+        imageAlt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
         images: [
           {
             src: '/images/live/eme-2008-001.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
           {
             src: '/images/live/eme-2008-002.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
           {
             src: '/images/live/eme-2008-003.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
           {
             src: '/images/live/eme-2008-004.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
           {
             src: '/images/live/eme-2008-005.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
           {
             src: '/images/live/eme-2008-006.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
           {
             src: '/images/live/eme-2008-007.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
           {
             src: '/images/live/eme-2008-008.jpg',
-            alt: 'Jerome Faria performing at EME Festival, Teatro Ibérico, Lisbon, 2008',
             photographer: { name: 'EME Festival', url: 'https://www.emefestival.org/' },
           },
         ],
@@ -878,20 +788,18 @@ export const liveData: LiveData = {
         title: '<a href="https://ra.co/promoters/4519">Störung</a>',
         venue: { name: 'La Farinera del Clot', url: 'https://farinera.org/', city: 'Barcelona', country: 'Spain' },
         description: 'With <a href="https://kimcascone.bandcamp.com/">Kim Cascone</a>, <a href="https://www.franciscolopez.net/">Francisco López</a>, <a href="https://philippepetit.bandcamp.com/">Philippe Petit</a>, <a href="https://ritornell.bandcamp.com/">Ritornell</a>, Sébastien Roux, Tonne.',
+        imageAlt: 'Jerome Faria performing at Störung Festival, La Farinera del Clot, Barcelona, 2008',
         images: [
           {
             src: '/images/live/storung-2008-001.jpg',
-            alt: 'Jerome Faria performing at Störung Festival, La Farinera del Clot, Barcelona, 2008',
             photographer: { name: 'Störung Festival', url: 'https://storung.com/' },
           },
           {
             src: '/images/live/storung-2008-002.jpg',
-            alt: 'Jerome Faria performing at Störung Festival, La Farinera del Clot, Barcelona, 2008',
             photographer: { name: 'Störung Festival', url: 'https://storung.com/' },
           },
           {
             src: '/images/live/storung-2008-003.jpg',
-            alt: 'Jerome Faria performing at Störung Festival, La Farinera del Clot, Barcelona, 2008',
             photographer: { name: 'Störung Festival', url: 'https://storung.com/' },
           },
         ],
@@ -908,20 +816,18 @@ export const liveData: LiveData = {
         title: 'STFU Porto',
         venue: { name: 'Fábrica do Som', url: 'https://fabricadesom.org/', city: 'Porto', country: 'Portugal' },
         description: 'With <a href="https://svartegreiner.bandcamp.com/">Svarte Greiner</a>, Pygar (<a href="https://vimeo.com/hugoolim">Hugo Olim</a> & <a href="https://opcabpol.bandcamp.com/">João Ricardo</a>), e:4c, CKZ, DeciBeats, Aenedra, Unknown Forces Of Everyday Life.',
+        imageAlt: 'Jerome Faria performing at STFU Porto, Fábrica do Som, Porto, 2007',
         images: [
           {
             src: '/images/live/stfu-porto-001.jpg',
-            alt: 'Jerome Faria performing at STFU Porto, Fábrica do Som, Porto, 2007',
             photographer: { name: 'STFU Porto' },
           },
           {
             src: '/images/live/stfu-porto-002.jpg',
-            alt: 'Jerome Faria performing at STFU Porto, Fábrica do Som, Porto, 2007',
             photographer: { name: 'STFU Porto' },
           },
           {
             src: '/images/live/stfu-porto-003.jpg',
-            alt: 'Jerome Faria performing at STFU Porto, Fábrica do Som, Porto, 2007',
             photographer: { name: 'STFU Porto' },
           },
         ],
@@ -932,55 +838,46 @@ export const liveData: LiveData = {
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
         venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
         description: 'With <a href="https://alogmusic.bandcamp.com/">Alog</a>, <a href="https://vladislavdelay.bandcamp.com/">Vladislav Delay</a>, <a href="https://ranslavin.com/">Ran Slavin</a>.',
+        imageAlt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
         images: [
           {
             src: '/images/live/madeiradig-2007-001.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-002.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-003.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-004.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-005.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-006.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-007.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-008.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-009.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
           {
             src: '/images/live/madeiradig-2007-010.jpg',
-            alt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
             photographer: { name: 'Marta León', url: 'https://leonmarta.wordpress.com/' },
           },
         ],
@@ -1010,55 +907,46 @@ export const liveData: LiveData = {
         title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
         venue: { name: 'RDP Auditorium', url: 'https://madeira.rtp.pt/', city: 'Funchal', country: 'Portugal' },
         description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>. With <a href="https://www.fennesz.com/">Fennesz</a>, <a href="https://florianhecker.blogspot.com/">Florian Hecker</a>, <a href="https://at-c.org/">@c</a> & <a href="https://liaworks.com/">Lia</a>.',
+        imageAlt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
         images: [
           {
             src: '/images/live/madeiradig-2005-001.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-002.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-003.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-004.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-005.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-006.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-007.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-008.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-009.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
           {
             src: '/images/live/madeiradig-2005-010.jpg',
-            alt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',
             photographer: { name: 'Louie de Bettencourt' },
           },
         ],

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -2,7 +2,8 @@ import type { Photographer } from './lightbox';
 
 export interface LiveImage {
   src: string;
-  alt: string;
+  // Per-image override; most galleries fall back to the event's imageAlt.
+  alt?: string;
   photographer?: Photographer;
 }
 
@@ -26,6 +27,7 @@ export interface LiveEvent {
   date: string;
   venue: EventVenue;
   description?: string;
+  imageAlt?: string;
   images?: LiveImage[];
   videos?: LiveVideo[];
 }


### PR DESCRIPTION
## Description
Phase 3, part 2. De-duplicates live-image alt text by hoisting it to the event.

## Finding
Every event's photos shared one hand-written alt — **134 copies of 22 strings** (all 11 Showcase images carried the identical alt). The alt is genuinely event-level (it describes the performance, same for every photo).

The original idea was to *derive* alt from event + venue, but the 22 unique strings are varied prose — performer (`Jerome Faria` / `NOx` / `… and Hugo Olim`), connector (`performing at` / `performing with Amess at` / `theatre production at` / `laptop meeting at`), and 5 of 22 don't contain "performing at". Deriving would be lossy, so this **hoists** rather than derives.

## Changes
- `types/live.ts` — `LiveEvent.imageAlt?`; `LiveImage.alt` is now optional (a per-image override).
- `data/live.ts` — each event's shared alt moved to `imageAlt`; the 134 per-image `alt` lines removed (net −112 lines).
- `EventItem.vue` — resolves `image.alt ?? event.imageAlt` when building lightbox items.

## Output is unchanged
The alt every image resolves to is identical to before — the lightbox `<img alt>` is byte-for-byte the same. Guarded by:
- `data/live.test.ts` — a golden snapshot asserting each event's `imageAlt` equals its original per-image alt, and that exactly the image-bearing events have one.
- `EventItem.test.ts` — the fallback (`image.alt ?? event.imageAlt`) and the per-image override.

## Testing
1. `gh pr checkout <this-PR> && npm ci && npm run build`
2. Open `/live`, open any event's gallery — the lightbox alt (VoiceOver) reads exactly as before.
3. `npm run test:coverage` — 363 pass; coverage 99.4 / 98.25 / 97.41 / 91.95.

## Acceptance Criteria
- [x] Event-level alt stored once, not per image
- [x] Optional per-image override retained for future distinct alts
- [x] Alt output provably unchanged (golden snapshot)
- [x] Full local gate green