### PR TITLE
refactor: share Photographer and Video primitives across the data types

### DIFF
--- a/src/types/about.ts
+++ b/src/types/about.ts
@@ -1,13 +1,12 @@
+import type { Photographer } from './media';
+
 export interface AboutImage {
   src: string;
   alt: string;
   position?: string;
   scale?: number;
   rotate?: number;
-  photographer?: {
-    name: string;
-    url?: string;
-  };
+  photographer?: Photographer;
 }
 
 export interface AboutTextSection {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './about';
 export * from './contact';
 export * from './lightbox';
 export * from './live';
+export * from './media';
 export * from './navigation';
 export * from './press';
 export * from './schema';

--- a/src/types/lightbox.ts
+++ b/src/types/lightbox.ts
@@ -1,11 +1,6 @@
-// Lightbox types with discriminated unions for Image and Video
+// Lightbox types: the discriminated items rendered in the lightbox.
 
-// A credited contributor (name + optional link). Shared by photo credits
-// (photographer) and video credits (author).
-export interface Photographer {
-  name: string;
-  url?: string;
-}
+import type { Photographer, Video } from './media';
 
 export interface LightboxImage {
   type: 'image';
@@ -14,12 +9,8 @@ export interface LightboxImage {
   photographer?: Photographer;
 }
 
-export interface LightboxVideo {
+export interface LightboxVideo extends Video {
   type: 'video';
-  url: string;
-  title: string;
-  platform: 'youtube' | 'vimeo';
-  author?: Photographer;
 }
 
 export type LightboxItem = LightboxImage | LightboxVideo;

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -1,16 +1,9 @@
-import type { Photographer } from './lightbox';
+import type { Photographer, Video } from './media';
 
 export interface LiveImage {
   src: string;
   alt?: string;
   photographer?: Photographer;
-}
-
-export interface LiveVideo {
-  url: string;
-  title: string;
-  platform: 'youtube' | 'vimeo';
-  author?: Photographer;
 }
 
 export interface EventVenue {
@@ -28,7 +21,7 @@ export interface LiveEvent {
   description?: string;
   imageAlt?: string;
   images?: LiveImage[];
-  videos?: LiveVideo[];
+  videos?: Video[];
 }
 
 export interface LiveYearSection {

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,0 +1,13 @@
+// A credited contributor (name + optional link). Used as both a photo credit
+// (photographer) and a video credit (author).
+export interface Photographer {
+  name: string;
+  url?: string;
+}
+
+export interface Video {
+  url: string;
+  title: string;
+  platform: 'youtube' | 'vimeo';
+  author?: Photographer;
+}

--- a/src/types/works.ts
+++ b/src/types/works.ts
@@ -1,19 +1,9 @@
-import type { Photographer } from './lightbox';
-
-export interface VideoItem {
-  url: string;
-  title: string;
-  platform: 'youtube' | 'vimeo';
-  author?: Photographer;
-}
+import type { Photographer, Video } from './media';
 
 export interface Image {
   src: string;
   alt: string;
-  photographer?: {
-    name: string;
-    url?: string;
-  };
+  photographer?: Photographer;
 }
 
 export interface MetaLink {
@@ -86,7 +76,7 @@ export interface Release {
   description?: string;
   credits?: string;
   images?: Image[];
-  videos?: VideoItem[];
+  videos?: Video[];
 }
 
 export const hasBandcampId = (release: Release): release is Release & { bandcampId: string } =>
@@ -113,7 +103,7 @@ export const hasCredits = (release: Release): release is Release & { credits: st
 export const hasImages = (release: Release): release is Release & { images: Image[] } =>
   Boolean(release.images);
 
-export const hasVideos = (release: Release): release is Release & { videos: VideoItem[] } =>
+export const hasVideos = (release: Release): release is Release & { videos: Video[] } =>
   Boolean(release.videos);
 
 export interface WorksSection {

--- a/src/utils/lightboxAdapters.ts
+++ b/src/utils/lightboxAdapters.ts
@@ -1,4 +1,5 @@
-import type { LightboxImage, LightboxVideo, Photographer } from '@/types/lightbox';
+import type { LightboxImage, LightboxVideo } from '@/types/lightbox';
+import type { Photographer } from '@/types/media';
 
 // Superset of the fields the app's image/video data carry (About/Live/Works),
 // so a single adapter serves every call site.


### PR DESCRIPTION
## Description
Finding #2 from the data-layer review. De-duplicates media primitives.

## Changes
- New `types/media.ts` with `Photographer` and `Video`.
- `VideoItem` (works) and `LiveVideo` (live) — byte-identical — collapse to the shared `Video`.
- Works `Image` and `AboutImage` use the shared `Photographer` instead of inline `{ name; url? }`.
- `Photographer` moves out of `lightbox.ts` into `media.ts`; `LightboxVideo extends Video`.

Not touched: the `Image` domain types stay separate (works `alt` is required, live `alt` optional) — merging them would loosen works, a judgment call I left out.

## Output is unchanged
Type-only. `tsc` confirms every reference resolves; tests + visual regression unchanged.

## Testing
`npm run test:coverage` (366 pass) / `npm run build` — green.

## Acceptance Criteria
- [x] `Video` shared; `VideoItem`/`LiveVideo` duplication gone
- [x] `Photographer` shared (no inline duplicates)
- [x] Output unchanged (type-only)