### PR TITLE
refactor: remove the dead AboutLegacyImageSection

### DIFF
--- a/src/styles/_pages.scss
+++ b/src/styles/_pages.scss
@@ -197,27 +197,6 @@
     }
   }
 
-  // Single image divider (legacy)
-  .about-image {
-    margin: $spacing-12 0;
-
-    @include respond-to(md) {
-      margin: $spacing-16 0;
-    }
-
-    img {
-      width: 100%;
-      height: auto;
-      display: block;
-      opacity: 0;
-      transition: opacity $transition-base;
-
-      &[src] {
-        opacity: 1;
-      }
-    }
-  }
-
   // Short bio section
   .short-bio {
     margin-bottom: $spacing-12;

--- a/src/types/about.ts
+++ b/src/types/about.ts
@@ -21,14 +21,7 @@ export interface AboutImageSection {
   images: AboutImage[];
 }
 
-export interface AboutLegacyImageSection {
-  id: string;
-  type: 'image';
-  src: string;
-  alt: string;
-}
-
-export type AboutSection = AboutTextSection | AboutImageSection | AboutLegacyImageSection;
+export type AboutSection = AboutTextSection | AboutImageSection;
 
 export function isImageSection(section: AboutSection): section is AboutImageSection {
   return section.type === 'image-group';

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -91,19 +91,6 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number =>
             </picture>
           </figure>
         </div>
-
-        <!-- Single image divider (legacy support) -->
-        <figure
-          v-else-if="section.type === 'image' && 'src' in section && 'alt' in section"
-          class="about-image"
-        >
-          <img
-            :src="section.src"
-            :alt="section.alt"
-            loading="lazy"
-            decoding="async"
-          >
-        </figure>
       </template>
     </PageShell>
 


### PR DESCRIPTION
## Description
Finding #3 from the data-layer review. Removes a dead, self-labelled "legacy" shape.

## Why
Every About section is `short-bio` or `image-group` — **0** use `type: 'image'`. So `AboutLegacyImageSection`, its `v-else-if="section.type === 'image'"` branch in `AboutView`, and the `.about-image` styles were all dead.

## Changes
- `types/about.ts` — drop `AboutLegacyImageSection`; `AboutSection = AboutTextSection | AboutImageSection`.
- `AboutView.vue` — remove the legacy single-image render branch.
- `_pages.scss` — remove the orphaned `.about-image` block.

## Output is unchanged
The removed branch never executed. `tsc` confirms the union narrows exhaustively; the built `/about` still renders its image groups.

## Testing
`npm run test:coverage` (366) / `npm run build` — green.

## Acceptance Criteria
- [x] Dead legacy type, render branch, and CSS removed
- [x] Output unchanged