### PR TITLE
feat: open external links in Live and About prose in a new tab

### DIFF
--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -33,6 +33,20 @@ const internalRefEvent: LiveEvent = {
 };
 
 describe('EventItem', () => {
+  describe('description', () => {
+    it('opens external links in a new tab and leaves internal links alone', () => {
+      const wrapper = mountEvent({
+        ...plainEvent,
+        description: 'With <a href="https://cavernancia.bandcamp.com/">Pedro Roque</a> at <a href="/works#x">Works</a>.',
+      });
+      const anchors = wrapper.findAll('.event-description a');
+
+      expect(anchors[0].attributes('target')).toBe('_blank');
+      expect(anchors[0].attributes('rel')).toBe('noopener noreferrer');
+      expect(anchors[1].attributes('target')).toBeUndefined();
+    });
+  });
+
   describe('title', () => {
     it('renders the title as the deep-link permalink and emits update-hash on click', async () => {
       const wrapper = mountEvent(plainEvent);

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 
 import type { LightboxItem, LiveEvent } from '@/types';
+import { externalizeLinks } from '@/utils/externalizeLinks';
 import { formatEventDate, stripHtml } from '@/utils/formatters';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
@@ -83,7 +84,7 @@ const imageLabel = computed(() => `View ${imageLightboxItems.value.length === 1 
       <p
         v-if="event.description"
         class="event-description"
-        v-html="event.description"
+        v-html="externalizeLinks(event.description)"
       />
       <MediaLinks
         :images="imageLightboxItems"

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -7,6 +7,7 @@ import { usePageHead } from '@/composables/usePageHead';
 import { aboutSections } from '@/data/about';
 import { pageMeta } from '@/data/pageMeta';
 import { isImageSection } from '@/types';
+import { externalizeLinks } from '@/utils/externalizeLinks';
 import { getImageStyles } from '@/utils/imageStyles';
 import { toLightboxImage } from '@/utils/lightboxAdapters';
 import { responsiveSrcset, toWebp } from '@/utils/responsiveImage';
@@ -43,6 +44,9 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number =>
       data-page="about"
       title="About"
     >
+      <p class="visually-hidden">
+        External links open in a new tab.
+      </p>
       <template
         v-for="(section, sectionIndex) in aboutSections"
         :key="section.id"
@@ -50,13 +54,13 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number =>
         <div
           v-if="section.type === 'short-bio'"
           class="short-bio"
-          v-html="section.content"
+          v-html="externalizeLinks(section.content)"
         />
 
         <div
           v-else-if="!section.type"
           class="prose"
-          v-html="section.content"
+          v-html="externalizeLinks(section.content)"
         />
 
         <!-- Image group (magazine-style layout) -->

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -30,6 +30,9 @@ const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
       data-page="live"
       title="Live"
     >
+      <p class="visually-hidden">
+        External links open in a new tab.
+      </p>
       <AccordionSection
         v-for="year in liveYears"
         :id="year"


### PR DESCRIPTION
## Description
Finding #1 from the data-layer review — completes the external-link unification. You settled the cue to per-page (same as Works), which removed the only open decision.

## Changes
- `EventItem.vue` — live event `description` runs through `externalizeLinks` (85 external links).
- `AboutView.vue` — both `content` renders run through `externalizeLinks` (30 links); page gets the visually-hidden cue.
- `LiveView.vue` — page gets the visually-hidden cue.
- Contact intro / press quotes have **0** external prose links, so they're left unchanged (no cue on a page with nothing to warn about).

## Consistency
This applies the exact behaviour you already approved and device-tested for Works (#137): external prose links open in a new tab with `rel="noopener noreferrer"`, one page-level cue instead of a per-link one on link-dense pages. Every page's external links now behave the same.

## Low risk / pixel-identical
`externalizeLinks` is tested and touches only `https:` links (internal/hash untouched). `target`/`rel` are invisible and the cue is visually-hidden, so **Visual Regression should stay green** — the only change is new-tab on click. Verified in the built HTML: live/about prose anchors carry `target="_blank" rel="noopener noreferrer"`; both notes present.

## Testing
1. `gh pr checkout <this-PR> && npm ci && npm run build`
2. `/live` and `/about` — click any external link in an event blurb or the bio → new tab; internal links stay in place.
3. `npm run test:coverage` — 367 pass; floor met.

## Acceptance Criteria
- [x] Live + About external prose links open new-tab with safe rel (in SSG output)
- [x] Per-page cue, matching Works
- [x] Internal/hash links untouched; empty pages unchanged
- [x] Full local gate green