### PR TITLE
refactor: drop the redundant date fallback in the live year sort

### DIFF
--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -878,7 +878,7 @@ const groupEventsByYear = (events: LiveEvent[]): LiveData => {
   return Object.fromEntries(
     Object.entries(byYear).map(([year, section]) => [
       year,
-      { ...section, items: [...section.items].sort((a, b) => (b.date ?? '').localeCompare(a.date ?? '')) },
+      { ...section, items: [...section.items].sort((a, b) => b.date.localeCompare(a.date)) },
     ]),
   );
 };


### PR DESCRIPTION
## Description
Removes the one unreachable branch in the data layer.

## Change
`LiveEvent.date` is a required `string`, so the `?? ''` in the year-grouping sort comparator guarded against a nullish value the type forbids:
```diff
- .sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''))
+ .sort((a, b) => b.date.localeCompare(a.date))
```
It was also inconsistent with `event.date.slice(0, 4)` three lines up, which already trusts the field.

## Impact
- Removes dead defensive code on a type-guaranteed field.
- `src/data` goes to **100% branch coverage** (it was the only uncovered branch there); overall branches 92.97% → 93.31%.
- No behaviour change — the grouping golden test (`live.test.ts`) guards the sort order.

## Testing
`npm run test:coverage` (367 pass) / `npm run build` — green.

## Acceptance Criteria
- [x] Redundant fallback removed; sort trusts the required field
- [x] Data layer 100% branch-covered
- [x] No behaviour change