### PR TITLE
test: pin accordion-view wiring before the AccordionListPage extraction

### DIFF
--- a/e2e/lightbox.spec.ts
+++ b/e2e/lightbox.spec.ts
@@ -46,6 +46,27 @@ const openLightboxFromFirstGallery = async (page: Page): Promise<void> => {
   await expect(page.locator(LIGHTBOX_SELECTOR)).toBeVisible();
 };
 
+// Live events label their gallery control "View photo(s)"; substring-match both.
+const LIVE_GALLERY_BUTTON = '.link-discrete:has-text("View photo")';
+
+/** Open the lightbox from a Live event gallery and wait for it. */
+const openLiveLightbox = async (page: Page): Promise<void> => {
+  await page.goto('/live');
+  await waitForHydration(page);
+
+  const owningSection = page.locator(ACCORDION_SECTION_SELECTOR)
+    .filter({ has: page.locator(LIVE_GALLERY_BUTTON) })
+    .first();
+  const trigger = owningSection.locator(ACCORDION_TRIGGER_SELECTOR);
+
+  if (await trigger.getAttribute('aria-expanded') !== 'true') {
+    await trigger.click();
+  }
+
+  await page.locator(`${LIVE_GALLERY_BUTTON}:visible`).first().click();
+  await expect(page.locator(LIGHTBOX_SELECTOR)).toBeVisible();
+};
+
 test.describe('Lightbox', () => {
   test.describe('Opening', () => {
     test('opens lightbox when clicking a View gallery button', async ({ page }) => {
@@ -127,6 +148,16 @@ test.describe('Lightbox', () => {
       if (await credit.count() > 0) {
         await expect(credit).toBeVisible();
       }
+    });
+  });
+
+  test.describe('Live page', () => {
+    test('opens and closes the lightbox from a live event gallery', async ({ page }) => {
+      await openLiveLightbox(page);
+      await expect(page.locator(LIGHTBOX_IMAGE_SELECTOR)).toBeVisible();
+
+      await page.locator(LIGHTBOX_CLOSE_SELECTOR).click();
+      await expect(page.locator(LIGHTBOX_SELECTOR)).toHaveCount(0);
     });
   });
 

--- a/src/views/LiveView.test.ts
+++ b/src/views/LiveView.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { nextTick } from 'vue';
 
 import AccordionSection from '@/components/AccordionSection.vue';
 import EventItem from '@/components/EventItem.vue';
+import LightboxOverlay from '@/components/LightboxOverlay.vue';
 import { liveEvents, liveYears } from '@/data/live';
 import { mountView } from '@/test-support/viewHarness';
 
@@ -12,6 +13,28 @@ const expandedYears = (wrapper: Awaited<ReturnType<typeof mountView>>): string[]
   liveYears.filter(year => wrapper.get(`#trigger-${year}`).attributes('aria-expanded') === 'true');
 
 describe('LiveView', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', window.location.pathname);
+  });
+
+  it('forwards an event open-lightbox event to the lightbox host', async () => {
+    const wrapper = await mountView(LiveView, '/live');
+    expect(wrapper.findComponent(LightboxOverlay).exists()).toBe(false);
+
+    wrapper.findComponent(EventItem).vm.$emit('open-lightbox', [{ type: 'image', src: '/x.jpg', alt: 'x' }], 0);
+    await nextTick();
+
+    expect(wrapper.findComponent(LightboxOverlay).exists()).toBe(true);
+  });
+
+  it('updates the URL hash when an event requests it', async () => {
+    const wrapper = await mountView(LiveView, '/live');
+
+    wrapper.findComponent(EventItem).vm.$emit('update-hash', 'showcase-casa-amarela');
+
+    expect(window.location.hash).toBe('#showcase-casa-amarela');
+  });
+
   it('renders an accordion section for every year', async () => {
     const wrapper = await mountView(LiveView, '/live');
     expect(wrapper.findAllComponents(AccordionSection)).toHaveLength(liveYears.length);

--- a/src/views/WorksView.test.ts
+++ b/src/views/WorksView.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { nextTick } from 'vue';
 
 import AccordionSection from '@/components/AccordionSection.vue';
+import LightboxOverlay from '@/components/LightboxOverlay.vue';
 import ReleaseItem from '@/components/ReleaseItem.vue';
 import { worksData, worksSections } from '@/data/works';
 import { mountView } from '@/test-support/viewHarness';
@@ -12,6 +13,28 @@ const expandedSections = (wrapper: Awaited<ReturnType<typeof mountView>>): strin
   worksSections.filter(section => wrapper.get(`#trigger-${section}`).attributes('aria-expanded') === 'true');
 
 describe('WorksView', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', window.location.pathname);
+  });
+
+  it('forwards a release open-lightbox event to the lightbox host', async () => {
+    const wrapper = await mountView(WorksView, '/works');
+    expect(wrapper.findComponent(LightboxOverlay).exists()).toBe(false);
+
+    wrapper.findComponent(ReleaseItem).vm.$emit('open-lightbox', [{ type: 'image', src: '/x.jpg', alt: 'x' }], 0);
+    await nextTick();
+
+    expect(wrapper.findComponent(LightboxOverlay).exists()).toBe(true);
+  });
+
+  it('updates the URL hash when a release requests it', async () => {
+    const wrapper = await mountView(WorksView, '/works');
+
+    wrapper.findComponent(ReleaseItem).vm.$emit('update-hash', 'contraplacado');
+
+    expect(window.location.hash).toBe('#contraplacado');
+  });
+
   it('renders an accordion section for every works category', async () => {
     const wrapper = await mountView(WorksView, '/works');
     expect(wrapper.findAllComponents(AccordionSection)).toHaveLength(worksSections.length);


### PR DESCRIPTION
## Description
Step 1 of 2 toward de-duplicating `WorksView`/`LiveView` into a shared `AccordionListPage`: build the safety net **first**, on the current structure, so the extraction runs under it. These tests characterize each view's observable behaviour, so they survive the refactor and will fail if the extraction mis-wires anything.

## What's added
- **`WorksView.test` / `LiveView.test`** — the wiring most at risk in the extraction:
  - forwarding an item's `open-lightbox` opens the lightbox host (slot → `openLightbox`)
  - an item's `update-hash` updates the URL hash (slot → `updateHash`)
- **`e2e/lightbox.spec`** — open + close the lightbox from a **live** event gallery, closing the gap where lightbox E2E only drove `/works` (now covered on both pages across all three engines).

Combined with the existing view tests (default-open, deep-link-opens-section, toggle) and E2E (`accordion`, `navigation`), every behaviour the extraction could break is now pinned.

## Risk
Test-only — no production code changes. All pass on the current structure (the new `/live` E2E verified locally on chromium in ~1s).

## Testing
`npm run test:coverage` (371 pass) / `npm run build` — green; new E2E green locally.

## Acceptance Criteria
- [x] View-level lightbox + hash wiring pinned on both views
- [x] Live-page lightbox covered in E2E
- [x] No production change