### PR TITLE
refactor: extract AccordionListPage from WorksView and LiveView

### DIFF
--- a/src/components/AccordionListPage.vue
+++ b/src/components/AccordionListPage.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts" generic="T extends { id: string }">
+import { useTemplateRef } from 'vue';
+
+import { useAccordion } from '@/composables/useAccordion';
+import { usePageHead } from '@/composables/usePageHead';
+import type { LightboxItem } from '@/types';
+import { findSectionContainingId, updateHash } from '@/utils/navigation';
+
+import AccordionSection from './AccordionSection.vue';
+import LightboxHost from './LightboxHost.vue';
+import PageShell from './PageShell.vue';
+
+interface Section {
+  title: string;
+  id: string;
+  items: T[];
+}
+
+const props = defineProps<{
+  dataPage: string;
+  title: string;
+  sections: string[];
+  sectionData: Record<string, Section>;
+  initialSection: string;
+  head: Parameters<typeof usePageHead>[0];
+}>();
+
+defineSlots<{
+  item(props: {
+    item: T;
+    openLightbox: (items: LightboxItem[], index: number) => void;
+    updateHash: (id: string) => void;
+  }): unknown;
+}>();
+
+usePageHead(props.head);
+
+const findSectionForId = (id: string): string | null =>
+  findSectionContainingId(props.sections, props.sectionData, id);
+
+const { openSection, handleToggle } = useAccordion(props.initialSection, props.sections, findSectionForId);
+const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
+
+const openLightbox = (items: LightboxItem[], index: number): void => {
+  lightbox.value?.openLightbox(items, index);
+};
+</script>
+
+<template>
+  <div class="container-wide">
+    <PageShell
+      :data-page="dataPage"
+      :title="title"
+    >
+      <p class="visually-hidden">
+        External links open in a new tab.
+      </p>
+      <AccordionSection
+        v-for="sectionKey in sections"
+        :id="sectionKey"
+        :key="sectionKey"
+        :title="sectionData[sectionKey]?.title || sectionKey"
+        :model-value="openSection === sectionKey"
+        @update:model-value="handleToggle(sectionKey, $event)"
+      >
+        <template
+          v-for="item in sectionData[sectionKey]?.items || []"
+          :key="item.id"
+        >
+          <slot
+            name="item"
+            :item="item"
+            :open-lightbox="openLightbox"
+            :update-hash="updateHash"
+          />
+        </template>
+      </AccordionSection>
+    </PageShell>
+
+    <LightboxHost ref="lightbox" />
+  </div>
+</template>

--- a/src/views/LiveView.vue
+++ b/src/views/LiveView.vue
@@ -1,56 +1,26 @@
 <script setup lang="ts">
-import { useTemplateRef } from 'vue';
-
-import AccordionSection from '@/components/AccordionSection.vue';
+import AccordionListPage from '@/components/AccordionListPage.vue';
 import EventItem from '@/components/EventItem.vue';
-import LightboxHost from '@/components/LightboxHost.vue';
-import PageShell from '@/components/PageShell.vue';
-import { useAccordion } from '@/composables/useAccordion';
-import { usePageHead } from '@/composables/usePageHead';
 import { liveYears, sortedLiveData } from '@/data/live';
 import { pageMeta } from '@/data/pageMeta';
-import { findSectionContainingId, updateHash } from '@/utils/navigation';
 import { createLiveEventsSchema } from '@/utils/pageSchemas';
-
-usePageHead({
-  ...pageMeta.live,
-  schema: createLiveEventsSchema(),
-});
-
-const findYearForEvent = (eventId: string): string | null =>
-  findSectionContainingId(liveYears, sortedLiveData, eventId);
-
-const { openSection, handleToggle } = useAccordion(liveYears[0] ?? '', liveYears, findYearForEvent);
-const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 </script>
 
 <template>
-  <div class="container-wide">
-    <PageShell
-      data-page="live"
-      title="Live"
-    >
-      <p class="visually-hidden">
-        External links open in a new tab.
-      </p>
-      <AccordionSection
-        v-for="year in liveYears"
-        :id="year"
-        :key="year"
-        :title="sortedLiveData[year]?.title || year"
-        :model-value="openSection === year"
-        @update:model-value="handleToggle(year, $event)"
-      >
-        <EventItem
-          v-for="event in sortedLiveData[year]?.items || []"
-          :key="event.id"
-          :event="event"
-          @update-hash="updateHash"
-          @open-lightbox="lightbox?.openLightbox"
-        />
-      </AccordionSection>
-    </PageShell>
-
-    <LightboxHost ref="lightbox" />
-  </div>
+  <AccordionListPage
+    data-page="live"
+    title="Live"
+    :sections="liveYears"
+    :section-data="sortedLiveData"
+    :initial-section="liveYears[0] ?? ''"
+    :head="{ ...pageMeta.live, schema: createLiveEventsSchema() }"
+  >
+    <template #item="{ item, openLightbox, updateHash }">
+      <EventItem
+        :event="item"
+        @update-hash="updateHash"
+        @open-lightbox="openLightbox"
+      />
+    </template>
+  </AccordionListPage>
 </template>

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -1,57 +1,27 @@
 <script setup lang="ts">
-import { useTemplateRef } from 'vue';
-
-import AccordionSection from '@/components/AccordionSection.vue';
-import LightboxHost from '@/components/LightboxHost.vue';
-import PageShell from '@/components/PageShell.vue';
+import AccordionListPage from '@/components/AccordionListPage.vue';
 import ReleaseItem from '@/components/ReleaseItem.vue';
-import { useAccordion } from '@/composables/useAccordion';
-import { usePageHead } from '@/composables/usePageHead';
 import { pageMeta } from '@/data/pageMeta';
 import { worksData, worksSections } from '@/data/works';
-import { findSectionContainingId, updateHash } from '@/utils/navigation';
 import { createWorksPageSchema } from '@/utils/pageSchemas';
-
-usePageHead({
-  ...pageMeta.works,
-  schema: createWorksPageSchema(),
-});
-
-const findSectionForRelease = (releaseId: string): string | null =>
-  findSectionContainingId(worksSections, worksData, releaseId);
-
-const { openSection, handleToggle } = useAccordion('solo', worksSections, findSectionForRelease);
-const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 </script>
 
 <template>
-  <div class="container-wide">
-    <PageShell
-      data-page="works"
-      title="Works"
-    >
-      <p class="visually-hidden">
-        External links open in a new tab.
-      </p>
-      <AccordionSection
-        v-for="sectionKey in worksSections"
-        :id="sectionKey"
-        :key="sectionKey"
-        :title="worksData[sectionKey]?.title || sectionKey"
-        :model-value="openSection === sectionKey"
-        @update:model-value="handleToggle(sectionKey, $event)"
-      >
-        <ReleaseItem
-          v-for="release in worksData[sectionKey]?.items || []"
-          :key="release.id"
-          :release="release"
-          :text-only="!('coverImage' in release && release.coverImage)"
-          @update-hash="updateHash"
-          @open-lightbox="lightbox?.openLightbox"
-        />
-      </AccordionSection>
-    </PageShell>
-
-    <LightboxHost ref="lightbox" />
-  </div>
+  <AccordionListPage
+    data-page="works"
+    title="Works"
+    :sections="worksSections"
+    :section-data="worksData"
+    initial-section="solo"
+    :head="{ ...pageMeta.works, schema: createWorksPageSchema() }"
+  >
+    <template #item="{ item, openLightbox, updateHash }">
+      <ReleaseItem
+        :release="item"
+        :text-only="!('coverImage' in item && item.coverImage)"
+        @update-hash="updateHash"
+        @open-lightbox="openLightbox"
+      />
+    </template>
+  </AccordionListPage>
 </template>


### PR DESCRIPTION
## Description
Step 2 of the accordion-view dedup (Step 1 was the safety net in #146). Extracts the ~90% shared structure of `WorksView`/`LiveView` into a generic `AccordionListPage`.

**Opening for review, not auto-merging** — this is behaviour-preserving rather than provably output-identical, so it earns your eyes.

## Change
- **`AccordionListPage.vue`** — generic `<T extends { id: string }>` component owning: `container-wide` → `PageShell` → the "opens in a new tab" cue → `AccordionSection v-for` → `LightboxHost`, plus `usePageHead`, `useAccordion` + `findSectionContainingId`, and the lightbox host. Exposes `item` / `openLightbox` / `updateHash` through a typed `#item` scoped slot.
- **`WorksView` / `LiveView`** — now thin config + an `#item` slot (~20 lines each, down from ~55).

## Behaviour-preserving — verified under the net built in #146
- **Wiring net (unit, both views):** `open-lightbox` opens the lightbox host, `update-hash` sets the URL hash — both pass *through* the extraction (the slot handlers are wired correctly).
- **Existing view unit tests:** default-open section, deep-link-opens-owning-section, toggle — all green.
- **Interactive E2E (chromium, local):** all 42 `accordion` + `navigation` + `lightbox` tests pass, including the `/live` lightbox added in #146.
- **Manual smoke:** screenshotted `/works` and `/live` — render identically (Live still defaults to the most-recent year with its events).
- Coverage: `AccordionListPage` fully covered via the view tests; overall branches ↑ to 93.64%.
- The Visual Regression CI check is the pixel-level guard.

## Review notes
- The item component (`ReleaseItem`/`EventItem`) and its props stay in each view's slot — only the shared shell moved.
- `usePageHead` runs inside `AccordionListPage` from a `head` prop, so per-page title/description/schema are unchanged.

## Testing
1. `gh pr checkout <this-PR> && npm ci && npm run build`
2. `/works` and `/live`: toggle sections, deep-link (`/works#aragao`, `/live#showcase-casa-amarela`), open a gallery lightbox — all behave as before.
3. `npm run test:coverage` (371) — green.

## Acceptance Criteria
- [x] Shared shell extracted into a generic `AccordionListPage`
- [x] Both views reduced to config + item slot
- [x] Behaviour preserved (wiring net + E2E + manual smoke)
- [x] Full local gate green