### PR TITLE
content: flesh out the 23 Aug 2026 gig as Festival Múltiplo

### DIFF
--- a/src/data/live.test.ts
+++ b/src/data/live.test.ts
@@ -65,7 +65,7 @@ describe('liveData year grouping (derived)', () => {
     '2022': ['amess-teatro-baltazar-dias', 'amess-museu-franco', 'jejum-11'],
     '2024': ['cca-no-desterro-august', 'cca-no-desterro'],
     '2025': ['showcase-casa-amarela', 'fim-de-emissao-45'],
-    '2026': ['tbc-2026-09-19', 'tbc-2026-08-23'],
+    '2026': ['tbc-2026-09-19', 'festival-multiplo-2026'],
   };
 
   it('derives the same years, newest first', () => {

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -9,11 +9,11 @@ export const liveEvents: LiveEvent[] = [
     description: 'Solo performance.',
   },
   {
-    id: 'tbc-2026-08-23',
-    title: 'TBC',
+    id: 'festival-multiplo-2026',
+    title: '<a href="https://ma.to/event/festival-multiplo-21-aug-2026">Festival Múltiplo</a>',
     date: '2026-08-23',
-    venue: { country: 'Portugal' },
-    description: 'Solo performance.',
+    venue: { name: 'Zaratan', url: 'https://zaratan.pt', city: 'Lisbon', country: 'Portugal' },
+    description: 'With Água Doce, Alga, <a href="https://canadian-rifles.bandcamp.com/">Canadian Rifles</a>, Caranguejos, Double Double, Formidolor, <a href="https://joanadesa.work/">Joana de Sá</a>, <a href="https://llamavirgem.bandcamp.com/">Llama Virgem</a>, Musgos, Open Source 3IO, Pedro PMDS.',
   },
   {
     id: 'showcase-casa-amarela',


### PR DESCRIPTION
Updates the placeholder Aug 23 2026 gig with the confirmed Festival Múltiplo appearance (Zaratan, Lisbon). tbc-2026-08-23 -> festival-multiplo-2026: title links to the ma.to event page, venue = Zaratan/zaratan.pt/Lisbon, description lists the full festival bill (Aug 21-23) alphabetised with Canadian Rifles / Joana de Sá / Llama Virgem linked. Grouping golden snapshot updated. Reviewed on the dev server; full gate + build green.