### PR TITLE
content: point the Festival Múltiplo title at Zaratan's official page

### DIFF
--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -10,7 +10,7 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'festival-multiplo-2026',
-    title: '<a href="https://ma.to/event/festival-multiplo-21-aug-2026">Festival Múltiplo</a>',
+    title: '<a href="https://zaratan.pt/en/event/806">Festival Múltiplo</a>',
     date: '2026-08-23',
     venue: { name: 'Zaratan', url: 'https://zaratan.pt', city: 'Lisbon', country: 'Portugal' },
     description: 'With Água Doce, Alga, <a href="https://canadian-rifles.bandcamp.com/">Canadian Rifles</a>, Caranguejos, Double Double, Formidolor, <a href="https://joanadesa.work/">Joana de Sá</a>, <a href="https://llamavirgem.bandcamp.com/">Llama Virgem</a>, Musgos, Open Source 3IO, Pedro PMDS.',


### PR DESCRIPTION
Zaratan published a dedicated festival page, so the title link moves from the ma.to aggregator listing to the organizer's official English event page (https://zaratan.pt/en/event/806) — more authoritative and matching the Störung entry's pattern (title → festival's own page). Venue stays zaratan.pt. Full gate + build green; rendered title ↗ now resolves to the Zaratan page.