### PR TITLE
Decouple the link URL from the Live event title

### DIFF
--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -20,14 +20,16 @@ const plainEvent: LiveEvent = {
 
 const festivalEvent: LiveEvent = {
   id: 'madeiradig-2011',
-  title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+  title: 'MADEIRADIG',
+  titleUrl: 'https://digitalinberlin.eu/',
   date: '2011-12-02',
   venue: { name: 'Casa das Mudas', city: 'Calheta', country: 'Portugal' },
 };
 
 const internalRefEvent: LiveEvent = {
   id: 'aragao-funchal',
-  title: '<a href="/works#aragao">Aragão</a>',
+  title: 'Aragão',
+  titleUrl: '/works#aragao',
   date: '2021-09-22',
   venue: { name: 'Teatro Municipal Baltazar Dias', city: 'Funchal', country: 'Portugal' },
 };

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 
 import type { LightboxItem, LiveEvent } from '@/types';
 import { externalizeLinks } from '@/utils/externalizeLinks';
-import { formatEventDate, stripHtml } from '@/utils/formatters';
+import { formatEventDate } from '@/utils/formatters';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 
 import ExternalLink from './ExternalLink.vue';
@@ -21,15 +21,10 @@ const emit = defineEmits<{
 
 const formattedDate = computed(() => formatEventDate(props.event.date));
 
-// Some event titles embed a link (festival site or an internal /works ref).
-// Render the title as plain text (the deep-link permalink) and surface the
-// embedded link separately as a trailing icon, avoiding invalid nested anchors.
-const titleText = computed(() => stripHtml(props.event.title));
-
-const titleHref = computed(() => {
-  const match = props.event.title.match(/href="([^"]+)"/);
-  return match ? match[1] : null;
-});
+// A title may link to a festival/venue site or an internal /works ref. It stays
+// a plain permalink, with the link surfaced as a trailing icon (a new-tab
+// ExternalLink for http(s), a RouterLink for internal paths).
+const titleHref = computed(() => props.event.titleUrl ?? null);
 
 const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? ''));
 
@@ -57,18 +52,18 @@ const imageLabel = computed(() => (imageLightboxItems.value.length === 1 ? 'Phot
             class="event-title-link"
             :href="`#${event.id}`"
             @click.prevent="emit('update-hash', event.id)"
-          >{{ titleText }}</a>
+          >{{ event.title }}</a>
           <ExternalLink
             v-if="titleHref && titleHrefIsExternal"
             class="event-title-ref"
             :href="titleHref"
-            :aria-label="`${titleText} website (opens in a new tab)`"
+            :aria-label="`${event.title} website (opens in a new tab)`"
           ><IconArrow direction="up-right" /></ExternalLink>
           <RouterLink
             v-else-if="titleHref"
             class="event-title-ref"
             :to="titleHref"
-            :aria-label="`View ${titleText}`"
+            :aria-label="`View ${event.title}`"
           ><IconArrow direction="up-right" /></RouterLink>
         </strong>
       </p>

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -10,7 +10,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'festival-multiplo-2026',
-    title: '<a href="https://zaratan.pt/en/event/806">Festival Múltiplo</a>',
+    title: 'Festival Múltiplo',
+    titleUrl: 'https://zaratan.pt/en/event/806',
     date: '2026-08-23',
     venue: { name: 'Zaratan', url: 'https://zaratan.pt', city: 'Lisbon', country: 'Portugal' },
     description: 'With Água Doce, Alga, <a href="https://canadian-rifles.bandcamp.com/">Canadian Rifles</a>, Caranguejos, Double Double, Formidolor, <a href="https://joanadesa.work/">Joana de Sá</a>, <a href="https://llamavirgem.bandcamp.com/">Llama Virgem</a>, Musgos, Open Source 3IO, Pedro PMDS.',
@@ -27,7 +28,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'showcase-casa-amarela',
-    title: '<a href="https://outra.pt/evento/showcase-casa-amarela-copo-dagua-nox-tiaavo-rebolation-all-stars-dj-set/">Showcase Casa Amarela</a>',
+    title: 'Showcase Casa Amarela',
+    titleUrl: 'https://outra.pt/evento/showcase-casa-amarela-copo-dagua-nox-tiaavo-rebolation-all-stars-dj-set/',
     date: '2025-06-14',
     venue: { name: 'Cooperativa Mula', url: 'https://www.instagram.com/cooperativamula/', city: 'Barreiro', country: 'Portugal' },
     description: 'NOx (with <a href="https://cavernancia.bandcamp.com/">Pedro Roque</a>). With <a href="https://copodagua.bandcamp.com/">Copo d\'Água</a>, TiaAvô, Rebolation All-Stars.',
@@ -331,7 +333,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'aragao-cartaxo',
-    title: '<a href="/works#aragao">Aragão</a>',
+    title: 'Aragão',
+    titleUrl: '/works#aragao',
     date: '2021-10-23',
     venue: { name: 'Centro Cultural do Cartaxo', url: 'https://www.cm-cartaxo.pt/servicos-municipais/cultura/equipamentos-culturais/item/49-centro-cultural-municipio-do-cartaxo', city: 'Cartaxo', country: 'Portugal' },
     description: 'Theatre production. Live music & interpretation.',
@@ -371,7 +374,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'aragao-funchal',
-    title: '<a href="/works#aragao">Aragão</a>',
+    title: 'Aragão',
+    titleUrl: '/works#aragao',
     date: '2021-09-22',
     venue: { name: 'Teatro Municipal Baltazar Dias', url: 'https://www.teatromunicipal.pt/', city: 'Funchal', country: 'Portugal' },
     description: 'Theatre production. Live music & interpretation.',
@@ -460,7 +464,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'fica-na-cidade',
-    title: '<a href="https://www.visitfunchal.pt/pt/todos-os-eventos/280-fica-na-cidade.html">Fica na Cidade</a>',
+    title: 'Fica na Cidade',
+    titleUrl: 'https://www.visitfunchal.pt/pt/todos-os-eventos/280-fica-na-cidade.html',
     date: '2015-06-05',
     venue: { name: 'Praça de Colombo', city: 'Funchal', country: 'Portugal' },
     description: 'With <a href="https://trengosoundsystem.bandcamp.com/">Tren Go! Sound System</a>.',
@@ -481,7 +486,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'caligari-live-3',
-    title: '<a href="https://www.pontadosol.com/l-concerts">Concertos L</a>: The Cabinet of Dr. Caligari',
+    title: 'Concertos L: The Cabinet of Dr. Caligari',
+    titleUrl: 'https://www.pontadosol.com/l-concerts',
     date: '2013-10-26',
     venue: { name: 'Estalagem da Ponta do Sol', url: 'https://www.pontadosol.com/', city: 'Ponta do Sol', country: 'Portugal' },
     description: 'Live score for Robert Wiene\'s 1920 expressionist silent film. With <a href="https://nunoandtheend.bandcamp.com/">Nuno Filipe</a>.',
@@ -530,7 +536,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'madeiradig-2011',
-    title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+    title: 'MADEIRADIG',
+    titleUrl: 'https://digitalinberlin.eu/',
     date: '2011-12-02',
     venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
     description: 'Duo with <a href="https://12k.com/">Taylor Deupree</a>. With <a href="https://sunblind.net/">Tim Hecker</a>, <a href="https://pointnever.com/">Oneohtrix Point Never</a>, <a href="https://ktl10.bandcamp.com/">KTL</a>, <a href="https://deafcenter.bandcamp.com/">Deaf Center</a>, <a href="https://www.leeranaldo.com/">Lee Ranaldo</a> & Manuel Mota, <a href="https://nadja.bandcamp.com/">Nadja</a>, <a href="https://akionda.net/">Aki Onda</a>.',
@@ -621,7 +628,8 @@ export const liveEvents: LiveEvent[] = [
   {
     id: 'madeiradig-2009',
     date: '2009-12-04',
-    title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+    title: 'MADEIRADIG',
+    titleUrl: 'https://digitalinberlin.eu/',
     venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
     description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>. With <a href="https://www.alvanoto.com/">Alva Noto</a>, <a href="https://murcof.com/">Murcof</a>, <a href="https://felixkubin.bandcamp.com/">Felix Kubin</a>, <a href="https://www.discogs.com/artist/31633-Christ">Christ.</a>, <a href="https://zavoloka.com/">Zavoloka</a> & <a href="https://laetitiamorais.com/">Laetitia Morais</a>, <a href="https://gigantiq.bandcamp.com/">Gigantiq</a>, <a href="http://www.jade-enterprises.at/">Jade</a>.',
     imageAlt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, Casa das Mudas, Calheta, 2009',
@@ -756,7 +764,8 @@ export const liveEvents: LiveEvent[] = [
   {
     id: 'storung-2008',
     date: '2008-09-25',
-    title: '<a href="https://ra.co/promoters/4519">Störung</a>',
+    title: 'Störung',
+    titleUrl: 'https://ra.co/promoters/4519',
     venue: { name: 'La Farinera del Clot', url: 'https://farinera.org/', city: 'Barcelona', country: 'Spain' },
     description: 'With <a href="https://kimcascone.bandcamp.com/">Kim Cascone</a>, <a href="https://www.franciscolopez.net/">Francisco López</a>, <a href="https://philippepetit.bandcamp.com/">Philippe Petit</a>, <a href="https://ritornell.bandcamp.com/">Ritornell</a>, Sébastien Roux, Tonne.',
     imageAlt: 'Jerome Faria performing at Störung Festival, La Farinera del Clot, Barcelona, 2008',
@@ -800,7 +809,8 @@ export const liveEvents: LiveEvent[] = [
   {
     id: 'madeiradig-2007',
     date: '2007-12-08',
-    title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+    title: 'MADEIRADIG',
+    titleUrl: 'https://digitalinberlin.eu/',
     venue: { name: 'Casa das Mudas', url: 'https://museus.madeira.gov.pt/DetalhesMuseu?museumId=1', city: 'Calheta', country: 'Portugal' },
     description: 'With <a href="https://alogmusic.bandcamp.com/">Alog</a>, <a href="https://vladislavdelay.bandcamp.com/">Vladislav Delay</a>, <a href="https://ranslavin.com/">Ran Slavin</a>.',
     imageAlt: 'Jerome Faria performing at MADEIRADIG, Casa das Mudas, Calheta, 2007',
@@ -849,7 +859,8 @@ export const liveEvents: LiveEvent[] = [
   },
   {
     id: 'madeiradig-2006',
-    title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+    title: 'MADEIRADIG',
+    titleUrl: 'https://digitalinberlin.eu/',
     date: '2006-12-07',
     venue: { name: 'RDP Auditorium', url: 'https://madeira.rtp.pt/', city: 'Funchal', country: 'Portugal' },
     description: 'With <a href="https://phonophani.bandcamp.com/">Phonophani</a> & <a href="https://mariuswatz.com/">Marius Watz</a>, <a href="https://frankbretschneider.bandcamp.com/">Frank Bretschneider</a>.',
@@ -857,7 +868,8 @@ export const liveEvents: LiveEvent[] = [
   {
     id: 'madeiradig-2005',
     date: '2005-12-07',
-    title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+    title: 'MADEIRADIG',
+    titleUrl: 'https://digitalinberlin.eu/',
     venue: { name: 'RDP Auditorium', url: 'https://madeira.rtp.pt/', city: 'Funchal', country: 'Portugal' },
     description: 'Duo with <a href="https://vimeo.com/hugoolim">Hugo Olim</a>. With <a href="https://www.fennesz.com/">Fennesz</a>, <a href="https://florianhecker.blogspot.com/">Florian Hecker</a>, <a href="https://at-c.org/">@c</a> & <a href="https://liaworks.com/">Lia</a>.',
     imageAlt: 'Jerome Faria and Hugo Olim performing at MADEIRADIG, RDP Auditorium, Funchal, 2005',

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -23,6 +23,7 @@ export interface EventVenue {
 export interface LiveEvent {
   id: string;
   title: string;
+  titleUrl?: string;
   date: string;
   venue: EventVenue;
   description?: string;

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,59 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatEventDate, stripHtml } from './formatters';
+import { formatEventDate } from './formatters';
 
 describe('formatters', () => {
-  describe('stripHtml', () => {
-    it('should remove simple HTML tags', () => {
-      const html = '<p>Hello World</p>';
-      expect(stripHtml(html)).toBe('Hello World');
-    });
-
-    it('should remove nested HTML tags', () => {
-      const html = '<div><p>Hello <strong>World</strong></p></div>';
-      expect(stripHtml(html)).toBe('Hello World');
-    });
-
-    it('should handle self-closing tags', () => {
-      const html = 'Line 1<br/>Line 2';
-      expect(stripHtml(html)).toBe('Line 1Line 2');
-    });
-
-    it('should handle img tags', () => {
-      const html = 'Text <img src="image.jpg" alt="test"/> more text';
-      expect(stripHtml(html)).toBe('Text  more text');
-    });
-
-    it('should preserve text content only', () => {
-      const html = '<a href="https://example.com">Click here</a>';
-      expect(stripHtml(html)).toBe('Click here');
-    });
-
-    it('should handle empty strings', () => {
-      expect(stripHtml('')).toBe('');
-    });
-
-    it('should handle strings with no HTML', () => {
-      const text = 'Plain text';
-      expect(stripHtml(text)).toBe('Plain text');
-    });
-
-    it('should handle multiple tags in a row', () => {
-      const html = '<p></p><div></div>Content';
-      expect(stripHtml(html)).toBe('Content');
-    });
-
-    it('should handle tags with attributes', () => {
-      const html = '<div class="container" id="main"><span style="color: red;">Text</span></div>';
-      expect(stripHtml(html)).toBe('Text');
-    });
-
-    it('should handle null/undefined gracefully', () => {
-      expect(stripHtml(null as unknown as string)).toBe('');
-      expect(stripHtml(undefined as unknown as string)).toBe('');
-    });
-  });
-
   describe('formatEventDate', () => {
     it('formats an ISO date as "Month Day, Year"', () => {
       expect(formatEventDate('2024-03-15')).toBe('March 15, 2024');

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,11 +1,4 @@
 /**
- * Strip HTML tags from a string
- * @param html - HTML string to strip
- * @returns Plain text without HTML tags
- */
-export const stripHtml = (html: string): string => html?.replace(/<[^>]*>/g, '') || '';
-
-/**
  * Format an ISO date string as a human-readable date
  * @param isoDate - Date in ISO format (YYYY-MM-DD)
  * @returns Formatted date (e.g., "January 17, 2025"), or '' when empty

--- a/src/utils/schemaHelpers.test.ts
+++ b/src/utils/schemaHelpers.test.ts
@@ -6,13 +6,14 @@ import { createItemListSchema, createMusicAlbumSchema, createMusicEventSchema } 
 
 const baseEvent: LiveEvent = {
   id: 'madeiradig-2011',
-  title: '<a href="https://digitalinberlin.eu/">MADEIRADIG</a>',
+  title: 'MADEIRADIG',
+  titleUrl: 'https://digitalinberlin.eu/',
   date: '2011-12-02',
   venue: { name: 'Casa das Mudas', url: 'https://example.com', city: 'Calheta', country: 'Portugal' },
 };
 
 describe('createMusicEventSchema', () => {
-  it('strips HTML from the title for the schema name', () => {
+  it('uses the event title as the schema name', () => {
     const schema = createMusicEventSchema(baseEvent, 'Jerome Faria');
     expect(schema.name).toBe('MADEIRADIG');
   });

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -1,8 +1,6 @@
 import type { LiveEvent } from '@/types/live';
 import type { SchemaItemList, SchemaMusicAlbum, SchemaMusicEvent } from '@/types/schema';
 
-import { stripHtml } from './formatters';
-
 interface ReleaseForSchema {
   title: string;
   bandcampUrl?: string;
@@ -24,7 +22,7 @@ export const createMusicEventSchema = (
   fallbackDate = '',
 ): SchemaMusicEvent => ({
   '@type': 'MusicEvent',
-  name: stripHtml(event.title),
+  name: event.title,
   startDate: event.date || fallbackDate,
   location: {
     '@type': 'Place',


### PR DESCRIPTION
## Description

Decouples the link URL from the Live event **title** in the data model. Previously a linked title was an HTML string with an embedded anchor (`'<a href="…">MADEIRADIG</a>'`) that `EventItem` regex-parsed at render time. The link is now a typed `titleUrl` field and the title is plain text.

## Motivation

HTML-in-data + regex extraction was a modeling smell: the title's text and its link were entangled in one string, the URL had to be recovered with `title.match(/href="…"/)`, and the type system couldn't see the link at all.

## Changes

- **`LiveEvent`** gains an optional `titleUrl?: string`; `title` is now plain text.
- **`EventItem`** reads `title` / `titleUrl` directly — no `stripHtml`, no regex. The trailing link icon is still an internal/external decision derived from the URL (a new-tab `ExternalLink` for `http(s)`, a `RouterLink` for `/works#…`).
- **Data** — migrated all 12 linked titles (Festival Múltiplo, Showcase, both Aragão, Fica na Cidade, Concertos L, five MADEIRADIG, Störung). The one compound title ("Concertos L: The Cabinet of Dr. Caligari", where only part was linked) is preserved exactly, since the render already flattened to full-plain-text + a trailing icon.
- **`schemaHelpers`** — the JSON-LD event `name` now uses the plain `event.title` directly.
- **Removed `stripHtml`** (+ its tests): the two callers above were its only users, so it is now dead code.

## Notes

- `check-anchors.js` needs no change — it scans `JSON.stringify(sortedLiveData)`, so the internal `/works#aragao` links are still validated now that they live in `titleUrl` (build confirms: "31 anchor links… all resolve").
- **Rendering is unchanged** — verified in the production build that external titles render a new-tab icon to their site and internal ones a same-tab RouterLink to `/works#…`.

## Testing

1. `npm ci && npm run dev`
2. **/live** → **Festival Múltiplo**: title reads plain, with a trailing ↗ icon opening zaratan.pt in a new tab.
3. **/live** → **Aragão**: trailing ↗ icon is a same-tab link to `/works#aragao` (no new tab).
4. **/live** → **Concertos L: The Cabinet of Dr. Caligari**: full title renders as the permalink, trailing icon opens pontadosol.com.
5. Plain-title events (e.g. Fim de Emissão #45) show no trailing icon.

Gate: type-check, lint, 372 unit tests, coverage above floor (lines 99.4 / stmts 98.3 / funcs 97.4 / branches 93.6), production build (incl. `check-anchors`) + SSG.
