### PR TITLE
Audit cleanups: composable/component refactors

### DIFF
--- a/src/components/BandcampPlayer.test.ts
+++ b/src/components/BandcampPlayer.test.ts
@@ -58,62 +58,54 @@ describe('BandcampPlayer', () => {
   describe('loading the player', () => {
     it('shows the iframe after clicking the player', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('iframe').exists()).toBe(true);
     });
 
     it('hides the cover image after clicking', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('picture').exists()).toBe(false);
     });
 
     it('hides the play button after clicking', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('.bandcamp-player__button').exists()).toBe(false);
     });
 
     it('shows a loading indicator before iframe fires load', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('.bandcamp-player__loading').exists()).toBe(true);
     });
 
     it('hides the loading indicator after iframe fires load', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       await wrapper.find('iframe').trigger('load');
       expect(wrapper.find('.bandcamp-player__loading').exists()).toBe(false);
     });
 
     it('adds the loading class while iframe is loading', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('.bandcamp-player').classes()).toContain('bandcamp-player--loading');
     });
 
     it('removes the loading class after iframe fires load', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       await wrapper.find('iframe').trigger('load');
       expect(wrapper.find('.bandcamp-player').classes()).not.toContain('bandcamp-player--loading');
     });
 
-    it('does not re-open player on second click', async () => {
-      const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
-      await wrapper.find('iframe').trigger('load');
-      await wrapper.find('.bandcamp-player').trigger('click');
-      // Still only one iframe
-      expect(wrapper.findAll('iframe')).toHaveLength(1);
-    });
   });
 
   describe('iframe attributes', () => {
     it('uses the correct Bandcamp embed URL', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       const iframeSrc = wrapper.find('iframe').attributes('src');
       expect(iframeSrc).toContain(DEFAULT_PROPS.albumId);
       expect(iframeSrc).toContain('bandcamp.com/EmbeddedPlayer');
@@ -121,13 +113,13 @@ describe('BandcampPlayer', () => {
 
     it('has a descriptive title attribute', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('iframe').attributes('title')).toContain(DEFAULT_PROPS.albumTitle);
     });
 
     it('uses sandbox attribute for security', async () => {
       const wrapper = mountPlayer();
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('iframe').attributes('sandbox')).toBeTruthy();
     });
   });
@@ -154,7 +146,7 @@ describe('BandcampPlayer', () => {
     it('still opens player on click after image error', async () => {
       const wrapper = mountPlayer();
       await wrapper.find('img').trigger('error');
-      await wrapper.find('.bandcamp-player').trigger('click');
+      await wrapper.find('.bandcamp-player__button').trigger('click');
       expect(wrapper.find('iframe').exists()).toBe(true);
     });
   });

--- a/src/components/BandcampPlayer.vue
+++ b/src/components/BandcampPlayer.vue
@@ -26,7 +26,6 @@ const embedUrl = computed(() =>
   `https://bandcamp.com/EmbeddedPlayer/album=${props.albumId}/${BANDCAMP_EMBED_PARAMS}/`);
 
 const loadPlayer = () => {
-  if (showPlayer.value) return;
   showPlayer.value = true;
 };
 
@@ -39,7 +38,6 @@ const handleIframeLoad = () => {
   <div
     class="bandcamp-player"
     :class="{ 'bandcamp-player--loading': showPlayer && !isLoaded, 'bandcamp-player--error': imageError }"
-    @click="loadPlayer"
   >
     <picture v-if="!showPlayer && !imageError">
       <source
@@ -68,6 +66,7 @@ const handleIframeLoad = () => {
       class="bandcamp-player__button"
       type="button"
       :aria-label="`Play ${albumTitle}`"
+      @click="loadPlayer"
     />
     <div
       v-if="showPlayer && !isLoaded"

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -5,6 +5,7 @@ import type { LightboxItem, LiveEvent } from '@/types';
 import { externalizeLinks } from '@/utils/externalizeLinks';
 import { formatEventDate } from '@/utils/formatters';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
+import { pluralize } from '@/utils/pluralize';
 
 import ExternalLink from './ExternalLink.vue';
 import IconArrow from './IconArrow.vue';
@@ -32,12 +33,15 @@ const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? '
 const venueLocation = computed(() =>
   [props.event.venue.city, props.event.venue.country].filter(Boolean).join(', '));
 
+// Comma between the venue name and its city/country, only when both are present.
+const venueSeparator = computed(() => (props.event.venue.name && venueLocation.value ? ', ' : ''));
+
 const imageLightboxItems = computed<LightboxItem[]>(() =>
   props.event.images?.map(image =>
     toLightboxImage({ ...image, alt: image.alt ?? props.event.imageAlt ?? '' })) ?? []);
 const posterLightboxItems = computed<LightboxItem[]>(() => props.event.posters?.map(toLightboxImage) ?? []);
 const videoLightboxItems = computed<LightboxItem[]>(() => props.event.videos?.map(toLightboxVideo) ?? []);
-const imageLabel = computed(() => (imageLightboxItems.value.length === 1 ? 'Photo' : 'Photos'));
+const imageLabel = computed(() => pluralize(imageLightboxItems.value.length, 'Photo'));
 </script>
 
 <template>
@@ -72,10 +76,10 @@ const imageLabel = computed(() => (imageLightboxItems.value.length === 1 ? 'Phot
           v-if="event.date"
           class="event-date"
         >{{ formattedDate }} · </span>
-        <span class="event-venue"><template v-if="event.venue.name"><a
-          v-if="event.venue.url"
+        <span class="event-venue"><a
+          v-if="event.venue.name && event.venue.url"
           :href="event.venue.url"
-        >{{ event.venue.name }}</a><template v-else>{{ event.venue.name }}</template><template v-if="venueLocation">, </template></template>{{ venueLocation }}</span>
+        >{{ event.venue.name }}</a><template v-else-if="event.venue.name">{{ event.venue.name }}</template>{{ venueSeparator }}{{ venueLocation }}</span>
       </p>
       <p
         v-if="event.description"

--- a/src/components/MediaLinks.vue
+++ b/src/components/MediaLinks.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 
 import type { LightboxItem } from '@/types';
+import { pluralize } from '@/utils/pluralize';
 
 const props = withDefaults(
   defineProps<{
@@ -21,8 +22,8 @@ const emit = defineEmits<{
 const links = computed(() =>
   [
     { items: props.images, label: props.imageLabel },
-    { items: props.posters, label: props.posters.length === 1 ? 'Poster' : 'Posters' },
-    { items: props.videos, label: props.videos.length === 1 ? 'Video' : 'Videos' },
+    { items: props.posters, label: pluralize(props.posters.length, 'Poster') },
+    { items: props.videos, label: pluralize(props.videos.length, 'Video') },
   ].filter(link => link.items.length));
 </script>
 

--- a/src/composables/useContactForm.ts
+++ b/src/composables/useContactForm.ts
@@ -79,6 +79,8 @@ export const useContactForm = (submitUrl: string): UseContactFormReturn => {
     isSubmitting.value = true;
     const formDataToSend = new FormData(form);
 
+    // Progressive enhancement: POST via fetch, falling back to a native form
+    // submission on a non-2xx response or a network/CORS failure.
     try {
       const response = await fetch(submitUrl, {
         method: 'POST',
@@ -91,17 +93,14 @@ export const useContactForm = (submitUrl: string): UseContactFormReturn => {
       if (response.ok) {
         showSuccess.value = true;
         resetForm();
-        isSubmitting.value = false;
-      } else {
-        // If response not ok, use regular form submission
-        isSubmitting.value = false;
-        form.submit();
+        return;
       }
-    } catch (error) {
-      // If fetch fails (CORS, network error), fall back to regular form submission
-      console.error('Form submission error:', error);
-      isSubmitting.value = false;
       form.submit();
+    } catch (error) {
+      console.error('Form submission error:', error);
+      form.submit();
+    } finally {
+      isSubmitting.value = false;
     }
   };
 

--- a/src/composables/useLightbox.ts
+++ b/src/composables/useLightbox.ts
@@ -55,8 +55,6 @@ export const useLightbox = (): UseLightboxReturn => {
     const item = items.value[index];
     if (!item) return;
 
-    // Support both image and video items
-    // Images have 'src', videos have 'url'
     currentItem.value = item;
   };
 

--- a/src/composables/useLightboxWithSwipe.ts
+++ b/src/composables/useLightboxWithSwipe.ts
@@ -4,19 +4,8 @@ import { useSwipeNavigation, type UseSwipeNavigationReturn } from './useSwipeNav
 type UseLightboxWithSwipeReturn = UseLightboxReturn & UseSwipeNavigationReturn;
 
 export const useLightboxWithSwipe = (): UseLightboxWithSwipeReturn => {
-  const { isOpen, currentItem, currentIndex, items, openLightbox, closeLightbox, goToNext, goToPrev } = useLightbox();
-  const { handleTouchStart, handleTouchEnd } = useSwipeNavigation(goToNext, goToPrev);
+  const lightbox = useLightbox();
+  const swipe = useSwipeNavigation(lightbox.goToNext, lightbox.goToPrev);
 
-  return {
-    isOpen,
-    currentItem,
-    currentIndex,
-    items,
-    openLightbox,
-    closeLightbox,
-    goToNext,
-    goToPrev,
-    handleTouchStart,
-    handleTouchEnd,
-  };
+  return { ...lightbox, ...swipe };
 };

--- a/src/composables/usePageHead.ts
+++ b/src/composables/usePageHead.ts
@@ -64,16 +64,12 @@ export const usePageHead = ({
     link.push({ rel: 'preload', as: 'image', type: 'image/webp', href: preloadImage, fetchpriority: 'high' });
   }
 
-  const headConfig: Record<string, unknown> = { title: fullTitle, meta, link };
-
-  if (schema) {
-    headConfig['script'] = [
-      {
-        type: 'application/ld+json',
-        innerHTML: JSON.stringify(schema),
-      },
-    ];
-  }
-
-  useHead(headConfig);
+  useHead({
+    title: fullTitle,
+    meta,
+    link,
+    ...(schema && {
+      script: [{ type: 'application/ld+json', innerHTML: JSON.stringify(schema) }],
+    }),
+  });
 };

--- a/src/composables/useSwipeNavigation.ts
+++ b/src/composables/useSwipeNavigation.ts
@@ -1,6 +1,3 @@
-import type { Ref } from 'vue';
-import { ref } from 'vue';
-
 import { TOUCH } from '@/utils/constants';
 
 export interface UseSwipeNavigationReturn {
@@ -24,13 +21,14 @@ export const useSwipeNavigation = (
   onSwipeLeft: () => void,
   onSwipeRight: () => void,
 ): UseSwipeNavigationReturn => {
-  const touchStart: Ref<TouchPosition> = ref({ x: 0, y: 0, time: 0 });
+  // Internal handle only — never rendered, so a plain binding (no reactivity).
+  let touchStart: TouchPosition = { x: 0, y: 0, time: 0 };
 
   const handleTouchStart = (event: TouchEvent): void => {
     const touch = event.touches[0];
     if (!touch) return;
 
-    touchStart.value = {
+    touchStart = {
       x: touch.clientX,
       y: touch.clientY,
       time: Date.now(),
@@ -41,9 +39,9 @@ export const useSwipeNavigation = (
     const touch = event.changedTouches[0];
     if (!touch) return;
 
-    const deltaX = touch.clientX - touchStart.value.x;
-    const deltaY = touch.clientY - touchStart.value.y;
-    const deltaTime = Date.now() - touchStart.value.time;
+    const deltaX = touch.clientX - touchStart.x;
+    const deltaY = touch.clientY - touchStart.y;
+    const deltaTime = Date.now() - touchStart.time;
 
     // Check if it's a horizontal swipe (not vertical scroll)
     const isHorizontalSwipe = Math.abs(deltaX) > Math.abs(deltaY);

--- a/src/utils/pluralize.test.ts
+++ b/src/utils/pluralize.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { pluralize } from './pluralize';
+
+describe('pluralize', () => {
+  it('returns the singular for a count of 1', () => {
+    expect(pluralize(1, 'Photo')).toBe('Photo');
+  });
+
+  it('appends "s" by default for any non-1 count', () => {
+    expect(pluralize(0, 'Poster')).toBe('Posters');
+    expect(pluralize(3, 'Video')).toBe('Videos');
+  });
+
+  it('uses an explicit plural when the default does not apply', () => {
+    expect(pluralize(2, 'Gallery', 'Galleries')).toBe('Galleries');
+  });
+});

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -1,0 +1,8 @@
+/**
+ * Pick the singular or plural noun for a count.
+ * @param count - How many items
+ * @param singular - The singular noun
+ * @param plural - The plural noun (defaults to `${singular}s`)
+ */
+export const pluralize = (count: number, singular: string, plural = `${singular}s`): string =>
+  (count === 1 ? singular : plural);


### PR DESCRIPTION
Second of the audit-fix PRs — behavior-preserving cleanups (no user-visible change). Verified with unit tests + lightbox/contact-form E2E.

## Changes (audit findings)
- **#10** `useContactForm` — the "reset `isSubmitting`" invariant is scattered across three branches; hoisted into `finally`, and the duplicated not-ok/catch fallbacks collapse to one native `form.submit()` per failure mode.
- **#11** `useLightboxWithSwipe` — replaced the manual destructure-and-relist of the whole lightbox surface with a spread (`{ ...lightbox, ...swipe }`), so adding a lightbox member can't be silently dropped.
- **#19** `useSwipeNavigation` — the non-rendered touch-start handle uses a plain `let` instead of a `ref` (no dead reactivity); consistent with `useLightbox`.
- **#13** `usePageHead` — inline typed head config with a conditional spread instead of a `Record<string, unknown>` accumulator + stringly-keyed write.
- **#14** `BandcampPlayer` — the click handler + accessible name move onto the full-area overlay `<button>` (it's `absolute-fill`, so the click target is unchanged); interactivity is no longer split across a `div`. The now-unreachable `loadPlayer` idempotency guard and its obsolete test are removed.
- **#15** extracted a `pluralize(count, singular, plural?)` helper and applied it to the media-control labels, unifying the ad-hoc `=== 1 ? …` ternaries.
- **#12** `EventItem` — named the venue-line separator in a `venueSeparator` computed so the venue markup's conditionals are legible (render is identical — guarded by the exact-string venue tests).
- **#19** removed a misleading comment in `useLightbox`.

## Deferred (need your call — see PR discussion)
- **#19 lightbox nav-test skip** — the fix needs a guaranteed multi-image gallery fixture; naive approaches couple the tests to specific content. Worth a dedicated fixture rather than a rushed edit.
- **#8/tests ReleaseMeta characterization tax** — retiring/trimming it changes a test guarantee and affects `ReleaseMeta.vue` branch coverage; deserves an explicit decision.
- **#9 ContactView `FormField` extraction** — larger, higher-regression-surface; its own PR next.

## Testing
Type-check, lint, 374 unit tests, coverage above floor, production build, plus lightbox + contact-form E2E (chromium) — all green.