### PR TITLE
Extract FormField from ContactView

### DIFF
--- a/src/components/FormField.test.ts
+++ b/src/components/FormField.test.ts
@@ -1,0 +1,67 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import FormField from './FormField.vue';
+
+const mountField = (props: Record<string, unknown>, slots = {}) =>
+  mount(FormField, { props: { id: 'name', label: 'Name', modelValue: '', ...props }, slots });
+
+describe('FormField', () => {
+  it('renders a labelled text input by default, named and id-matched', () => {
+    const field = mountField({});
+    const input = field.get('input');
+
+    expect(input.attributes('id')).toBe('name');
+    expect(input.attributes('name')).toBe('name');
+    expect(input.attributes('type')).toBe('text');
+    expect(field.get('label').attributes('for')).toBe('name');
+    expect(field.get('label').text()).toContain('Name');
+  });
+
+  it('renders a textarea when type is "textarea"', () => {
+    const field = mountField({ id: 'message', label: 'Message', type: 'textarea', rows: 8 });
+
+    expect(field.find('textarea').exists()).toBe(true);
+    expect(field.find('input').exists()).toBe(false);
+    expect(field.get('textarea').attributes('rows')).toBe('8');
+  });
+
+  it('shows a required marker only when required', () => {
+    expect(mountField({ required: true }).find('abbr').exists()).toBe(true);
+    expect(mountField({ required: false }).find('abbr').exists()).toBe(false);
+  });
+
+  it('exposes an announced error and aria wiring when invalid', () => {
+    const field = mountField({ invalid: true, error: 'Name is required' });
+
+    expect(field.get('input').attributes('aria-invalid')).toBe('true');
+    expect(field.get('input').attributes('aria-describedby')).toBe('name-error');
+    const error = field.get('#name-error');
+    expect(error.attributes('role')).toBe('alert');
+    expect(error.text()).toBe('Name is required');
+  });
+
+  it('omits aria-invalid entirely for an unvalidated field (invalid undefined)', () => {
+    const field = mountField({});
+
+    expect(field.get('input').attributes('aria-invalid')).toBeUndefined();
+    expect(field.find('.contact-form__error').exists()).toBe(false);
+  });
+
+  it('emits update:modelValue and input on input, and blur on blur', async () => {
+    const field = mountField({});
+    const input = field.get('input');
+
+    await input.setValue('Ada');
+    expect(field.emitted('update:modelValue')?.[0]).toEqual(['Ada']);
+    expect(field.emitted('input')).toHaveLength(1);
+
+    await input.trigger('blur');
+    expect(field.emitted('blur')).toHaveLength(1);
+  });
+
+  it('renders slotted content (e.g. a hidden reply-to input)', () => {
+    const field = mountField({}, { default: '<input type="hidden" name="_replyto">' });
+    expect(field.find('input[name="_replyto"]').exists()).toBe(true);
+  });
+});

--- a/src/components/FormField.vue
+++ b/src/components/FormField.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  id: string;
+  label: string;
+  modelValue: string;
+  type?: 'text' | 'email' | 'textarea' | undefined;
+  required?: boolean | undefined;
+  autocomplete?: string | undefined;
+  rows?: number | undefined;
+  invalid?: boolean | undefined;
+  error?: string | undefined;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+  input: [];
+  blur: [];
+}>();
+
+// A field is validated when the parent supplies an `error` slot for it; only
+// then does it carry aria-invalid (the optional subject omits it entirely).
+const ariaInvalid = computed(() => (props.error === undefined ? undefined : props.invalid));
+
+const onInput = (event: Event): void => {
+  emit('update:modelValue', (event.target as HTMLInputElement | HTMLTextAreaElement).value);
+  emit('input');
+};
+</script>
+
+<template>
+  <div class="contact-form__field">
+    <label
+      :for="id"
+      class="contact-form__label"
+    >
+      {{ label }}
+      <abbr
+        v-if="required"
+        title="Required"
+      >*</abbr>
+    </label>
+
+    <textarea
+      v-if="type === 'textarea'"
+      :id="id"
+      :name="id"
+      :value="modelValue"
+      :class="['contact-form__textarea', { 'contact-form__textarea--invalid': invalid }]"
+      :rows="rows"
+      :required="required"
+      :aria-invalid="ariaInvalid"
+      :aria-describedby="invalid ? `${id}-error` : undefined"
+      @input="onInput"
+      @blur="emit('blur')"
+    />
+    <input
+      v-else
+      :id="id"
+      :name="id"
+      :value="modelValue"
+      :type="type ?? 'text'"
+      :class="['contact-form__input', { 'contact-form__input--invalid': invalid }]"
+      :autocomplete="autocomplete"
+      :required="required"
+      :aria-invalid="ariaInvalid"
+      :aria-describedby="invalid ? `${id}-error` : undefined"
+      @input="onInput"
+      @blur="emit('blur')"
+    >
+
+    <span
+      v-if="invalid"
+      :id="`${id}-error`"
+      class="contact-form__error"
+      role="alert"
+    >{{ error }}</span>
+
+    <slot />
+  </div>
+</template>

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import FormField from '@/components/FormField.vue';
 import PageShell from '@/components/PageShell.vue';
 import { useContactForm } from '@/composables/useContactForm';
 import { usePageHead } from '@/composables/usePageHead';
@@ -64,124 +65,58 @@ const { formData, isSubmitting, showSuccess, isFormValid, fieldInvalid, errors, 
           aria-label="Leave this field empty"
         >
 
-        <div class="contact-form__field">
-          <label
-            for="name"
-            class="contact-form__label"
-          >
-            {{ contactContent.form.fields.name.label }}
-            <abbr
-              v-if="contactContent.form.fields.name.required"
-              title="Required"
-            >*</abbr>
-          </label>
-          <input
-            id="name"
-            v-model="formData.name"
-            type="text"
-            name="name"
-            :class="['contact-form__input', { 'contact-form__input--invalid': fieldInvalid.name }]"
-            :autocomplete="contactContent.form.fields.name.autocomplete"
-            :required="contactContent.form.fields.name.required"
-            :aria-invalid="fieldInvalid.name"
-            :aria-describedby="fieldInvalid.name ? 'name-error' : undefined"
-            @input="handleInput"
-            @blur="handleBlur('name')"
-          >
-          <span
-            v-if="fieldInvalid.name"
-            id="name-error"
-            class="contact-form__error"
-            role="alert"
-          >{{ errors.name }}</span>
-        </div>
+        <FormField
+          id="name"
+          v-model="formData.name"
+          :label="contactContent.form.fields.name.label"
+          :required="contactContent.form.fields.name.required"
+          :autocomplete="contactContent.form.fields.name.autocomplete"
+          :invalid="fieldInvalid.name"
+          :error="errors.name"
+          @input="handleInput"
+          @blur="handleBlur('name')"
+        />
 
-        <div class="contact-form__field">
-          <label
-            for="email"
-            class="contact-form__label"
-          >
-            {{ contactContent.form.fields.email.label }}
-            <abbr
-              v-if="contactContent.form.fields.email.required"
-              title="Required"
-            >*</abbr>
-          </label>
-          <input
-            id="email"
-            v-model="formData.email"
-            type="email"
-            name="email"
-            :class="['contact-form__input', { 'contact-form__input--invalid': fieldInvalid.email }]"
-            :autocomplete="contactContent.form.fields.email.autocomplete"
-            :required="contactContent.form.fields.email.required"
-            :aria-invalid="fieldInvalid.email"
-            :aria-describedby="fieldInvalid.email ? 'email-error' : undefined"
-            @input="handleInput"
-            @blur="handleBlur('email')"
-          >
-          <span
-            v-if="fieldInvalid.email"
-            id="email-error"
-            class="contact-form__error"
-            role="alert"
-          >{{ errors.email }}</span>
+        <FormField
+          id="email"
+          v-model="formData.email"
+          type="email"
+          :label="contactContent.form.fields.email.label"
+          :required="contactContent.form.fields.email.required"
+          :autocomplete="contactContent.form.fields.email.autocomplete"
+          :invalid="fieldInvalid.email"
+          :error="errors.email"
+          @input="handleInput"
+          @blur="handleBlur('email')"
+        >
           <!-- FormSubmit: use email as reply-to -->
           <input
             type="hidden"
             :name="FORM_SUBMIT.REPLY_TO"
             :value="formData.email"
           >
-        </div>
+        </FormField>
 
-        <div class="contact-form__field">
-          <label
-            for="subject"
-            class="contact-form__label"
-          >
-            {{ contactContent.form.fields.subject.label }}
-          </label>
-          <input
-            id="subject"
-            v-model="formData.subject"
-            type="text"
-            name="subject"
-            class="contact-form__input"
-            :autocomplete="contactContent.form.fields.subject.autocomplete"
-            @input="handleInput"
-          >
-        </div>
+        <FormField
+          id="subject"
+          v-model="formData.subject"
+          :label="contactContent.form.fields.subject.label"
+          :autocomplete="contactContent.form.fields.subject.autocomplete"
+          @input="handleInput"
+        />
 
-        <div class="contact-form__field">
-          <label
-            for="message"
-            class="contact-form__label"
-          >
-            {{ contactContent.form.fields.message.label }}
-            <abbr
-              v-if="contactContent.form.fields.message.required"
-              title="Required"
-            >*</abbr>
-          </label>
-          <textarea
-            id="message"
-            v-model="formData.message"
-            name="message"
-            :class="['contact-form__textarea', { 'contact-form__textarea--invalid': fieldInvalid.message }]"
-            :rows="contactContent.form.fields.message.rows"
-            :required="contactContent.form.fields.message.required"
-            :aria-invalid="fieldInvalid.message"
-            :aria-describedby="fieldInvalid.message ? 'message-error' : undefined"
-            @input="handleInput"
-            @blur="handleBlur('message')"
-          />
-          <span
-            v-if="fieldInvalid.message"
-            id="message-error"
-            class="contact-form__error"
-            role="alert"
-          >{{ errors.message }}</span>
-        </div>
+        <FormField
+          id="message"
+          v-model="formData.message"
+          type="textarea"
+          :label="contactContent.form.fields.message.label"
+          :rows="contactContent.form.fields.message.rows"
+          :required="contactContent.form.fields.message.required"
+          :invalid="fieldInvalid.message"
+          :error="errors.message"
+          @input="handleInput"
+          @blur="handleBlur('message')"
+        />
 
         <button
           type="submit"


### PR DESCRIPTION
Audit finding #9. The name/email/subject/message fields repeated the same *label + required marker + input/textarea + announced-error* cluster, making `ContactView` the largest view (196 lines).

## Change
- New `FormField` component: renders an `<input>` or `<textarea>` by `type`, drives the required `<abbr>`, and wires `aria-invalid` / `aria-describedby` / the `role="alert"` error span. A default `<slot>` carries the email reply-to hidden input.
- `ContactView` now declares the four fields declaratively via `FormField`.

## Behavior-identical
The optional **subject** isn't a validated field, so it must omit `aria-invalid`. Vue coerces an absent boolean prop to `false`, so `FormField` gates `aria-invalid` on whether the parent supplied an `error` (validated fields do; subject doesn't). Verified in the production build:

```
name:    aria-invalid="false"
email:   aria-invalid="false"
subject: aria-invalid ABSENT
message: aria-invalid="false"
```

## Testing
- New `FormField.test.ts` (input vs textarea, required marker, invalid/aria wiring, undefined-invalid omission, v-model/input/blur emits, slot).
- Existing `ContactView.test.ts` unchanged and green (integration).
- Type-check, lint, 381 unit tests, coverage above floor, production build, plus contact-form + accessibility E2E (chromium) green.