### PR TITLE
Model image credits explicitly (Credit + role)

### DIFF
--- a/src/components/EventItem.test.ts
+++ b/src/components/EventItem.test.ts
@@ -110,10 +110,11 @@ describe('EventItem', () => {
       expect(button.attributes('aria-label')).toBe('View photos');
     });
 
-    it('emits open-lightbox with the converted images on click', async () => {
+    it('emits open-lightbox with the converted images (photo-role credit) on click', async () => {
       const wrapper = mountEvent({
         ...plainEvent,
-        images: [{ src: '/images/live/a-001.jpg', alt: 'A', photographer: { name: 'Someone' } }],
+        imageAlt: 'A live photo',
+        images: [{ src: '/images/live/a-001.jpg', photographer: { name: 'Someone' } }],
       });
 
       await wrapper.get('.media-links button').trigger('click');
@@ -121,15 +122,15 @@ describe('EventItem', () => {
 
       expect(payload?.[1]).toBe(0);
       expect(payload?.[0]).toEqual([
-        { type: 'image', src: '/images/live/a-001.jpg', alt: 'A', photographer: { name: 'Someone' } },
+        { type: 'image', src: '/images/live/a-001.jpg', alt: 'A live photo', credit: { role: 'photo', name: 'Someone' } },
       ]);
     });
 
-    it('falls back to the event imageAlt when an image has no alt of its own', async () => {
+    it('applies the event imageAlt to every photo', async () => {
       const wrapper = mountEvent({
         ...plainEvent,
         imageAlt: 'Event-level description',
-        images: [{ src: '/images/live/a-001.jpg' }, { src: '/images/live/a-002.jpg', alt: 'Override' }],
+        images: [{ src: '/images/live/a-001.jpg' }, { src: '/images/live/a-002.jpg' }],
       });
 
       await wrapper.get('.media-links button').trigger('click');
@@ -137,7 +138,7 @@ describe('EventItem', () => {
 
       expect((payload?.[0] as Array<{ alt: string }>).map(item => item.alt)).toEqual([
         'Event-level description',
-        'Override',
+        'Event-level description',
       ]);
     });
 

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -38,7 +38,7 @@ const venueSeparator = computed(() => (props.event.venue.name && venueLocation.v
 
 const imageLightboxItems = computed<LightboxItem[]>(() =>
   props.event.images?.map(image =>
-    toLightboxImage({ ...image, alt: image.alt ?? props.event.imageAlt ?? '' })) ?? []);
+    toLightboxImage({ ...image, alt: props.event.imageAlt ?? '' })) ?? []);
 const posterLightboxItems = computed<LightboxItem[]>(() => props.event.posters?.map(toLightboxImage) ?? []);
 const videoLightboxItems = computed<LightboxItem[]>(() => props.event.videos?.map(toLightboxVideo) ?? []);
 const imageLabel = computed(() => pluralize(imageLightboxItems.value.length, 'Photo'));

--- a/src/components/LightboxOverlay.test.ts
+++ b/src/components/LightboxOverlay.test.ts
@@ -154,7 +154,7 @@ describe('LightboxOverlay', () => {
 
     it('links the photographer name as a safe new-tab link when a url is given', () => {
       const wrapper = mountOverlay({
-        currentItem: { type: 'image', src: '/p.jpg', alt: 'P', photographer: { name: 'Ana Lens', url: 'https://ana.example.com' } },
+        currentItem: { type: 'image', src: '/p.jpg', alt: 'P', credit: { role: 'photo', name: 'Ana Lens', url: 'https://ana.example.com' } },
       });
       const credit = wrapper.get('.lightbox__credit');
       const link = credit.get('a');
@@ -170,7 +170,7 @@ describe('LightboxOverlay', () => {
 
     it('renders the photographer name as plain text when no url is given', () => {
       const wrapper = mountOverlay({
-        currentItem: { type: 'image', src: '/p.jpg', alt: 'P', photographer: { name: 'Ana Lens' } },
+        currentItem: { type: 'image', src: '/p.jpg', alt: 'P', credit: { role: 'photo', name: 'Ana Lens' } },
       });
       const credit = wrapper.get('.lightbox__credit');
 
@@ -182,7 +182,7 @@ describe('LightboxOverlay', () => {
 
     it('credits a poster artist as "Poster by" with a safe new-tab link', () => {
       const wrapper = mountOverlay({
-        currentItem: { type: 'image', src: '/poster.jpg', alt: 'Poster', artist: { name: 'André Lemos', url: 'https://andre.example.com' } },
+        currentItem: { type: 'image', src: '/poster.jpg', alt: 'Poster', credit: { role: 'poster', name: 'André Lemos', url: 'https://andre.example.com' } },
       });
       const credit = wrapper.get('.lightbox__credit');
       const link = credit.get('a');

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -26,13 +26,14 @@ const emit = defineEmits<{
 const isVideo = computed(() => props.currentItem !== null && isLightboxVideo(props.currentItem));
 const isImage = computed(() => props.currentItem !== null && isLightboxImage(props.currentItem));
 
-// Credit for the current item: "Photo by" for a photograph's photographer,
-// "Poster by" for a poster's artist, "Video by" for a video's author. Null when
-// the current item carries no credit.
+// Credit line for the current item: an image's role-tagged credit renders as
+// "Photo by" / "Poster by", a video's author as "Video by". Null when absent.
 const credit = computed(() => {
   const item = props.currentItem;
-  if (item && isLightboxImage(item) && item.photographer) return { prefix: 'Photo by', ...item.photographer };
-  if (item && isLightboxImage(item) && item.artist) return { prefix: 'Poster by', ...item.artist };
+  if (item && isLightboxImage(item) && item.credit) {
+    const prefix = item.credit.role === 'photo' ? 'Photo by' : 'Poster by';
+    return { prefix, name: item.credit.name, url: item.credit.url };
+  }
   if (item && isLightboxVideo(item) && item.author) return { prefix: 'Video by', ...item.author };
   return null;
 });

--- a/src/types/about.ts
+++ b/src/types/about.ts
@@ -1,4 +1,4 @@
-import type { Photographer } from './media';
+import type { Credit } from './media';
 
 export interface AboutImage {
   src: string;
@@ -6,7 +6,7 @@ export interface AboutImage {
   position?: string;
   scale?: number;
   rotate?: number;
-  photographer?: Photographer;
+  photographer?: Credit;
 }
 
 export interface AboutTextSection {

--- a/src/types/lightbox.ts
+++ b/src/types/lightbox.ts
@@ -1,13 +1,18 @@
 // Lightbox types: the discriminated items rendered in the lightbox.
 
-import type { Photographer, Video } from './media';
+import type { Credit, Video } from './media';
+
+// A credit whose role names how it's attributed in the lightbox, so the overlay
+// reads the role instead of inferring it from which field is populated.
+export interface LightboxCredit extends Credit {
+  role: 'photo' | 'poster';
+}
 
 export interface LightboxImage {
   type: 'image';
   src: string;
   alt: string;
-  photographer?: Photographer;
-  artist?: Photographer;
+  credit?: LightboxCredit;
 }
 
 export interface LightboxVideo extends Video {

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -1,16 +1,15 @@
-import type { Photographer, Video } from './media';
+import type { Credit, Video } from './media';
 
 export interface LiveImage {
   src: string;
-  alt?: string;
-  photographer?: Photographer;
+  photographer?: Credit;
 }
 
 // Event artwork, not a photograph: alt is required (it carries the event's text) and it credits an artist.
 export interface Poster {
   src: string;
   alt: string;
-  artist?: Photographer;
+  artist?: Credit;
 }
 
 export interface EventVenue {

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,6 +1,6 @@
-// A credited contributor (name + optional link). Used as both a photo credit
-// (photographer) and a video credit (author).
-export interface Photographer {
+// A credited contributor: a name and an optional link. Serves as a photo
+// (photographer), poster (artist), or video (author) credit.
+export interface Credit {
   name: string;
   url?: string;
 }
@@ -9,5 +9,5 @@ export interface Video {
   url: string;
   title: string;
   platform: 'youtube' | 'vimeo';
-  author?: Photographer;
+  author?: Credit;
 }

--- a/src/types/works.ts
+++ b/src/types/works.ts
@@ -1,9 +1,9 @@
-import type { Photographer, Video } from './media';
+import type { Credit, Video } from './media';
 
 export interface Image {
   src: string;
   alt: string;
-  photographer?: Photographer;
+  photographer?: Credit;
 }
 
 export interface MetaLink {

--- a/src/utils/lightboxAdapters.test.ts
+++ b/src/utils/lightboxAdapters.test.ts
@@ -7,20 +7,20 @@ describe('toLightboxImage', () => {
     expect(toLightboxImage({ src: '/a.jpg', alt: 'A' })).toEqual({ type: 'image', src: '/a.jpg', alt: 'A' });
   });
 
-  it('copies the photographer credit when present', () => {
+  it('tags a photographer as a photo-role credit', () => {
     const photographer = { name: 'Jane', url: 'https://example.com/jane' };
 
     expect(
       toLightboxImage({ src: '/a.jpg', alt: 'A', photographer }),
-    ).toEqual({ type: 'image', src: '/a.jpg', alt: 'A', photographer });
+    ).toEqual({ type: 'image', src: '/a.jpg', alt: 'A', credit: { role: 'photo', ...photographer } });
   });
 
-  it('copies the artist credit (poster) when present', () => {
+  it('tags an artist as a poster-role credit', () => {
     const artist = { name: 'André Lemos', url: 'https://example.com/andre' };
 
     expect(
       toLightboxImage({ src: '/poster.jpg', alt: 'Poster', artist }),
-    ).toEqual({ type: 'image', src: '/poster.jpg', alt: 'Poster', artist });
+    ).toEqual({ type: 'image', src: '/poster.jpg', alt: 'Poster', credit: { role: 'poster', ...artist } });
   });
 });
 

--- a/src/utils/lightboxAdapters.ts
+++ b/src/utils/lightboxAdapters.ts
@@ -1,32 +1,21 @@
 import type { LightboxImage, LightboxVideo } from '@/types/lightbox';
-import type { Photographer } from '@/types/media';
+import type { Credit, Video } from '@/types/media';
 
-// Superset of the fields the app's image/video data carry (About/Live/Works),
-// so a single adapter serves every call site.
+// The app's image data carries either a photographer (photos) or an artist
+// (posters); this superset lets one adapter serve every call site.
 interface LightboxImageSource {
   src: string;
   alt: string;
-  photographer?: Photographer;
-  artist?: Photographer;
+  photographer?: Credit;
+  artist?: Credit;
 }
 
-interface LightboxVideoSource {
-  url: string;
-  title: string;
-  platform: 'youtube' | 'vimeo';
-  author?: Photographer;
-}
-
-/** Map a domain image to a lightbox image item, copying the credit when present. */
+/** Map a domain image to a lightbox item, tagging its credit with a role. */
 export const toLightboxImage = (image: LightboxImageSource): LightboxImage => {
   const item: LightboxImage = { type: 'image', src: image.src, alt: image.alt };
-  if (image.photographer) item.photographer = image.photographer;
-  if (image.artist) item.artist = image.artist;
+  if (image.photographer) item.credit = { role: 'photo', ...image.photographer };
+  else if (image.artist) item.credit = { role: 'poster', ...image.artist };
   return item;
 };
 
-export const toLightboxVideo = (video: LightboxVideoSource): LightboxVideo => {
-  const item: LightboxVideo = { type: 'video', url: video.url, title: video.title, platform: video.platform };
-  if (video.author) item.author = video.author;
-  return item;
-};
+export const toLightboxVideo = (video: Video): LightboxVideo => ({ type: 'video', ...video });


### PR DESCRIPTION
Audit finding #3 (+ #6 dead field, part of #7). Firms up the credit model introduced with poster credits.

## Changes
- **`Photographer` → `Credit`** — it was already reused for photo credits, video `author`, and poster `artist` (its own comment admitted the dual use). The name asserted one role and forced the field-name juggling.
- **Discriminated lightbox credit** — `LightboxImage` dropped its two optional `photographer?` + `artist?` fields for a single `credit?: LightboxCredit` (`Credit & { role: 'photo' | 'poster' }`). `LightboxOverlay` now reads `credit.role` for the "Photo by" / "Poster by" prefix instead of inferring the kind from which field happens to be set.
- **Dropped dead `LiveImage.alt`** (#6) — no photo entry in `live.ts` ever set it; every live photo takes the event-level `imageAlt`. Removed the field and the now-pointless `image.alt ??` fallback in `EventItem`.
- **Adapter tidy** (part of #7) — `toLightboxVideo` now takes the domain `Video` directly rather than a re-declared source shape.

## Addressed by decision (no change — rationale)
- **#7 broad image-interface base** — the five image interfaces share `{ src }` but diverge legitimately (Poster's required alt + artist; About's layout hints; the lightbox's discriminant). A forced base buys little and couples unrelated shapes, so I left them distinct after the `Credit` rename removed the real duplication (the credit type).
- **#3-data `titleUrl` external/internal** — a URL genuinely *is* just a URL; whether it's same-origin is a property of the value, reliably derived (`/^https?:/`). An explicit `kind` discriminator would duplicate information already in the string and could contradict it, so deriving is the sounder model here.

## Testing
Type-check, lint, 381 unit tests (adapter/overlay/EventItem credit tests updated to the role-tagged shape), coverage above floor, production build, plus the lightbox photographer-credit E2E (chromium). Poster-role credit is covered by the adapter + overlay unit tests.