### PR TITLE
Discriminate CommissionMeta on the work kind

### DIFF
--- a/src/types/works.ts
+++ b/src/types/works.ts
@@ -39,14 +39,36 @@ export interface CompilationMeta {
   year: number;
 }
 
-export interface CommissionMeta {
+// Each commission `work` requires exactly its own credit field, so the variant
+// is discriminated rather than carrying three undiscriminated optionals.
+interface FilmCommission {
   kind: 'commission';
-  work: 'Film' | 'Theatre' | 'Live Score' | 'DVD';
-  director?: MetaLink;
-  venue?: MetaLink;
-  publisher?: Edition;
+  work: 'Film';
+  director: MetaLink;
   year: number;
 }
+
+interface TheatreCommission {
+  kind: 'commission';
+  work: 'Theatre';
+  venue: MetaLink;
+  year: number;
+}
+
+interface DvdCommission {
+  kind: 'commission';
+  work: 'DVD';
+  publisher: Edition;
+  year: number;
+}
+
+interface LiveScoreCommission {
+  kind: 'commission';
+  work: 'Live Score';
+  year: number;
+}
+
+export type CommissionMeta = FilmCommission | TheatreCommission | DvdCommission | LiveScoreCommission;
 
 export interface PublicationMeta {
   kind: 'publication';

--- a/src/utils/metaSegments.ts
+++ b/src/utils/metaSegments.ts
@@ -42,22 +42,22 @@ export const buildMetaSegments = (meta: ReleaseMeta): MetaSegment[] => {
       ];
     }
 
-    case 'commission': {
-      if (meta.director) {
-        return [text(`${meta.work} — dir. `), { kind: 'link', link: meta.director }, text(`, ${meta.year}`)];
-      }
+    case 'commission':
+      switch (meta.work) {
+        case 'Film':
+          return [text(`${meta.work} — dir. `), { kind: 'link', link: meta.director }, text(`, ${meta.year}`)];
 
-      if (meta.venue) {
-        return [text(`${meta.work} — `), { kind: 'link', link: meta.venue }, text(`, ${meta.year}`)];
-      }
+        case 'Theatre':
+          return [text(`${meta.work} — `), { kind: 'link', link: meta.venue }, text(`, ${meta.year}`)];
 
-      if (meta.publisher) {
-        const catalog = meta.publisher.catalog ? `, ${meta.publisher.catalog}` : '';
-        return [text(`${meta.work} — `), { kind: 'link', link: meta.publisher.label }, text(`${catalog}, ${meta.year}`)];
-      }
+        case 'DVD': {
+          const catalog = meta.publisher.catalog ? `, ${meta.publisher.catalog}` : '';
+          return [text(`${meta.work} — `), { kind: 'link', link: meta.publisher.label }, text(`${catalog}, ${meta.year}`)];
+        }
 
-      return [text(`${meta.work} — ${meta.year}`)];
-    }
+        case 'Live Score':
+          return [text(`${meta.work} — ${meta.year}`)];
+      }
 
     case 'publication': {
       const segments: MetaSegment[] = [


### PR DESCRIPTION
Audit finding #4. `CommissionMeta.work` was a literal, but `director?` / `venue?` / `publisher?` were undiscriminated optionals — so `{ work: 'Film', venue: … }` was representable, and `metaSegments` inferred the intended field by presence-testing in a fixed order.

## Verified before changing
The data maps each `work` 1:1:
```
Theatre    → venue
Film       → director
DVD        → publisher
Live Score → (none)
```

## Change
- Split `CommissionMeta` into a discriminated union keyed on `work` (Film/Theatre/DVD/Live Score), each variant declaring exactly its required credit field.
- `metaSegments` switches on `meta.work` instead of presence-testing. Output is unchanged — the `ReleaseMeta` characterization golden covers every release's rendered meta string.

## Addressed by decision (no change — rationale)
- **#8 publisher/label shapes** — `editions: Edition[]` (multi-edition records), `publisher: Edition` (a DVD's single publisher + catalog), and `publisher: MetaLink` (a book — no catalog, ISBN is separate) genuinely differ by domain. Converging a book's publisher onto `Edition` would force a catalog concept books don't have. Left domain-fit.
- **#9 `has*` guards** — the nine one-line guards are trivial, type-safe, and far more readable at call sites (`hasCoverImage(release)` vs `hasField(release, 'coverImage')`). A generic guard trades call-site clarity for fewer definition lines; kept the named guards.

## Testing
Type-check (data conforms to the union; the work-switch is exhaustive), lint, 381 unit tests, coverage above floor, production build.