### PR TITLE
Comment sweep: remove comments that restate the code

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -50,7 +50,6 @@ interface CheckA11yOptions {
   tags?: string[];
 }
 
-/** Run axe-core against the current page and fail on any violation. */
 export const checkA11y = async (page: Page, options: CheckA11yOptions = {}): Promise<void> => {
   const { tags } = options;
 

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -33,7 +33,6 @@ const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? '
 const venueLocation = computed(() =>
   [props.event.venue.city, props.event.venue.country].filter(Boolean).join(', '));
 
-// Comma between the venue name and its city/country, only when both are present.
 const venueSeparator = computed(() => (props.event.venue.name && venueLocation.value ? ', ' : ''));
 
 const imageLightboxItems = computed<LightboxItem[]>(() =>

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -26,8 +26,6 @@ const emit = defineEmits<{
 const isVideo = computed(() => props.currentItem !== null && isLightboxVideo(props.currentItem));
 const isImage = computed(() => props.currentItem !== null && isLightboxImage(props.currentItem));
 
-// Credit line for the current item: an image's role-tagged credit renders as
-// "Photo by" / "Poster by", a video's author as "Video by". Null when absent.
 const credit = computed(() => {
   const item = props.currentItem;
   if (item && isLightboxImage(item) && item.credit) {

--- a/src/types/works.ts
+++ b/src/types/works.ts
@@ -11,7 +11,6 @@ export interface MetaLink {
   url?: string;
 }
 
-// A tracklist entry: a title, plus an artist credit on various-artists releases.
 export interface Track {
   title: string;
   artist?: MetaLink;


### PR DESCRIPTION
Removes four comments added during the audit that only restate what the adjacent name or code already says:
- the `checkA11y` helper JSDoc
- the `venueSeparator` computed comment
- the `LightboxOverlay` credit computed comment
- the `Track` interface comment

Kept the genuine "why" notes elsewhere (the `aria-invalid` gating rationale in `FormField`, the progressive-enhancement fallback in `useContactForm`, the `textContent`-not-`.text()` gotcha, the `!important` underline WCAG justification, etc.).

Comment-only change: type-check, lint, 382 tests, coverage, build all green.