### PR TITLE
Model the Aragão Funchal run as its full four-night range

### DIFF
--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 
 import type { LightboxItem, LiveEvent } from '@/types';
 import { externalizeLinks } from '@/utils/externalizeLinks';
-import { formatEventDate } from '@/utils/formatters';
+import { formatEventDateRange } from '@/utils/formatters';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
 import { buildEventDescription } from '@/utils/liveDescription';
 import { pluralize } from '@/utils/pluralize';
@@ -21,7 +21,7 @@ const emit = defineEmits<{
   'open-lightbox': [items: LightboxItem[], index: number];
 }>();
 
-const formattedDate = computed(() => formatEventDate(props.event.date));
+const formattedDate = computed(() => formatEventDateRange(props.event.date, props.event.endDate));
 
 // Surfaced as a trailing icon link, not wrapping the title, since the title is
 // already a permalink anchor and anchors can't nest.

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -410,6 +410,7 @@ export const liveEvents: LiveEvent[] = [
     title: 'Aragão',
     titleUrl: '/works#aragao',
     date: '2021-09-22',
+    endDate: '2021-09-25',
     venue: { name: 'Teatro Municipal Baltazar Dias', url: 'https://www.teatromunicipal.pt/', city: 'Funchal', country: 'Portugal' },
     performance: { kind: 'theatre' },
     imageAlt: 'Aragão theatre production at Teatro Municipal Baltazar Dias, Funchal, 2021',

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -41,6 +41,7 @@ export interface LiveEvent {
   title: string;
   titleUrl?: string;
   date: string;
+  endDate?: string;
   venue: EventVenue;
   performance: Performance;
   lineup?: Act[];

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -24,6 +24,7 @@ export interface SchemaMusicEvent {
   '@type': 'MusicEvent';
   name: string;
   startDate: string;
+  endDate?: string;
   location: SchemaPlace;
   performer: SchemaPerson;
 }

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatEventDate } from './formatters';
+import { formatEventDate, formatEventDateRange } from './formatters';
 
 describe('formatters', () => {
   describe('formatEventDate', () => {
@@ -27,6 +27,28 @@ describe('formatters', () => {
       expect(formatEventDate('')).toBe('');
       expect(formatEventDate(null as unknown as string)).toBe('');
       expect(formatEventDate(undefined as unknown as string)).toBe('');
+    });
+  });
+
+  describe('formatEventDateRange', () => {
+    it('formats a single date when there is no end date', () => {
+      expect(formatEventDateRange('2021-09-22')).toBe('September 22, 2021');
+    });
+
+    it('formats a single date when the end date equals the start', () => {
+      expect(formatEventDateRange('2021-09-22', '2021-09-22')).toBe('September 22, 2021');
+    });
+
+    it('collapses a same-month run to a shared month and year', () => {
+      expect(formatEventDateRange('2021-09-22', '2021-09-25')).toBe('September 22–25, 2021');
+    });
+
+    it('spells out both months for a same-year run that crosses months', () => {
+      expect(formatEventDateRange('2021-09-30', '2021-10-02')).toBe('September 30 – October 2, 2021');
+    });
+
+    it('spells out both full dates for a run that crosses years', () => {
+      expect(formatEventDateRange('2021-12-31', '2022-01-02')).toBe('December 31, 2021 – January 2, 2022');
     });
   });
 });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -5,3 +5,22 @@ export const formatEventDate = (isoDate: string): string => {
   const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: 'numeric' };
   return date.toLocaleDateString('en-US', options);
 };
+
+export const formatEventDateRange = (isoStart: string, isoEnd?: string): string => {
+  if (!isoEnd || isoEnd === isoStart) return formatEventDate(isoStart);
+
+  const start = new Date(`${isoStart}T00:00:00`);
+  const end = new Date(`${isoEnd}T00:00:00`);
+
+  if (start.getFullYear() !== end.getFullYear()) {
+    return `${formatEventDate(isoStart)} – ${formatEventDate(isoEnd)}`;
+  }
+
+  if (start.getMonth() !== end.getMonth()) {
+    const dayAndMonth: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric' };
+    return `${start.toLocaleDateString('en-US', dayAndMonth)} – ${end.toLocaleDateString('en-US', dayAndMonth)}, ${start.getFullYear()}`;
+  }
+
+  const month = start.toLocaleDateString('en-US', { month: 'long' });
+  return `${month} ${start.getDate()}–${end.getDate()}, ${start.getFullYear()}`;
+};

--- a/src/utils/schemaHelpers.test.ts
+++ b/src/utils/schemaHelpers.test.ts
@@ -42,6 +42,16 @@ describe('createMusicEventSchema', () => {
     expect(schema.startDate).toBe('2011');
   });
 
+  it('emits endDate for a multi-day run', () => {
+    const schema = createMusicEventSchema({ ...baseEvent, endDate: '2011-12-04' }, 'Jerome Faria');
+    expect(schema.endDate).toBe('2011-12-04');
+  });
+
+  it('omits endDate for a single-day event', () => {
+    const schema = createMusicEventSchema(baseEvent, 'Jerome Faria');
+    expect(schema.endDate).toBeUndefined();
+  });
+
   it('sets the performer name', () => {
     const schema = createMusicEventSchema(baseEvent, 'Jerome Faria');
     expect(schema.performer).toEqual({ '@type': 'Person', name: 'Jerome Faria' });

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -18,6 +18,7 @@ export const createMusicEventSchema = (
   '@type': 'MusicEvent',
   name: event.title,
   startDate: event.date || fallbackDate,
+  ...(event.endDate && { endDate: event.endDate }),
   location: {
     '@type': 'Place',
     name: event.venue.name ?? '',


### PR DESCRIPTION
## Description
The `aragao-funchal` Live entry was dated a single day (`2021-09-22`), but the theatre production ran **22–25 September 2021** at Teatro Municipal Baltazar Dias — the poster/programme reads "22 → 25 Setembro 2021". The single date represented only opening night.

## Changes
- **`LiveEvent`** gains an optional `endDate?: string` (the start `date` stays the sort/group key, so single-day events and the whole existing list are untouched).
- **`formatEventDateRange`** (new, in `formatters.ts`) collapses a run to its shared parts and models the three real cases:
  - same month → `September 22–25, 2021`
  - same year, crossing months → `September 30 – October 2, 2021`
  - crossing years → `December 31, 2021 – January 2, 2022`
  - no/equal end date → falls back to the existing single-date format
- **`EventItem.vue`** renders via the range formatter.
- **JSON-LD**: `SchemaMusicEvent` gains an optional `endDate`, emitted only when present, so `aragao-funchal` now advertises `startDate`/`endDate` to search engines; single-day events omit it.
- **Data**: `aragao-funchal` gets `endDate: '2021-09-25'`.

Aragão Funchal is currently the only multi-night run in the data; the model is general but applied to the one real case.

## Testing
1. `npm ci && npm run dev`
2. Visit `/live`, expand **2021**, find **Aragão** at Teatro Municipal Baltazar Dias, Funchal.
3. The date reads **September 22–25, 2021** (not "September 22, 2021"). The sibling Aragão at Centro Cultural do Cartaxo (single day) still reads **October 23, 2021**.
4. View source / DevTools → the Live page `application/ld+json` block has `"startDate":"2021-09-22","endDate":"2021-09-25"` for the Funchal event, and no `endDate` on single-day events.

## Acceptance Criteria
- [x] Aragão Funchal shows the full 22–25 September run in the UI
- [x] Single-day events render and behave exactly as before
- [x] JSON-LD emits `endDate` for the run and omits it otherwise
- [x] Full gate green: type-check, lint, coverage (branches 94% ≥ 91%), production build