### PR TITLE
Correct and reconcile the project license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,17 @@
-# Released under MIT License
+# License
 
-Copyright (c) 2013 Mark Otto.
+## Source code — MIT License
+
+Copyright (c) 2026 Jerome Faria
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Site content — All rights reserved
+
+The MIT terms above cover the source code only. All site content — photographs, poster and cover artwork, audio and video recordings, and written text — is not covered by the MIT License and may not be reused, redistributed, or adapted without written permission.
+
+Content produced by third parties (photographers, artists, festivals, and other collaborators credited in the site data) remains the property of its respective authors. All remaining content is copyright © 2026 Jerome Faria.

--- a/README.md
+++ b/README.md
@@ -169,22 +169,6 @@ The site deploys to GitHub Pages via GitHub Actions on push to `master`. The dep
 
 ## License
 
-Copyright (c) Jerome Faria
+The source code is released under the [MIT License](LICENSE.md), © 2026 Jerome Faria.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Site content — photographs, poster and cover artwork, audio and video, and written text — is **not** covered by the MIT License and may not be reused without permission. Third-party media is credited to its authors in the site data and remains their property. See [`LICENSE.md`](LICENSE.md) for the full terms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "jeromefaria-website",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "vue": "^3.5.41",
         "vue-router": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "keywords": [],
   "author": "Jerome Faria",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/jeromefaria/jeromefaria.github.io/issues"
   },


### PR DESCRIPTION
## Description
The license was inconsistent across three files and carried stale template attribution:

| File | Was | Problem |
|---|---|---|
| `LICENSE.md` | MIT, © 2013 **Mark Otto** | Leftover from the original Jekyll *Hyde/Poole* theme — wrong owner, and not the author's code. |
| `package.json` | `"license": "ISC"` | The `npm init` default; contradicted the MIT in `LICENSE.md`. |
| `README.md` §License | Full MIT text inlined, © Jerome Faria | A third copy, drifting against `LICENSE.md`. |

## Changes
- **`LICENSE.md`** rewritten: **MIT for the source code** (© 2026 Jerome Faria), plus an explicit **content-reserved** section — photographs, poster/cover artwork, audio/video, and writing are not covered by MIT and remain reserved; third-party media stays its authors' property (they're credited in the site data).
- **`package.json`** + **`package-lock.json`** root entry: `ISC` → `MIT` (lockfile regenerated canonically; single-line change).
- **`README.md`** §License: replaced the duplicated MIT text with a short summary that links to `LICENSE.md`, so there's one source of truth.

## Why 2026 (not the 2013 repo origin)
The current site is a Vue app nurtured since late 2025; the prior Jekyll iterations were template-derived and had sat stale for years. The MIT license covers the *code as it stands*, so the copyright year reflects this work rather than the discontinued Jekyll lineage. This also matches the site footer's `© 2026`.

## Why this scope
The repo bundles third-party-credited media, so a blanket MIT over everything would wrongly sublicense photos/art that aren't the author's to relicense. Splitting scope — permissive code, reserved content — keeps the code an open showcase while protecting the content. The footer is unchanged: it already asserts content copyright (`© 2026 Jerome Faria`), which is reserved.

## Testing
- `npm run lint` — clean
- `npm run build` — succeeds
- `npm install --package-lock-only` produces no further diff (lockfile is canonical)
- No source or test logic changed.

## Acceptance Criteria
- [x] No stale "Mark Otto" attribution anywhere
- [x] `LICENSE.md`, `package.json`, `README.md` all agree: MIT for code, © 2026
- [x] Site content explicitly reserved; third-party media attributed to its authors
- [x] Single source of truth (README points to LICENSE.md, no duplicated terms)