### PR TITLE
feat: add typed live-event query helpers

### DIFF
--- a/src/utils/liveQueries.test.ts
+++ b/src/utils/liveQueries.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { eventsByFormat, eventsBySetup } from './liveQueries';
+
+describe('eventsBySetup', () => {
+  it('returns only events with the requested setup kind', () => {
+    const solos = eventsBySetup('solo');
+
+    expect(solos.length).toBeGreaterThan(0);
+    expect(solos.every(event => event.setup.kind === 'solo')).toBe(true);
+  });
+
+  it('finds a known band-setup event', () => {
+    expect(eventsBySetup('band').map(event => event.id)).toContain('reviralho');
+  });
+});
+
+describe('eventsByFormat', () => {
+  it('returns only events with the requested format kind', () => {
+    const theatre = eventsByFormat('theatre');
+
+    expect(theatre.length).toBeGreaterThan(0);
+    expect(theatre.every(event => event.format?.kind === 'theatre')).toBe(true);
+  });
+
+  it('finds a known talk-format event', () => {
+    expect(eventsByFormat('talk').map(event => event.id)).toContain('olhares-de-outono-2010');
+  });
+
+  it('excludes events that have no format', () => {
+    expect(eventsByFormat('filmScore').every(event => event.format !== undefined)).toBe(true);
+    expect(eventsByFormat('theatre').some(event => event.id === 'madeiradig-2005')).toBe(false);
+  });
+});

--- a/src/utils/liveQueries.ts
+++ b/src/utils/liveQueries.ts
@@ -1,0 +1,8 @@
+import { liveEvents } from '@/data/live';
+import type { Format, LiveEvent, Setup } from '@/types/live';
+
+export const eventsBySetup = (kind: Setup['kind']): LiveEvent[] =>
+  liveEvents.filter(event => event.setup.kind === kind);
+
+export const eventsByFormat = (kind: Format['kind']): LiveEvent[] =>
+  liveEvents.filter(event => event.format?.kind === kind);


### PR DESCRIPTION
## Description

Adds `eventsBySetup()` and `eventsByFormat()` — typed helpers to filter live events by the `setup`/`format` kinds from the two-axis model (#170). This is the query capability that motivated the refactor.

## Changes
- `src/utils/liveQueries.ts` — two one-line filters over `liveEvents`, typed to `Setup['kind']` / `Format['kind']`.
- `src/utils/liveQueries.test.ts` — verifies each returns only matching events, finds known events, and excludes format-less events.

## Notes
Provided as reusable utilities per the agreed scope; the curated EPK `highlightLiveIds` is intentionally left untouched. No production consumer yet — the tests exercise them so they're verified rather than inert.