### PR TITLE
feat: embed Inter in the EPK one-sheet PDF

### DIFF
--- a/scripts/generate-epk-bundle.mjs
+++ b/scripts/generate-epk-bundle.mjs
@@ -1,13 +1,20 @@
 import { createWriteStream } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
 
 import { chromium } from '@playwright/test';
 
-import { contact, content, kitName, outDir, photoDownloadFilename, photosDir, siteConfig, siteUrl } from './epk-context.mjs';
+import { contact, content, kitName, outDir, photoDownloadFilename, photosDir, root, siteConfig, siteUrl } from './epk-context.mjs';
 
 const archiver = createRequire(import.meta.url)('archiver');
+
+const fontFace = async weight => {
+  const data = (await readFile(join(root, `public/fonts/inter-${weight}.woff2`))).toString('base64');
+  return `@font-face{font-family:'Inter';font-style:normal;font-weight:${weight};src:url(data:font/woff2;base64,${data}) format('woff2')}`;
+};
+
+const fonts = (await Promise.all([400, 500, 600].map(fontFace))).join('');
 
 const photoFiles = content.photos.map((photo, index) => {
   const filename = photoDownloadFilename(photo, index);
@@ -17,9 +24,10 @@ const photoFiles = content.photos.map((photo, index) => {
 const rows = items => items.map(item => `<div class="year">${item.year}</div><div>${item.body}</div>`).join('');
 
 const html = `<!doctype html><html><head><meta charset="utf-8"><style>
+  ${fonts}
   body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1a1a1a; font-size: 10pt; line-height: 1.48; margin: 0; }
   header { border-bottom: 1px solid #ddd; padding-bottom: 10px; margin-bottom: 16px; }
-  h1 { font-size: 20pt; margin: 0; letter-spacing: -0.01em; }
+  h1 { font-size: 20pt; font-weight: 600; margin: 0; letter-spacing: -0.01em; }
   .tagline { text-transform: uppercase; letter-spacing: 0.12em; font-size: 8pt; color: #666; margin-top: 4px; }
   h2 { font-size: 8pt; text-transform: uppercase; letter-spacing: 0.12em; color: #666; border-bottom: 1px solid #eee; padding-bottom: 4px; margin: 0 0 7px; }
   .prose p { margin: 0 0 7px; }


### PR DESCRIPTION
## Description

The one-sheet's CSS declared `font-family: 'Inter'` but shipped no font, so Playwright fell back to the system sans and the PDF didn't match the website. Closes follow-up #7.

## Changes
- `generate-epk-bundle.mjs` reads the site's committed `public/fonts/inter-{400,500,600}.woff2` and inlines them as base64 `@font-face` rules in the PDF HTML.
- Masthead set to `font-weight: 600` (semibold) to match the site.

## Notes
- The base64 lives only in the transient HTML Playwright renders; the emitted PDF embeds just the glyphs it uses, so it stays small (~145 KB, still one page).
- The subset covers every glyph in the one-sheet (verified by render — accents Ã/Ç/ö, the `·` separators, italic quotes all resolve, no tofu). The fonts are already committed, so CI's `epk:bundle` step reads them with no new dependency.

## Testing
`npm run epk:bundle` → PDF renders in Inter; `e2e/epk.spec.ts` download assertions unaffected (content-type unchanged).