### PR TITLE
feat: add a downloadable technical rider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
-      - name: Generate EPK bundle
-        run: npm run epk:bundle
+      - name: Generate downloadable PDFs
+        run: npm run downloads:build
 
       - name: Build production bundle
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
-    "test:e2e": "npm run epk:bundle && npm run build && playwright test --grep-invert @visual",
+    "test:e2e": "npm run downloads:build && npm run build && playwright test --grep-invert @visual",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
     "lighthouse": "lhci autorun",
@@ -26,7 +26,9 @@
     "images:responsive": "node scripts/generate-responsive-images.mjs",
     "epk:photos": "node scripts/generate-epk-photos.mjs",
     "epk:bundle": "node scripts/generate-epk-bundle.mjs",
-    "epk:kit": "npm run epk:photos && npm run epk:bundle"
+    "rider:pdf": "node scripts/generate-tech-rider.mjs",
+    "downloads:build": "npm run epk:bundle && npm run rider:pdf",
+    "epk:kit": "npm run epk:photos && npm run downloads:build"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-epk-bundle.mjs
+++ b/scripts/generate-epk-bundle.mjs
@@ -1,20 +1,16 @@
 import { createWriteStream } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
 
 import { chromium } from '@playwright/test';
 
 import { contact, content, kitName, outDir, photoDownloadFilename, photosDir, root, siteConfig, siteUrl } from './epk-context.mjs';
+import { baseStyles } from './pdf-styles.mjs';
 
 const archiver = createRequire(import.meta.url)('archiver');
 
-const fontFace = async weight => {
-  const data = (await readFile(join(root, `public/fonts/inter-${weight}.woff2`))).toString('base64');
-  return `@font-face{font-family:'Inter';font-style:normal;font-weight:${weight};src:url(data:font/woff2;base64,${data}) format('woff2')}`;
-};
-
-const fonts = (await Promise.all([400, 500, 600].map(fontFace))).join('');
+const styles = await baseStyles(root);
 
 const photoFiles = content.photos.map((photo, index) => {
   const filename = photoDownloadFilename(photo, index);
@@ -24,12 +20,11 @@ const photoFiles = content.photos.map((photo, index) => {
 const rows = items => items.map(item => `<div class="year">${item.year}</div><div>${item.body}</div>`).join('');
 
 const html = `<!doctype html><html><head><meta charset="utf-8"><style>
-  ${fonts}
-  body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1a1a1a; font-size: 10pt; line-height: 1.48; margin: 0; }
+  ${styles}
+  body { line-height: 1.48; }
   header { border-bottom: 1px solid #ddd; padding-bottom: 10px; margin-bottom: 16px; }
-  h1 { font-size: 20pt; font-weight: 600; margin: 0; letter-spacing: -0.01em; }
-  .tagline { text-transform: uppercase; letter-spacing: 0.12em; font-size: 8pt; color: #666; margin-top: 4px; }
-  h2 { font-size: 8pt; text-transform: uppercase; letter-spacing: 0.12em; color: #666; border-bottom: 1px solid #eee; padding-bottom: 4px; margin: 0 0 7px; }
+  .tagline { margin-top: 4px; }
+  h2 { margin: 0 0 7px; }
   .prose p { margin: 0 0 7px; }
   .prose p:last-child { margin-bottom: 0; }
   .columns { display: grid; grid-template-columns: 1fr 1fr; gap: 16px 30px; margin-top: 16px; }
@@ -42,7 +37,6 @@ const html = `<!doctype html><html><head><meta charset="utf-8"><style>
   .press { margin-top: 16px; }
   .contact { margin-top: 16px; padding-top: 10px; border-top: 1px solid #ddd; font-size: 9.5pt; }
   .contact a { color: #1a1a1a; text-decoration: none; }
-  em { font-style: italic; }
 </style></head><body>
   <header>
     <h1>Jerome Faria</h1><div class="tagline">Sound Artist &amp; Composer</div>

--- a/scripts/generate-tech-rider.mjs
+++ b/scripts/generate-tech-rider.mjs
@@ -1,0 +1,87 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { chromium } from '@playwright/test';
+import { createJiti } from 'jiti';
+
+import { baseStyles } from './pdf-styles.mjs';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const jiti = createJiti(import.meta.url, { alias: { '@': join(root, 'src') } });
+const { techRider } = await jiti.import(join(root, 'src/data/techRider.ts'));
+const { epkRiderBasename } = await jiti.import(join(root, 'src/utils/epk.ts'));
+
+const styles = await baseStyles(root);
+
+const bullet = item =>
+  typeof item === 'string'
+    ? `<div class="item">${item}</div>`
+    : `<div class="item"><span class="lbl">${item.label}</span> — ${item.text}</div>`;
+
+const inputTable = table => `<table class="io">
+  <thead><tr><th>Input</th><th>Format</th><th>Notes</th></tr></thead>
+  <tbody>${table.rows.map(([input, format, notes]) => `<tr><td>${input}</td><td>${format}</td><td>${notes}</td></tr>`).join('')}</tbody>
+</table>`;
+
+const timingTable = table => `<table class="timing"><tbody>${table.rows
+  .map(([stage, duration]) => `<tr><td>${stage}</td><td>${duration}</td></tr>`)
+  .join('')}</tbody></table>`;
+
+const table = t => (t.kind === 'input' ? inputTable(t) : timingTable(t));
+
+const section = s => `<section>
+  <h2>${s.title}</h2>
+  ${s.body ? `<p class="body">${s.body}</p>` : ''}
+  ${s.bullets ? s.bullets.map(bullet).join('') : ''}
+  ${s.table ? table(s.table) : ''}
+  ${s.footnote ? `<p class="footnote">${s.footnote}</p>` : ''}
+</section>`;
+
+const html = `<!doctype html><html><head><meta charset="utf-8"><style>
+  ${styles}
+  body { line-height: 1.45; }
+  header { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 1px solid #ddd; padding-bottom: 12px; margin-bottom: 16px; }
+  .tagline { margin-top: 5px; }
+  .updated { text-transform: uppercase; letter-spacing: 0.1em; font-size: 7.5pt; color: #999; text-align: right; white-space: nowrap; }
+  .overview { margin: 0 0 10px; }
+  .summary { margin: 0 0 22px; padding: 12px 16px; background: #f6f6f6; }
+  section { margin-bottom: 22px; break-inside: avoid; }
+  h2 { margin: 0 0 9px; }
+  .body { margin: 0 0 8px; }
+  .item { position: relative; padding-left: 15px; margin-bottom: 6px; }
+  .item::before { content: '•'; position: absolute; left: 2px; color: #bbb; }
+  .item:last-child { margin-bottom: 0; }
+  .lbl { font-weight: 500; }
+  .footnote { font-size: 9pt; color: #666; margin: 8px 0 0; }
+  table.io { width: 100%; border-collapse: collapse; margin-top: 6px; border: 1px solid #ddd; }
+  table.io th { text-align: left; font-size: 7.5pt; text-transform: uppercase; letter-spacing: 0.08em; color: #666; font-weight: 500; padding: 6px 10px; background: #f6f6f6; border-bottom: 1px solid #ddd; }
+  table.io td { padding: 8px 10px; border-bottom: 1px solid #eee; vertical-align: top; }
+  table.io td:first-child { font-weight: 500; white-space: nowrap; }
+  table.io tr:last-child td { border-bottom: none; }
+  table.timing { border-collapse: collapse; margin-top: 4px; }
+  table.timing td { padding: 4px 14px 4px 0; vertical-align: top; }
+  table.timing td:first-child { color: #555; font-weight: 500; white-space: nowrap; }
+  .footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid #ddd; font-size: 9pt; color: #444; }
+  .footer a { color: #1a1a1a; text-decoration: none; }
+</style></head><body>
+  <header>
+    <div>
+      <h1>Jerome Faria</h1>
+      <div class="tagline">Sound Artist &amp; Composer — Technical Rider</div>
+    </div>
+    <div class="updated">Updated ${techRider.updated}</div>
+  </header>
+  <p class="overview">${techRider.overview}</p>
+  <div class="summary">${techRider.summary.map(item => `<div class="item">${item}</div>`).join('')}</div>
+  ${techRider.sections.map(section).join('')}
+  <div class="footer">Technical questions ahead of a booking — <a href="mailto:${techRider.contact}">${techRider.contact}</a></div>
+</body></html>`;
+
+const outPath = join(root, 'public/epk', `${epkRiderBasename}.pdf`);
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.setContent(html, { waitUntil: 'networkidle' });
+await page.pdf({ path: outPath, format: 'A4', printBackground: true, margin: { top: '13mm', bottom: '13mm', left: '16mm', right: '16mm' } });
+await browser.close();
+
+console.log(`Tech rider → public/epk/${epkRiderBasename}.pdf`);

--- a/scripts/pdf-fonts.mjs
+++ b/scripts/pdf-fonts.mjs
@@ -1,0 +1,11 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const interFontFaces = async root => {
+  const face = async weight => {
+    const data = (await readFile(join(root, `public/fonts/inter-${weight}.woff2`))).toString('base64');
+    return `@font-face{font-family:'Inter';font-style:normal;font-weight:${weight};src:url(data:font/woff2;base64,${data}) format('woff2')}`;
+  };
+
+  return (await Promise.all([400, 500, 600].map(face))).join('');
+};

--- a/scripts/pdf-styles.mjs
+++ b/scripts/pdf-styles.mjs
@@ -1,0 +1,11 @@
+import { interFontFaces } from './pdf-fonts.mjs';
+
+export const baseStyles = async root => `
+  ${await interFontFaces(root)}
+  body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1a1a1a; font-size: 10pt; margin: 0; }
+  h1 { font-size: 20pt; font-weight: 600; margin: 0; letter-spacing: -0.01em; }
+  h2 { font-size: 8pt; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; color: #1a1a1a; border-bottom: 1px solid #ddd; padding-bottom: 4px; }
+  .tagline { text-transform: uppercase; letter-spacing: 0.12em; font-size: 8pt; color: #666; }
+  strong { font-weight: 600; }
+  em { font-style: italic; }
+`;

--- a/src/data/techRider.ts
+++ b/src/data/techRider.ts
@@ -1,0 +1,118 @@
+export interface RiderBullet {
+  label?: string;
+  text: string;
+}
+
+export interface RiderTable {
+  kind: 'input' | 'timing';
+  rows: string[][];
+}
+
+export interface RiderSection {
+  title: string;
+  body?: string;
+  bullets?: (string | RiderBullet)[];
+  table?: RiderTable;
+  footnote?: string;
+}
+
+export interface TechRider {
+  updated: string;
+  contact: string;
+  overview: string;
+  summary: string[];
+  sections: RiderSection[];
+}
+
+export const techRider: TechRider = {
+  updated: 'August 2026',
+  contact: 'jerome.faria@gmail.com',
+  overview:
+    'Solo electronic performance — analogue instrument, sampler, and effects through a small-format mixer. No backline, no additional musicians, and no crew required beyond venue power and PA access.',
+  summary: [
+    '<strong>1 stereo pair to FOH</strong> — balanced XLR, line level',
+    '<strong>1 mains socket</strong> — everything else self-powered',
+    '<strong>Self-monitored via IEMs</strong> — no stage monitor required',
+  ],
+  sections: [
+    {
+      title: 'Timing',
+      body: 'Please allow the following as a minimum buffer either side of the set — the performer handles setup and load out unassisted.',
+      table: {
+        kind: 'timing',
+        rows: [
+          ['Load in', '15 min'],
+          ['Setup', '20–30 min'],
+          ['Soundcheck', '15 min (a brief line check — the signal is a finished stereo mix, not a multi-channel setup)'],
+          ['Performance', 'as booked'],
+          ['Load out', '15 min'],
+        ],
+      },
+    },
+    {
+      title: 'Stage & performance surface',
+      bullets: [
+        { label: 'Surface', text: 'one table, minimum <strong>100 × 60 cm</strong> (rig footprint 70 × 40 cm).' },
+        { label: 'Height', text: 'a fixed table at standard height (~75 cm) with a chair provided, or an adjustable-height surface — the performer plays standing or seated depending on setup, so either is acceptable.' },
+        { label: 'Seating', text: 'one chair required if the table is fixed at standard height.' },
+        { label: 'Stability', text: 'the table must be stable and level. No folding tables with loose joints.' },
+      ],
+    },
+    {
+      title: 'Power',
+      bullets: [
+        { label: 'Required', text: '<strong>1 × mains socket</strong> (13 A or Schuko) within reach; the performer\'s own extension lead bridges reasonable distances.' },
+        'Everything runs from the performer\'s own distribution (extension strip + isolated pedal supply); no high-current or specialist power.',
+      ],
+    },
+    {
+      title: 'Input list / PA connection',
+      body: 'One <strong>stereo pair</strong> from the performer\'s mixer to the house, <strong>balanced XLR</strong> at line level — a standard XLR run from the performance position to FOH.',
+      table: {
+        kind: 'input',
+        rows: [
+          ['Main L', 'XLR (balanced)', 'Full stereo mix from performer\'s mixer'],
+          ['Main R', 'XLR (balanced)', 'Full stereo mix from performer\'s mixer'],
+        ],
+      },
+    },
+    {
+      title: 'Monitoring',
+      bullets: [
+        'Self-contained via in-ear monitors, fed from the performer\'s own mixer — <strong>no stage monitor required</strong>.',
+        'A stage monitor alongside IEMs for room reference can be discussed, but is never required.',
+      ],
+    },
+    {
+      title: 'Front of house',
+      bullets: [
+        'The signal at the desk is a <strong>finished stereo mix</strong> — levels, balance, and dynamics set and managed by the performer throughout. After gain staging at line check, no fader riding or level intervention is needed.',
+        'House EQ / system processing for the room is welcome.',
+        { label: 'Low cut', text: 'if used, <strong>no higher than 50 Hz</strong> — low-frequency content is a deliberate part of the performance.' },
+        { label: 'Compression', text: 'if applied, test against performance peaks at line check and confirm with the performer — typically unnecessary, as the performer\'s dynamics are already controlled.' },
+      ],
+    },
+    {
+      title: 'Lighting & environment',
+      bullets: [
+        { label: 'Lighting', text: 'adjustable stage/area lighting, dimmable, with a preference for darker, colder tones over warm or bright presets. The performer\'s own work light can supplement if needed.' },
+        { label: 'Temperature', text: 'a cool room is preferred. If a cool temperature cannot be maintained, a quiet fan at the performance position.' },
+      ],
+    },
+    {
+      title: 'Hospitality',
+      bullets: ['Still water at the performance position.'],
+    },
+    {
+      title: 'Recording',
+      body: 'The performer takes their own stereo + room recording for personal archival — nothing required from the venue, noted only so it is known in advance.',
+    },
+    {
+      title: 'Cancellation & changes',
+      bullets: [
+        'Please advise as early as possible of any change to load in, soundcheck, or set times, so the performer can adjust travel and preparation.',
+        'In the event of unavoidable cancellation on either side, please give as much notice as possible — the performer will do the same.',
+      ],
+    },
+  ],
+};

--- a/src/utils/epk.ts
+++ b/src/utils/epk.ts
@@ -41,6 +41,9 @@ export const epkKitBasename = 'jerome-faria-press-kit';
 export const epkZipHref = `/epk/${epkKitBasename}.zip`;
 export const epkPdfHref = `/epk/${epkKitBasename}.pdf`;
 
+export const epkRiderBasename = 'jerome-faria-tech-rider';
+export const epkRiderHref = `/epk/${epkRiderBasename}.pdf`;
+
 export const resolveLongBio = (longBio: EpkLongBio, sections: AboutSection[]): string => {
   if (longBio.source === 'custom') {
     return longBio.html;

--- a/src/views/EpkView.vue
+++ b/src/views/EpkView.vue
@@ -6,7 +6,7 @@ import PageShell from '@/components/PageShell.vue';
 import { usePageHead } from '@/composables/usePageHead';
 import { epkManifest } from '@/data/epk';
 import { pageMeta } from '@/data/pageMeta';
-import { epkPdfHref, epkZipHref, photoDownloadHref, resolveEpkContent } from '@/utils/epk';
+import { epkPdfHref, epkRiderHref, epkZipHref, photoDownloadHref, resolveEpkContent } from '@/utils/epk';
 import { externalizeLinks } from '@/utils/externalizeLinks';
 import { responsiveSrcset, toWebp } from '@/utils/responsiveImage';
 
@@ -51,6 +51,12 @@ const epk = resolveEpkContent(epkManifest);
             :href="epkPdfHref"
             download
           >One-sheet (PDF)</a>
+          <span> | </span>
+          <a
+            class="link-discrete"
+            :href="epkRiderHref"
+            download
+          >Technical rider (PDF)</a>
         </p>
       </section>
 


### PR DESCRIPTION
## Description

Adds a downloadable **technical rider** — a quick-reference PDF for venue sound engineers — built with the same pipeline and design language as the press one-sheet, and extracts the shared PDF styling so the two documents keep one visual identity.

## Changes

**Shared PDF styling** (`refactor` commit)
- `scripts/pdf-fonts.mjs` — the Inter `@font-face` embedding.
- `scripts/pdf-styles.mjs` — shared base (masthead, section headers, colours), consumed by **both** generators so the one-sheet and rider can't drift apart.
- The one-sheet's section headers pick up the shared ink/semibold treatment (they were muted grey).

**Tech rider** (`feat` commit)
- `src/data/techRider.ts` — content as data (sections, the input-list and timing tables, contact, last-updated stamp).
- `scripts/generate-tech-rider.mjs` — renders it to `jerome-faria-tech-rider.pdf`; Inter-embedded, **CI-generated** (via `downloads:build`), **gitignored** — same model as the one-sheet.
- Linked from the `/epk` download row: `ZIP · one-sheet · technical rider`.
- Ordered to the **practical event timeline** (Timing → setup → audio → room → extras), with an at-a-glance summary and the input list / timing as emphasised blocks.

## Design decisions (settled with the owner)
- Clean section labels (no numbering — consistency with the site/one-sheet).
- No stage plot (a one-table, one-stereo-line rig doesn't need one).
- Rig footprint kept as a fallback figure, rounded up (`70 × 40 cm`).
- Contact is **email only** — the phone travels privately via the sender's email signature, never on the public document.

## Testing
- `npm run downloads:build` → one-sheet + rider PDFs; `npm run build` → `dist/epk/` contains all three downloads.
- `e2e/epk.spec.ts` "serves every download the page links to" now covers the rider link.
- Rider renders as two pages, matching the one-sheet's type and hierarchy.

## Notes for CI
- The `/epk` download row gained a link, so the committed `/epk` visual baseline is refreshed on this branch before mark-ready.
- Merging updates the **already-live** one-sheet PDF's headers to the shared style — intended (cross-document consistency).

## Refactor assessment
- **Bundle** — `pdf-fonts` + `pdf-styles` remove the duplicated font/typography setup across the two generators; consistency is now structural.
