### PR TITLE
build: fail the build on a missing EPK photo source

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && node scripts/check-anchors.js && vite-ssg build && node scripts/async-css.js",
+    "build": "vue-tsc --noEmit && node scripts/check-anchors.js && node scripts/check-epk-photos.mjs && vite-ssg build && node scripts/async-css.js",
     "preview": "vite preview",
     "lint": "eslint src scripts e2e playwright.config.ts",
     "lint:fix": "eslint src scripts e2e playwright.config.ts --fix",

--- a/scripts/check-epk-photos.mjs
+++ b/scripts/check-epk-photos.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createJiti } from 'jiti';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const jiti = createJiti(import.meta.url, { alias: { '@': resolve(root, 'src') } });
+
+const { epkManifest } = await jiti.import(resolve(root, 'src/data/epk.ts'));
+
+const missing = epkManifest.photos.map(photo => photo.src).filter(src => !existsSync(join(root, 'public', src)));
+
+console.log('\n🖼️  EPK Photo Source Check:');
+console.log('━'.repeat(50));
+console.log(`Checked ${epkManifest.photos.length} photo sources against public/.`);
+console.log('━'.repeat(50));
+
+if (missing.length > 0) {
+  console.error(`\n❌ ${missing.length} EPK photo source(s) missing from public/:`);
+  missing.forEach(src => console.error(`  - ${src}`));
+  console.error('');
+  process.exit(1);
+}
+
+console.log('\n✅ All EPK photo sources present!\n');
+process.exit(0);


### PR DESCRIPTION
## Description
Closes the last EPK follow-up (#9 from the review). The EPK manifest references most things by **id** — quotes, live/work highlights — which fail the build via `findById` if broken. But the six press **photos** are inline with a `src` path that nothing validates, so a renamed or deleted image would 404 at runtime instead of failing fast.

## Change
- `scripts/check-epk-photos.mjs` — a sibling to `check-anchors.js`: loads the manifest via jiti and verifies each `photo.src` exists in `public/`, exiting non-zero (with the offending paths listed) if any is missing.
- Wired into `npm run build` right after `check-anchors`, so it runs in the CI Build job and the deploy — the same gate the id references already fail at.

## Testing
- Passes on real data (6/6 sources present, exit 0).
- **Negative test**: pointing one `src` at a nonexistent file made it exit 1 and list the path — reverted after.
- Gate: type-check · lint · build (with the new check) · coverage 99.35% lines.

No production code touched; build-only. The script isn't in the coverage set (same as `check-anchors.js`).