### PR TITLE
Remove the italic on EPK press quotes

### DIFF
--- a/scripts/generate-epk-bundle.mjs
+++ b/scripts/generate-epk-bundle.mjs
@@ -32,7 +32,7 @@ const html = `<!doctype html><html><head><meta charset="utf-8"><style>
   .grid a { color: #1a1a1a; text-decoration: underline; text-decoration-color: #ccc; text-underline-offset: 2px; }
   .year { color: #999; font-variant-numeric: tabular-nums; }
   .quotes { column-count: 2; column-gap: 30px; margin-top: 7px; }
-  blockquote { margin: 0 0 10px; font-style: italic; break-inside: avoid; }
+  blockquote { margin: 0 0 10px; break-inside: avoid; }
   blockquote cite { display: block; font-style: normal; font-size: 8pt; color: #666; text-transform: uppercase; letter-spacing: 0.1em; margin-top: 3px; }
   .press { margin-top: 16px; }
   .contact { margin-top: 16px; padding-top: 10px; border-top: 1px solid #ddd; font-size: 9.5pt; }


### PR DESCRIPTION
## Description
The press quotes in the generated EPK PDF rendered in italic. Removes the `font-style: italic` from the `blockquote` rule in `scripts/generate-epk-bundle.mjs` so the quotes render upright.

## Notes
- Only the quote *body* changes — the `cite` (source) was already `font-style: normal`, and intentional `<em>` emphasis inside a quote (e.g. *Discreet Music* in the Quietus quote) still renders italic via the shared `em` rule.

## Testing
- `npm run epk:bundle` → opened `public/epk/jerome-faria-press-kit.pdf`; the PRESS section quotes render upright, with in-quote `<em>` still italic. (The PDF is CI-generated + gitignored.)