### PR TITLE
Refresh page meta descriptions

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -3,7 +3,7 @@ import type { NavItem, SiteConfig, SocialLink } from '@/types/navigation';
 export const siteConfig: SiteConfig = {
   title: 'Jerome Faria',
   tagline: 'Sound Artist & Composer',
-  description: 'Creating at the edges of experimental electronics, film scoring, and live performance since 2004',
+  description: 'Portuguese composer and sound artist, moving between confrontational noise and patient drone, film scores and theatre.',
   url: 'https://jeromefaria.com',
   image: '/images/performance.jpg',
   author: {

--- a/src/data/pageMeta.ts
+++ b/src/data/pageMeta.ts
@@ -13,12 +13,12 @@ export const pageMeta = {
   },
   about: {
     title: 'About',
-    description: 'Biography and background of Jerome Faria, Portuguese sound artist and electronic music composer.',
+    description: 'The biography of Jerome Faria — Portuguese composer and sound artist, from netlabel-era noise to drone, film scores, and theatre.',
     ogType: 'profile',
   },
   works: {
     title: 'Works',
-    description: 'Discography, film scores, and works by Jerome Faria including solo releases, collaborations, and curatorial projects.',
+    description: 'Discography and works by Jerome Faria — solo releases, film and theatre scores, collaborations, curation, and mastering.',
   },
   live: {
     title: 'Live',
@@ -26,7 +26,7 @@ export const pageMeta = {
   },
   contact: {
     title: 'Contact',
-    description: 'Get in touch with Jerome Faria for commissions, collaborations, performance bookings, and general inquiries.',
+    description: 'Get in touch with Jerome Faria — performance bookings, commissions, licensing, mastering, and general inquiries.',
   },
   press: {
     title: 'Press',


### PR DESCRIPTION
## Description
Refreshes four page meta descriptions that had drifted from the current practice. These feed search results and social-share cards (and, for the site description, the JSON-LD Person schema).

## Changes
- **Contact** — adds **licensing** and **mastering** to match the actual inquiry types (the old copy predated them; surfaced when a shared link's card still read 'commissions, collaborations, performance bookings').
- **Site / home** (`siteConfig.description`, feeds home meta + structured data) — from 'experimental electronics … since 2004' to the bio's 'composer and sound artist … noise and drone, film scores and theatre.'
- **About** — 'electronic music composer' → 'composer and sound artist', with the netlabel-to-drone arc.
- **Works** — adds mastering + theatre scores.
- Live / Press / EPK / Privacy — reviewed, left unchanged (already accurate).

## Testing
- Type-check, lint, 425 unit tests green.
- `npm run build` → confirmed the new strings land in the pre-rendered `<head>` (e.g. `dist/contact.html` og:description now names licensing + mastering).