### PR TITLE
refactor: audit quick wins — dead code, dedup, worker hardening

### DIFF
--- a/src/composables/useContactForm.ts
+++ b/src/composables/useContactForm.ts
@@ -57,6 +57,11 @@ export const useContactForm = (
   const fields = uniqueFields(collectFields(form));
   const labelById = new Map(fields.map(field => [field.id, field.label]));
 
+  const inquiryId = form.inquiry.id;
+  const nameId = form.baseFields.name.id;
+  const emailId = form.baseFields.email.id;
+  const messageId = form.baseFields.message.id;
+
   const emptyState = <T>(value: T): Record<string, T> =>
     Object.fromEntries(fields.map(field => [field.id, value]));
 
@@ -69,7 +74,7 @@ export const useContactForm = (
   const errorMessage = ref('');
 
   const selectedType = computed<InquiryType | null>(() =>
-    form.inquiryTypes.find(type => type.id === formData['inquiry']) ?? null);
+    form.inquiryTypes.find(type => type.id === formData[inquiryId]) ?? null);
 
   const requiredIds = computed<string[]>(() => {
     const base = [form.inquiry, form.baseFields.name, form.baseFields.email, form.baseFields.message]
@@ -113,9 +118,9 @@ export const useContactForm = (
   const buildPayload = (token: string): ContactPayload => ({
     token,
     inquiry: selectedType.value?.label ?? '',
-    name: formData['name'] ?? '',
-    email: formData['email'] ?? '',
-    message: formData['message'] ?? '',
+    name: formData[nameId] ?? '',
+    email: formData[emailId] ?? '',
+    message: formData[messageId] ?? '',
     fields: (selectedType.value?.fields ?? [])
       .map(field => ({ label: field.label, value: formData[field.id] ?? '' }))
       .filter(entry => entry.value.trim() !== ''),

--- a/src/composables/useScrollLock.test.ts
+++ b/src/composables/useScrollLock.test.ts
@@ -23,9 +23,8 @@ describe('useScrollLock', () => {
     document.body.style.overflow = '';
   });
 
-  it('starts unlocked', () => {
-    const { api } = mountWithScrollLock();
-    expect(api.isLocked.value).toBe(false);
+  it('starts with body scroll unlocked', () => {
+    mountWithScrollLock();
     expect(document.body.style.overflow).toBe('');
   });
 
@@ -33,11 +32,9 @@ describe('useScrollLock', () => {
     const { api } = mountWithScrollLock();
 
     api.lock();
-    expect(api.isLocked.value).toBe(true);
     expect(document.body.style.overflow).toBe('hidden');
 
     api.unlock();
-    expect(api.isLocked.value).toBe(false);
     expect(document.body.style.overflow).toBe('');
   });
 

--- a/src/composables/useScrollLock.ts
+++ b/src/composables/useScrollLock.ts
@@ -1,26 +1,20 @@
-import type { Ref } from 'vue';
-import { onUnmounted, ref } from 'vue';
+import { onUnmounted } from 'vue';
 
 interface UseScrollLockReturn {
-  isLocked: Ref<boolean>;
   lock: () => void;
   unlock: () => void;
 }
 
 export const useScrollLock = (): UseScrollLockReturn => {
-  const isLocked = ref(false);
-
   const lock = (): void => {
     document.body.style.overflow = 'hidden';
-    isLocked.value = true;
   };
 
   const unlock = (): void => {
     document.body.style.overflow = '';
-    isLocked.value = false;
   };
 
   onUnmounted(unlock);
 
-  return { isLocked, lock, unlock };
+  return { lock, unlock };
 };

--- a/src/data/techRider.ts
+++ b/src/data/techRider.ts
@@ -1,3 +1,5 @@
+import { siteConfig } from './navigation';
+
 export interface RiderBullet {
   label?: string;
   text: string;
@@ -26,7 +28,7 @@ export interface TechRider {
 
 export const techRider: TechRider = {
   updated: 'August 2026',
-  contact: 'jerome.faria@gmail.com',
+  contact: siteConfig.author.email,
   overview:
     'Solo electronic performance — analogue instrument, sampler, and effects through a small-format mixer. No backline, no additional musicians, and no crew required beyond venue power and PA access.',
   summary: [

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -7,16 +7,12 @@ $font-size-base: 0.875rem;
 $font-size-lg: 1rem;
 $font-size-xl: 1.125rem;
 $font-size-2xl: 1.375rem;
-$font-size-3xl: 1.625rem;
 
-$line-height-tight: 1.25;
 $line-height-snug: 1.4;
 $line-height-base: 1.6;
 $line-height-relaxed: 1.75;
 $line-height-prose: 1.8;
 
-$letter-spacing-tight: -0.01em;
-$letter-spacing-normal: 0;
 $letter-spacing-wide: 0.05em;
 $letter-spacing-wider: 0.12em;
 
@@ -35,11 +31,9 @@ $spacing-10: 2.5rem;
 $spacing-12: 3rem;
 $spacing-16: 4rem;
 $spacing-20: 5rem;
-$spacing-24: 6rem;
 
 $max-width: 33rem;
 $max-width-wide: 72rem;
-$max-width-full: 100%;
 
 $breakpoint-sm: 480px;
 $breakpoint-md: 768px;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,6 +24,5 @@ export const TOUCH = {
 } as const;
 
 export const TURNSTILE = {
-  ONLOAD_CALLBACK: 'onloadTurnstileCallback',
   SCRIPT_URL: 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onloadTurnstileCallback',
 } as const;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,7 +1,10 @@
+// Local midnight, so an ISO date parses as a calendar day without timezone drift.
+const parseLocalDate = (isoDate: string): Date => new Date(`${isoDate}T00:00:00`);
+
 export const formatEventDate = (isoDate: string): string => {
   if (!isoDate) return '';
 
-  const date = new Date(`${isoDate}T00:00:00`); // Local midnight, avoids timezone drift
+  const date = parseLocalDate(isoDate);
   const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: 'numeric' };
   return date.toLocaleDateString('en-US', options);
 };
@@ -9,8 +12,8 @@ export const formatEventDate = (isoDate: string): string => {
 export const formatEventDateRange = (isoStart: string, isoEnd?: string): string => {
   if (!isoEnd || isoEnd === isoStart) return formatEventDate(isoStart);
 
-  const start = new Date(`${isoStart}T00:00:00`);
-  const end = new Date(`${isoEnd}T00:00:00`);
+  const start = parseLocalDate(isoStart);
+  const end = parseLocalDate(isoEnd);
 
   if (start.getFullYear() !== end.getFullYear()) {
     return `${formatEventDate(isoStart)} – ${formatEventDate(isoEnd)}`;

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -30,7 +30,7 @@ const postRequest = (body: unknown, origin = 'https://jeromefaria.com'): Request
 const turnstileResult = (success: boolean): Response =>
   ({ ok: true, json: async () => ({ success }) }) as unknown as Response;
 
-const resendResult = (ok: boolean): Response => ({ ok }) as unknown as Response;
+const resendResult = (ok: boolean): Response => ({ ok, text: async () => 'error body' }) as unknown as Response;
 
 const sentBody = (fetchMock: ReturnType<typeof vi.spyOn>): Record<string, string> =>
   JSON.parse((fetchMock.mock.calls[1] as [string, RequestInit])[1].body as string);
@@ -40,6 +40,7 @@ describe('contact worker', () => {
 
   beforeEach(() => {
     fetchMock = vi.spyOn(globalThis, 'fetch');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -116,6 +117,15 @@ describe('contact worker', () => {
     const response = await worker.fetch(postRequest(VALID_BODY), ENV);
 
     expect(response.status).toBe(502);
+  });
+
+  it('returns a CORS 502 when a downstream request throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network error'));
+
+    const response = await worker.fetch(postRequest(VALID_BODY), ENV);
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://jeromefaria.com');
   });
 
   it('escapes HTML in user content', async () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -111,7 +111,12 @@ const sendEmail = async (payload: ContactPayload, env: Env): Promise<boolean> =>
     }),
   });
 
-  return response.ok;
+  if (!response.ok) {
+    console.error('Resend send failed:', response.status, await response.text());
+    return false;
+  }
+
+  return true;
 };
 
 export default {
@@ -142,16 +147,21 @@ export default {
       return jsonResponse({ error: `Missing required field: ${missing}` }, 400, cors);
     }
 
-    const verified = await verifyTurnstile(payload.token, env.TURNSTILE_SECRET, request);
-    if (!verified) {
-      return jsonResponse({ error: 'Verification failed' }, 403, cors);
-    }
+    try {
+      const verified = await verifyTurnstile(payload.token, env.TURNSTILE_SECRET, request);
+      if (!verified) {
+        return jsonResponse({ error: 'Verification failed' }, 403, cors);
+      }
 
-    const delivered = await sendEmail(payload, env);
-    if (!delivered) {
+      const delivered = await sendEmail(payload, env);
+      if (!delivered) {
+        return jsonResponse({ error: 'Could not send message' }, 502, cors);
+      }
+
+      return jsonResponse({ ok: true }, 200, cors);
+    } catch (error) {
+      console.error('Contact relay error:', error);
       return jsonResponse({ error: 'Could not send message' }, 502, cors);
     }
-
-    return jsonResponse({ ok: true }, 200, cors);
   },
 };


### PR DESCRIPTION
## Description
Quick-win refactors from the whole-codebase audit — dead-code removal, small internal dedup, and failure-hardening for the contact Worker. No behavioural or visual change to the site.

## Changes
- **Dead code**: removed six unused SCSS tokens from `_variables.scss`, the dead `ONLOAD_CALLBACK` entry from the Turnstile constant, and the unused `isLocked` return from `useScrollLock`.
- **Dedup**: extracted `parseLocalDate` in `formatters.ts` (single timezone-safe ISO→Date helper, was inlined three times); routed `useContactForm`'s payload/lookup through the config field ids instead of hard-coded key literals; pointed `techRider.contact` at `siteConfig.author.email` instead of a duplicated address literal.
- **Worker hardening**: wrapped the verify/send block in a try/catch that returns a consistent CORS-carrying `502` on any downstream throw, and made `sendEmail` log the Resend status + body on a non-ok response. Added a worker test for the rejected-downstream path and gave the Resend mock a `text()` stub.

## Testing
Pure refactor / no UI surface — verified via the gate rather than a browser recipe:
- `vue-tsc --noEmit` clean; worker `tsc --noEmit` clean.
- Frontend unit suite: 426 passing; worker suite: 11 passing.
- Coverage above floor (lines 99.24%, statements 98.45%, functions 97.86%, branches 91.84%); `check-coverage` exits 0.
- Production build (`npm run build`) succeeds.

## Note
The Worker code change does **not** auto-deploy — GitHub Actions only publishes the site. The hardened Worker goes live only on a manual `wrangler deploy` (deploy → set secrets, per `worker/README.md`).
