### PR TITLE
fix: honor prefers-reduced-motion for press hash-scroll

### DIFF
--- a/src/views/PressView.test.ts
+++ b/src/views/PressView.test.ts
@@ -14,7 +14,7 @@ describe('PressView', () => {
     vi.restoreAllMocks();
   });
 
-  it('scrolls the targeted quote into view when the hash changes', async () => {
+  const mountAndScrollToFirstQuote = async (): Promise<ReturnType<typeof vi.spyOn>> => {
     const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
     const router = createRouter({
       history: createMemoryHistory(),
@@ -28,7 +28,23 @@ describe('PressView', () => {
     await router.push({ hash: `#${pressQuotes[0].id}` });
     await nextTick();
 
+    return scrollIntoView;
+  };
+
+  it('smooth-scrolls the targeted quote into view when the hash changes', async () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: false } as MediaQueryList);
+
+    const scrollIntoView = await mountAndScrollToFirstQuote();
+
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('jumps without animation when reduced motion is preferred', async () => {
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true } as MediaQueryList);
+
+    const scrollIntoView = await mountAndScrollToFirstQuote();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' });
   });
 
   it('renders a blockquote for every press quote, keyed by id', async () => {

--- a/src/views/PressView.vue
+++ b/src/views/PressView.vue
@@ -5,12 +5,13 @@ import { useHashScroll } from '@/composables/useHashScroll';
 import { usePageHead } from '@/composables/usePageHead';
 import { pageMeta } from '@/data/pageMeta';
 import { pressQuotes } from '@/data/press';
+import { prefersReducedMotion } from '@/utils/scroll';
 
 usePageHead(pageMeta.press);
 
 const scrollToHash = (hash: string) => {
   const element = document.getElementById(hash.replace('#', ''));
-  element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  element?.scrollIntoView({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
 };
 
 useHashScroll(scrollToHash);


### PR DESCRIPTION
## Description
The Press page's hash-scroll was hardcoded to `behavior: 'smooth'`, ignoring `prefers-reduced-motion` — the one JS-driven scroll in the app that didn't honor the setting (`useAccordion` already does, via `prefersReducedMotion()`). This routes it through the same shared helper so a reduced-motion visitor gets an instant jump.

## Changes
- `PressView.vue`: `scrollToHash` now uses `behavior: prefersReducedMotion() ? 'auto' : 'smooth'`, importing the shared `prefersReducedMotion` from `@/utils/scroll`.
- `PressView.test.ts`: extracted a `mountAndScrollToFirstQuote` helper and split the scroll test into two — smooth when motion is allowed, `auto` when reduced motion is preferred.

## Why not the fuller "dedup"
The audit also flagged PressView's scroll as duplicating `useAccordion`'s. It isn't true duplication: `scrollIntoView` (Press) respects the `scroll-padding-top` set on `html` for header clearance, whereas `useAccordion`'s `window.scrollTo` needs a manual offset because `scrollTo` ignores scroll-padding. Collapsing them would risk a visible scroll-position change, so only the reduced-motion behavior was unified.

## Testing
- Unit: 427 passing (added the reduced-motion case); coverage above floor (lines 99.24%, branches 91.87%), `check-coverage` exits 0.
- `vue-tsc --noEmit` clean, lint clean, production build succeeds.
- Behavioural: motion-allowed visitors are unchanged (smooth); with OS "reduce motion" on, clicking a press-quote deep link jumps instantly instead of animating.
