### PR TITLE
docs: correct the worker deploy note on secret persistence

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -34,15 +34,23 @@ Responses: `200 {ok:true}` on success (and on a tripped honeypot, silently),
 
 ## Deploy
 
-Set the secrets **after** `deploy`, and don't `deploy` again afterward — a
-`wrangler deploy` detaches previously-set secrets from the served version, so
-setting them last is what binds them at runtime.
-
 ```sh
 cd worker
 npm install
 npx wrangler login
 npx wrangler deploy                         # prints the *.workers.dev URL
+npx wrangler secret list                    # confirm both secrets are attached
+```
+
+The secrets live at the Worker level and persist across deploys, so a routine
+code deploy needs nothing more. Note that `wrangler deploy`'s "bindings" list
+only prints the `wrangler.toml` vars — out-of-band secrets never appear there,
+which is expected and not a sign they were dropped. Verify with `secret list`
+rather than reading the deploy output.
+
+First-time setup (or if `secret list` ever comes back missing one) sets them:
+
+```sh
 npx wrangler secret put TURNSTILE_SECRET    # paste the Turnstile secret key
 npx wrangler secret put RESEND_API_KEY      # paste the Resend API key
 ```


### PR DESCRIPTION
## Description
Corrects the `worker/README.md` deploy note. It previously asserted that a `wrangler deploy` *detaches* previously-set secrets — almost certainly a misread: `wrangler deploy`'s "bindings" list only prints the `wrangler.toml` vars, and out-of-band secrets never appear there. That absence was mistaken for a detach.

Verified this session: after a code deploy, `wrangler secret list` showed both `TURNSTILE_SECRET` and `RESEND_API_KEY` still attached, and the live Worker smoke-tested healthy (204 preflight / 200 honeypot-drop / 403 on a bad token).

## Changes
- Reframes the Deploy section: secrets persist at the Worker level across deploys; a routine code deploy needs nothing extra.
- Adds `wrangler secret list` as the verification step (instead of reading deploy output).
- Keeps the `secret put` commands scoped to first-time setup / recovery if a secret is ever actually missing.

## Testing
Docs only — no code change.