### PR TITLE
refactor: extract recurring SCSS mixins

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -186,17 +186,8 @@
 
     .release-title-link {
       color: inherit;
-      text-decoration: none;
-      transition: opacity $transition-base;
-
-      &:hover {
-        opacity: $opacity-70;
-      }
-
-      &:focus-visible {
-        outline: 1px solid var(--color-border);
-        outline-offset: 2px;
-      }
+      @include subtle-link-hover;
+      @include focus-outline-subtle;
     }
 
     .release-meta {
@@ -318,11 +309,7 @@
   }
 
   h2 {
-    font-size: $font-size-xs;
-    font-weight: $font-weight-medium;
-    text-transform: uppercase;
-    letter-spacing: $letter-spacing-wider;
-    color: var(--color-text-muted);
+    @include label-style($font-weight-medium);
     margin-top: 0;
     margin-bottom: $spacing-4;
   }
@@ -373,11 +360,7 @@
   &__label {
     display: block;
     margin-bottom: $spacing-2;
-    font-size: $font-size-xs;
-    font-weight: $font-weight-medium;
-    text-transform: uppercase;
-    letter-spacing: $letter-spacing-wider;
-    color: var(--color-text-muted);
+    @include label-style($font-weight-medium);
 
     abbr {
       margin-left: $spacing-1;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -99,19 +99,7 @@ footer {
 }
 
 .page-loading__dot {
-  width: $loading-dot-size;
-  height: $loading-dot-size;
-  background: var(--color-text-muted);
-  border-radius: 50%;
-  animation: loading-pulse 1.2s ease-in-out infinite;
-
-  &:nth-child(2) {
-    animation-delay: 0.2s;
-  }
-
-  &:nth-child(3) {
-    animation-delay: 0.4s;
-  }
+  @include loading-dot;
 }
 
 @keyframes loading-pulse {

--- a/src/styles/_pages.scss
+++ b/src/styles/_pages.scss
@@ -40,19 +40,7 @@
   }
 
   .hero__loading-dot {
-    width: $loading-dot-size;
-    height: $loading-dot-size;
-    background: var(--color-text-muted);
-    border-radius: 50%;
-    animation: loading-pulse 1.2s ease-in-out infinite;
-
-    &:nth-child(2) {
-      animation-delay: 0.2s;
-    }
-
-    &:nth-child(3) {
-      animation-delay: 0.4s;
-    }
+    @include loading-dot;
   }
 }
 
@@ -304,34 +292,16 @@
 
   .event-title-link {
     color: inherit;
-    text-decoration: none;
-    transition: opacity $transition-base;
-
-    &:hover {
-      opacity: $opacity-70;
-    }
-
-    &:focus-visible {
-      outline: 1px solid var(--color-border);
-      outline-offset: 2px;
-    }
+    @include subtle-link-hover;
+    @include focus-outline-subtle;
   }
 
   .event-title-ref {
     margin-left: $spacing-1;
     color: var(--color-text-muted);
     font-size: 0.85em;
-    text-decoration: none;
-    transition: opacity $transition-base;
-
-    &:hover {
-      opacity: $opacity-70;
-    }
-
-    &:focus-visible {
-      outline: 1px solid var(--color-border);
-      outline-offset: 2px;
-    }
+    @include subtle-link-hover;
+    @include focus-outline-subtle;
   }
 }
 
@@ -401,11 +371,7 @@
 
   &__heading {
     margin-bottom: $spacing-3;
-    font-size: $font-size-xs;
-    font-weight: $font-weight-medium;
-    text-transform: uppercase;
-    letter-spacing: $letter-spacing-wider;
-    color: var(--color-text-muted);
+    @include label-style($font-weight-medium);
   }
 
   &__body {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -93,9 +93,9 @@ $overlay-dark: rgba(0, 0, 0, 0.4);
   }
 }
 
-@mixin label-style {
+@mixin label-style($weight: $font-weight-normal) {
   font-size: $font-size-xs;
-  font-weight: $font-weight-normal;
+  font-weight: $weight;
   text-transform: uppercase;
   letter-spacing: $letter-spacing-wider;
   color: var(--color-text-muted);
@@ -130,6 +130,22 @@ $overlay-dark: rgba(0, 0, 0, 0.4);
   }
 }
 
+@mixin subtle-link-hover {
+  text-decoration: none;
+  transition: opacity $transition-base;
+
+  &:hover {
+    opacity: $opacity-70;
+  }
+}
+
+@mixin focus-outline-subtle {
+  &:focus-visible {
+    outline: 1px solid var(--color-border);
+    outline-offset: 2px;
+  }
+}
+
 // Visible underline for links in prose (WCAG 2.1 Level A — distinguishable without colour)
 @mixin link-underline {
   text-decoration: underline !important;
@@ -153,6 +169,22 @@ $overlay-dark: rgba(0, 0, 0, 0.4);
   &.is-loaded {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@mixin loading-dot {
+  width: $loading-dot-size;
+  height: $loading-dot-size;
+  background: var(--color-text-muted);
+  border-radius: 50%;
+  animation: loading-pulse 1.2s ease-in-out infinite;
+
+  &:nth-child(2) {
+    animation-delay: 0.2s;
+  }
+
+  &:nth-child(3) {
+    animation-delay: 0.4s;
   }
 }
 


### PR DESCRIPTION
## Description
Bundle B of the refreshed refactoring audit. Extracts the recurring SCSS idioms into mixins. **Zero visual change — proven by a compiled-CSS byte-diff** (baseline vs. post-refactor `dist/assets/*.css` are byte-identical, 34,179 bytes).

## Changes
- **New mixins** in `_variables.scss`: `subtle-link-hover` (opacity-on-hover link), `focus-outline-subtle` (the subtle 1px focus-visible outline, was 4× byte-identical), `loading-dot` (the pulsing loader dot). Parametrized the existing `label-style` mixin with a `$weight` argument (defaults unchanged).
- **Consumers routed through them** (all byte-identical conversions): `.release-title-link` / `.event-title-link` / `.event-title-ref`, `.hero__loading-dot` / `.page-loading__dot`, and three uppercase-label headings (`h2`, `.contact-form__label`, `&__heading`).

## Deliberately excluded
- **`link-underline` consolidation** — the existing mixin carries `!important`, which the two hand-rolls omit; folding them in would change the compiled CSS, so it's deferred rather than forced under a zero-change PR.
- **Footer label** — converting it would add an explicit `font-weight` declaration (not byte-clean), so left as-is.

## Testing
- **Compiled-CSS byte-diff: identical** (the primary guard for a pure-styling refactor).
- Visual Regression (CI) — the backstop.
- 427 unit tests pass; coverage above floor; lint clean; production build succeeds.