### PR TITLE
refactor: dedupe build scripts and E2E hydration boilerplate

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { checkA11y, isMobile, MIN_TOUCH_TARGET_SIZE, waitForHydration } from './helpers';
+import { checkA11y, gotoHydrated, isMobile, MIN_TOUCH_TARGET_SIZE } from './helpers';
 
 const MAIN_CONTENT_SELECTOR = '#main-content';
 const SKIP_LINK_SELECTOR = 'a[href="#main-content"]';
@@ -11,8 +11,7 @@ test.describe('Accessibility', () => {
   test.describe('WCAG Compliance', () => {
     for (const path of PAGES) {
       test(`${path} should not have violations`, async ({ page }) => {
-        await page.goto(path);
-        await waitForHydration(page);
+        await gotoHydrated(page, path);
         await checkA11y(page);
       });
     }
@@ -20,16 +19,14 @@ test.describe('Accessibility', () => {
 
   test.describe('Keyboard Navigation', () => {
     test('should allow tab navigation through interactive elements', async ({ page }) => {
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
 
       await page.locator(SKIP_LINK_SELECTOR).focus();
       await expect(page.locator(SKIP_LINK_SELECTOR)).toBeFocused();
     });
 
     test('should skip to main content with skip link', async ({ page }) => {
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
 
       const skipLink = page.locator(SKIP_LINK_SELECTOR);
       test.skip(await skipLink.count() === 0, 'No skip link found');
@@ -56,8 +53,7 @@ test.describe('Accessibility', () => {
 
   test.describe('Focus Management', () => {
     test('should have visible focus indicators', async ({ page }) => {
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
 
       const firstLink = page.locator('a').first();
       await firstLink.focus();
@@ -70,8 +66,7 @@ test.describe('Accessibility', () => {
     });
 
     test('should maintain focus order', async ({ page }) => {
-      await page.goto('/works');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/works');
 
       const interactive = page.locator('a, button, input, textarea, [tabindex="0"]').first();
       await interactive.focus();
@@ -146,23 +141,20 @@ test.describe('Accessibility', () => {
 
   test.describe('Color Contrast', () => {
     test('should meet WCAG AA contrast requirements', async ({ page }) => {
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
       await checkA11y(page, { tags: ['wcag2aa'] });
     });
 
     test('should be readable in dark mode', async ({ page }) => {
       await page.emulateMedia({ colorScheme: 'dark' });
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
       await checkA11y(page, { tags: ['wcag2aa'] });
     });
   });
 
   test.describe('ARIA Attributes', () => {
     test('should have valid ARIA attributes', async ({ page }) => {
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
       await checkA11y(page, { tags: ['wcag2a', 'wcag2aa'] });
     });
 
@@ -180,16 +172,14 @@ test.describe('Accessibility', () => {
 
   test.describe('Responsive Accessibility', () => {
     test('should be accessible on all viewports', async ({ page }) => {
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
       await checkA11y(page);
     });
 
     test('should have touch-friendly targets on mobile', async ({ page }) => {
       test.skip(!isMobile(page), 'Not a mobile viewport');
 
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
 
       const box = await page.locator('.nav-toggle').boundingBox();
       expect(box).not.toBeNull();

--- a/e2e/accordion.spec.ts
+++ b/e2e/accordion.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { toggleAndVerifyAccordion, waitForHydration } from './helpers';
+import { gotoHydrated, toggleAndVerifyAccordion } from './helpers';
 
 const ACCORDION_SECTION_SELECTOR = '.accordion-section';
 const ACCORDION_TRIGGER_SELECTOR = '.accordion-trigger';
@@ -17,8 +17,7 @@ test.describe('Accordion Functionality', () => {
     });
 
     test('should toggle accordion sections on click', async ({ page }) => {
-      await page.goto(WORKS_PAGE);
-      await waitForHydration(page);
+      await gotoHydrated(page, WORKS_PAGE);
 
       const firstTrigger = page.locator(ACCORDION_TRIGGER_SELECTOR).first();
       await toggleAndVerifyAccordion(firstTrigger, 'true');
@@ -31,8 +30,7 @@ test.describe('Accordion Functionality', () => {
     });
 
     test('should update URL hash when accordion opens', async ({ page }) => {
-      await page.goto(WORKS_PAGE);
-      await waitForHydration(page);
+      await gotoHydrated(page, WORKS_PAGE);
 
       const sectionId = await page.locator(ACCORDION_SECTION_SELECTOR).nth(1).getAttribute('id');
       expect(sectionId).toBeTruthy();
@@ -47,8 +45,7 @@ test.describe('Accordion Functionality', () => {
     });
 
     test('should handle multiple accordion sections', async ({ page }) => {
-      await page.goto(WORKS_PAGE);
-      await waitForHydration(page);
+      await gotoHydrated(page, WORKS_PAGE);
 
       expect(await page.locator(ACCORDION_TRIGGER_SELECTOR).count()).toBeGreaterThan(1);
 
@@ -70,8 +67,7 @@ test.describe('Accordion Functionality', () => {
     });
 
     test('should toggle year sections', async ({ page }) => {
-      await page.goto(LIVE_PAGE);
-      await waitForHydration(page);
+      await gotoHydrated(page, LIVE_PAGE);
 
       await toggleAndVerifyAccordion(page.locator(ACCORDION_TRIGGER_SELECTOR).first(), 'true');
     });
@@ -96,8 +92,7 @@ test.describe('Accordion Functionality', () => {
 
   test.describe('Accordion Keyboard Accessibility', () => {
     test('should be keyboard navigable', async ({ page }) => {
-      await page.goto(WORKS_PAGE);
-      await waitForHydration(page);
+      await gotoHydrated(page, WORKS_PAGE);
 
       const firstTrigger = page.locator(ACCORDION_TRIGGER_SELECTOR).first();
       await firstTrigger.focus();
@@ -109,8 +104,7 @@ test.describe('Accordion Functionality', () => {
     });
 
     test('should support Space key activation', async ({ page }) => {
-      await page.goto(WORKS_PAGE);
-      await waitForHydration(page);
+      await gotoHydrated(page, WORKS_PAGE);
 
       const firstTrigger = page.locator(ACCORDION_TRIGGER_SELECTOR).first();
       await firstTrigger.focus();
@@ -123,8 +117,7 @@ test.describe('Accordion Functionality', () => {
 
   test.describe('Accordion Mobile Behavior', () => {
     test('should toggle accordion with pointer events', async ({ page }) => {
-      await page.goto(WORKS_PAGE);
-      await waitForHydration(page);
+      await gotoHydrated(page, WORKS_PAGE);
 
       const firstTrigger = page.locator(ACCORDION_TRIGGER_SELECTOR).first();
       await expect(firstTrigger).toHaveAttribute('aria-expanded', 'true');
@@ -135,8 +128,7 @@ test.describe('Accordion Functionality', () => {
     });
 
     test('should handle hash navigation on all devices', async ({ page }) => {
-      await page.goto(`${WORKS_PAGE}#section-solo`);
-      await waitForHydration(page);
+      await gotoHydrated(page, `${WORKS_PAGE}#section-solo`);
       await expect(page.locator(SOLO_SECTION_ID)).toBeVisible();
       await expect(page.locator(SOLO_TRIGGER_ID)).toHaveAttribute('aria-expanded', 'true');
     });

--- a/e2e/epk.spec.ts
+++ b/e2e/epk.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { checkA11y, waitForHydration } from './helpers';
+import { checkA11y, gotoHydrated } from './helpers';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
@@ -46,8 +46,7 @@ test.describe('Press kit (EPK)', () => {
   });
 
   test('has no detectable accessibility violations', async ({ page }) => {
-    await page.goto('/epk');
-    await waitForHydration(page);
+    await gotoHydrated(page, '/epk');
 
     await checkA11y(page, { tags: WCAG_TAGS });
   });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -12,6 +12,11 @@ export const waitForHydration = async (page: Page): Promise<void> => {
   await page.evaluate(() => document.fonts.ready);
 };
 
+export const gotoHydrated = async (page: Page, path: string): Promise<void> => {
+  await page.goto(path);
+  await waitForHydration(page);
+};
+
 export const isMobile = (page: Page): boolean => {
   const viewport = page.viewportSize();
   return viewport !== null && viewport.width < MOBILE_BREAKPOINT;

--- a/e2e/home-hero.spec.ts
+++ b/e2e/home-hero.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { waitForHydration } from './helpers';
+import { gotoHydrated } from './helpers';
 
 const MAX_GAP = 3;
 
@@ -19,8 +19,7 @@ test.describe('Home hero fills the viewport to the footer', () => {
   ]) {
     test(`hero meets the footer with no gap on ${label}`, async ({ page }) => {
       await page.setViewportSize({ width, height });
-      await page.goto('/');
-      await waitForHydration(page);
+      await gotoHydrated(page, '/');
 
       const gap = await heroFooterGap(page);
       expect(

--- a/e2e/lightbox.spec.ts
+++ b/e2e/lightbox.spec.ts
@@ -1,6 +1,6 @@
 import { expect, type Page, test } from '@playwright/test';
 
-import { waitForHydration } from './helpers';
+import { gotoHydrated } from './helpers';
 
 const LIGHTBOX_SELECTOR = '.lightbox';
 const LIGHTBOX_CLOSE_SELECTOR = '.lightbox__hint--close';
@@ -17,8 +17,7 @@ const GALLERY_BUTTON_SELECTOR = '.link-discrete:has-text("Gallery")';
 const VISIBLE_GALLERY_BUTTON = `${GALLERY_BUTTON_SELECTOR}:visible`;
 
 const openFirstGallery = async (page: Page): Promise<void> => {
-  await page.goto('/works');
-  await waitForHydration(page);
+  await gotoHydrated(page, '/works');
 
   const owningSection = page.locator(ACCORDION_SECTION_SELECTOR)
     .filter({ has: page.locator(GALLERY_BUTTON_SELECTOR) })
@@ -42,8 +41,7 @@ const openLightboxFromFirstGallery = async (page: Page): Promise<void> => {
 const LIVE_GALLERY_BUTTON = '.link-discrete:has-text("Photo")';
 
 const openLiveLightbox = async (page: Page): Promise<void> => {
-  await page.goto('/live');
-  await waitForHydration(page);
+  await gotoHydrated(page, '/live');
 
   const owningSection = page.locator(ACCORDION_SECTION_SELECTOR)
     .filter({ has: page.locator(LIVE_GALLERY_BUTTON) })

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { isMobile, openMobileMenuIfNeeded, waitForHydration } from './helpers';
+import { gotoHydrated, isMobile, openMobileMenuIfNeeded } from './helpers';
 
 const NAV_TOGGLE_SELECTOR = '.nav-toggle';
 const NAV_OPEN_SELECTOR = '.nav--open';
@@ -145,8 +145,7 @@ test.describe('Navigation', () => {
 
   test('keeps the mobile menu open when opened on a scrolled page', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto(PAGES.ABOUT);
-    await waitForHydration(page);
+    await gotoHydrated(page, PAGES.ABOUT);
 
     await page.mouse.wheel(0, 400);
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { waitForHydration } from './helpers';
+import { gotoHydrated } from './helpers';
 
 // Baselines are platform-specific (generated on CI/Linux) — regenerate with
 // `playwright test --grep @visual --update-snapshots` on CI, not locally.
@@ -18,8 +18,7 @@ const PAGES = [
 test.describe('Visual regression', () => {
   for (const [path, name] of PAGES) {
     test(`${name} matches its snapshot`, { tag: '@visual' }, async ({ page }) => {
-      await page.goto(path);
-      await waitForHydration(page);
+      await gotoHydrated(page, path);
 
       await expect(page).toHaveScreenshot(`${name}.png`, {
         animations: 'disabled',

--- a/scripts/data-loader.mjs
+++ b/scripts/data-loader.mjs
@@ -1,0 +1,10 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createJiti } from 'jiti';
+
+export const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const jiti = createJiti(import.meta.url, { alias: { '@': join(root, 'src') } });
+
+export const loadData = relativePath => jiti.import(join(root, relativePath));

--- a/scripts/generate-responsive-images.mjs
+++ b/scripts/generate-responsive-images.mjs
@@ -1,21 +1,33 @@
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
 
 import sharp from 'sharp';
 
-const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+import { loadData, root } from './data-loader.mjs';
+
 const PUBLIC = join(root, 'public');
 const OUT = join(PUBLIC, 'images/responsive');
 
-const extract = (file, key) => {
-  const text = readFileSync(join(root, 'src/data', file), 'utf8');
-  const imagePattern = new RegExp(`${key}:\\s*'(/images/[a-z0-9-]+\\.jpg)'`, 'g');
-  return [...text.matchAll(imagePattern)].map(match => match[1]);
-};
+// Only flat, lowercase-slug JPEGs get responsive variants — the same set the
+// runtime srcset expects. Reading the typed data (rather than regex-scanning the
+// source) keeps this robust to formatting changes in the data files.
+const RESPONSIVE_IMAGE = /^\/images\/[a-z0-9-]+\.jpg$/;
 
-const covers = [...new Set(extract('works.ts', 'coverImage'))].map(src => ({ src, widths: [320, 640, 960] }));
-const aboutImages = [...new Set(extract('about.ts', 'src'))].map(src => ({ src, widths: [480, 960, 1440] }));
+const { worksData } = await loadData('src/data/works.ts');
+const { aboutSections } = await loadData('src/data/about.ts');
+
+const coverSrcs = Object.values(worksData)
+  .flatMap(section => section.items)
+  .map(item => item.coverImage)
+  .filter(src => src && RESPONSIVE_IMAGE.test(src));
+
+const aboutSrcs = aboutSections
+  .flatMap(section => section.images ?? [])
+  .map(image => image.src)
+  .filter(src => RESPONSIVE_IMAGE.test(src));
+
+const covers = [...new Set(coverSrcs)].map(src => ({ src, widths: [320, 640, 960] }));
+const aboutImages = [...new Set(aboutSrcs)].map(src => ({ src, widths: [480, 960, 1440] }));
 const targets = [...covers, ...aboutImages];
 
 mkdirSync(OUT, { recursive: true });

--- a/scripts/inter-weights.mjs
+++ b/scripts/inter-weights.mjs
@@ -1,0 +1,3 @@
+// Single source of the Inter weights shipped as self-hosted woff2 — the
+// subsetter produces these files and the PDF embedder consumes them.
+export const INTER_WEIGHTS = [400, 500, 600];

--- a/scripts/pdf-fonts.mjs
+++ b/scripts/pdf-fonts.mjs
@@ -1,11 +1,13 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { INTER_WEIGHTS } from './inter-weights.mjs';
+
 export const interFontFaces = async root => {
   const face = async weight => {
     const data = (await readFile(join(root, `public/fonts/inter-${weight}.woff2`))).toString('base64');
     return `@font-face{font-family:'Inter';font-style:normal;font-weight:${weight};src:url(data:font/woff2;base64,${data}) format('woff2')}`;
   };
 
-  return (await Promise.all([400, 500, 600].map(face))).join('');
+  return (await Promise.all(INTER_WEIGHTS.map(face))).join('');
 };

--- a/scripts/subset-fonts.mjs
+++ b/scripts/subset-fonts.mjs
@@ -5,10 +5,12 @@ import { fileURLToPath } from 'node:url';
 
 import subsetFont from 'subset-font';
 
+import { INTER_WEIGHTS } from './inter-weights.mjs';
+
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const FONT_DIR = join(root, 'node_modules/@fontsource/inter/files');
 const OUT_DIR = join(root, 'public/fonts');
-const WEIGHTS = { 400: 'inter-latin-400-normal.woff2', 500: 'inter-latin-500-normal.woff2', 600: 'inter-latin-600-normal.woff2' };
+const WEIGHTS = Object.fromEntries(INTER_WEIGHTS.map(weight => [weight, `inter-latin-${weight}-normal.woff2`]));
 
 const collectChars = () => {
   const chars = new Set();


### PR DESCRIPTION
## Description
Bundle D of the refreshed audit — tooling/test dedup only. **No production code changes.**

## Changes
- **`gotoHydrated(page, path)` E2E helper** — collapses 24 repeated `await page.goto(x); await waitForHydration(page);` pairs across 7 specs into one call. Only true adjacent pairs were converted; standalone `goto`s (deliberately pre-hydration) are untouched.
- **Responsive-image generator reads typed data via `jiti`** — replaces a brittle source-text regex (`/coverImage:\s*'...'/`) that silently missed any path not matching its narrow shape. A shared `scripts/data-loader.mjs` wraps the `jiti` setup. **Generated manifest is byte-identical** (37 images) — proven by diffing `responsiveImages.json` before/after.
- **`INTER_WEIGHTS` const** — single-sources the `[400, 500, 600]` weight list shared between the font subsetter (producer) and the PDF embedder (consumer).

## Deliberately scoped out
The lower-value Bundle D items (PDF Chromium-pipeline helper, the report-format `repeat(50)` helper, an E2E route registry) were left for a possible follow-up — and the audit's "a11y sweep misses /epk & /privacy" claim was **stale** (both are covered today), so nothing was done there.

## Testing
- Chromium E2E: **85 passed, 1 skipped** locally (the `gotoHydrated` guard); CI runs all three engines.
- Responsive manifest byte-identical; production build OK; lint clean.