### PR TITLE
a11y: per-link new-tab cues, drop the blanket page notes

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -11,6 +11,8 @@ const LinksPage = {
     <a href="https://external.example.com">external</a>
     <a href="/about">internal</a>
     <a href="http://localhost/local-page">same-origin absolute</a>
+    <a href="https://labelled.example.com" aria-label="Docs, opens in a new tab">labelled</a>
+    <a href="https://precued.example.com">precued<span class="visually-hidden"> (opens in a new tab)</span></a>
   </div>`,
 };
 
@@ -78,12 +80,35 @@ describe('App', () => {
     expect(external.attributes('rel')).toBe('noopener noreferrer');
   });
 
+  it('adds a single visually-hidden new-tab cue to a cross-origin link', async () => {
+    const { wrapper } = await mountApp();
+    const cues = wrapper.get('main a[href="https://external.example.com"]').findAll('.visually-hidden');
+
+    expect(cues).toHaveLength(1);
+    expect(cues[0].text()).toContain('opens in a new tab');
+  });
+
+  it('does not add a cue to a link that already conveys new-tab via aria-label', async () => {
+    const { wrapper } = await mountApp();
+    const labelled = wrapper.get('main a[href="https://labelled.example.com"]');
+
+    expect(labelled.findAll('.visually-hidden')).toHaveLength(0);
+  });
+
+  it('does not double-cue a link that already carries a visually-hidden cue', async () => {
+    const { wrapper } = await mountApp();
+    const precued = wrapper.get('main a[href="https://precued.example.com"]');
+
+    expect(precued.findAll('.visually-hidden')).toHaveLength(1);
+  });
+
   it('leaves a same-origin internal link untouched', async () => {
     const { wrapper } = await mountApp();
     const internal = wrapper.get('main a[href="/about"]');
 
     expect(internal.attributes('target')).toBeUndefined();
     expect(internal.attributes('rel')).toBeUndefined();
+    expect(internal.findAll('.visually-hidden')).toHaveLength(0);
   });
 
   it('leaves a same-origin absolute link untouched', async () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,16 +5,35 @@ import { RouterView } from 'vue-router';
 import SiteFooter from '@/components/SiteFooter.vue';
 import SiteHeader from '@/components/SiteHeader.vue';
 
+// Every external link opens in a new tab and gets a visually-hidden cue so
+// screen readers announce it. This is the single source of that cue: links that
+// already carry one (the ExternalLink component, or an aria-label that conveys
+// it) are left alone, so nothing is announced twice.
+const NEW_TAB_CUE = ' (opens in a new tab)';
+
+const addNewTabCue = (link: HTMLAnchorElement) => {
+  if (link.hasAttribute('aria-label') || link.querySelector('.visually-hidden')) return;
+
+  const cue = document.createElement('span');
+  cue.className = 'visually-hidden';
+  cue.textContent = NEW_TAB_CUE;
+  link.appendChild(cue);
+};
+
 const processExternalLinks = () => {
   const main = document.querySelector('main');
   if (!main) return;
 
-  const links = main.querySelectorAll<HTMLAnchorElement>('a[href^="http"]:not([target])');
+  const links = main.querySelectorAll<HTMLAnchorElement>('a[href^="http"]');
   links.forEach(link => {
-    if (link.hostname !== window.location.hostname) {
+    if (link.hostname === window.location.hostname) return;
+
+    if (!link.hasAttribute('target')) {
       link.setAttribute('target', '_blank');
       link.setAttribute('rel', 'noopener noreferrer');
     }
+
+    addNewTabCue(link);
   });
 };
 

--- a/src/components/AccordionPage.vue
+++ b/src/components/AccordionPage.vue
@@ -52,9 +52,6 @@ const openLightbox = (items: LightboxItem[], index: number): void => {
       :data-page="dataPage"
       :title="title"
     >
-      <p class="visually-hidden">
-        External links open in a new tab.
-      </p>
       <AccordionSection
         v-for="sectionKey in sections"
         :id="sectionKey"

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -42,9 +42,6 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number =>
       data-page="about"
       title="About"
     >
-      <p class="visually-hidden">
-        External links open in a new tab.
-      </p>
       <template
         v-for="(section, sectionIndex) in aboutSections"
         :key="section.id"

--- a/src/views/EpkView.vue
+++ b/src/views/EpkView.vue
@@ -21,10 +21,6 @@ const epk = resolveEpkContent(epkManifest);
       data-page="epk"
       title="Press Kit"
     >
-      <p class="visually-hidden">
-        External links open in a new tab.
-      </p>
-
       <section class="epk__section">
         <h2 class="epk__heading">
           Short bio

--- a/src/views/PrivacyView.vue
+++ b/src/views/PrivacyView.vue
@@ -14,9 +14,6 @@ usePageHead(pageMeta.privacy);
       data-page="privacy"
       title="Privacy"
     >
-      <p class="visually-hidden">
-        External links open in a new tab.
-      </p>
       <div class="privacy">
         <p class="privacy__intro">
           {{ privacyContent.intro }}


### PR DESCRIPTION
## Description
Bundle C's a11y item. The site was mixing **two** conventions for signalling that a link opens in a new tab: a *page-level* blanket note (`External links open in a new tab.`, hand-copied on 4 pages) **and** a *per-link* cue (`ExternalLink.vue`'s visually-hidden `(opens in a new tab)`). Pages that used both double-announced. This standardizes on the precise per-link cue and removes the blanket notes.

## Changes
- **`App.vue`** — its existing external-link scan is now the single source of the per-link cue: for every cross-origin link in `<main>` it adds the visually-hidden `(opens in a new tab)` span, **skipping** links that already convey it (the `ExternalLink` component's own cue, or an `aria-label`). This uniformly covers all link sources — `ExternalLink`, `externalizeLinks` (v-html descriptions/quotes), `ReleaseMeta`'s `renderLink`, and raw v-html — without any double-announce. Idempotent across re-runs (the presence of the cue is the guard).
- **Removed the 4 blanket notes** — `AccordionPage`, `About`, `EPK`, `Privacy`. (Privacy had no external links at all.)

## Note on rendering
The cue is injected client-side (as target/rel already were for raw links), so it lives in the hydrated DOM that screen readers read — not the pre-rendered HTML. Real SR users (JS on) get precise per-link cues; the removed blanket notes were the only SR affordance for the no-JS case, a negligible cohort for a hydrated SPA. Visually-hidden throughout, so no visual change (VR unaffected).

## Testing
- Unit: 430 pass — new App.vue tests assert exactly one cue on a cross-origin link, no cue on internal/same-origin links, and no double-cue when an `aria-label` or existing cue is present.
- Chromium E2E: accessibility + EPK specs pass (**27 passed**), axe clean — no new violations from removing the notes.
- Type-check, lint, coverage (above floor), production build all green.