### PR TITLE
refactor: extract ResponsivePicture, unify the image load-in fade

### DIFF
--- a/src/components/ReleaseCover.vue
+++ b/src/components/ReleaseCover.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import { useImageLoader } from '@/composables/useImageLoader';
-import { responsiveSrcset } from '@/utils/responsiveImage';
-
 import ExternalLink from './ExternalLink.vue';
+import ResponsivePicture from './ResponsivePicture.vue';
 
 const props = defineProps<{
   src: string;
@@ -13,16 +11,7 @@ const props = defineProps<{
   bandcamp?: boolean;
 }>();
 
-const emit = defineEmits<{ error: [] }>();
-
-const { setImageRef, imageLoaded, webpSrc, handleImageLoad, handleImageError } = useImageLoader(props.src);
-
-const coverSrcset = computed(() => responsiveSrcset(props.src));
-
-const onError = (): void => {
-  handleImageError();
-  emit('error');
-};
+defineEmits<{ error: [] }>();
 
 const wrapperClass = computed(() => ({
   'release-cover': true,
@@ -37,27 +26,11 @@ const wrapperClass = computed(() => ({
     :href="href"
     :class="wrapperClass"
   >
-    <picture>
-      <source
-        v-if="coverSrcset"
-        :srcset="coverSrcset"
-        sizes="(min-width: 768px) 200px, 90vw"
-        type="image/webp"
-      >
-      <source
-        :srcset="webpSrc"
-        type="image/webp"
-      >
-      <img
-        :ref="setImageRef"
-        :src="src"
-        :alt="alt"
-        loading="lazy"
-        decoding="async"
-        :class="{ 'is-loaded': imageLoaded }"
-        @load="handleImageLoad"
-        @error="onError"
-      >
-    </picture>
+    <ResponsivePicture
+      :src="src"
+      :alt="alt"
+      sizes="(min-width: 768px) 200px, 90vw"
+      @error="$emit('error')"
+    />
   </component>
 </template>

--- a/src/components/ResponsivePicture.test.ts
+++ b/src/components/ResponsivePicture.test.ts
@@ -1,0 +1,57 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import ResponsivePicture from './ResponsivePicture.vue';
+
+// A src present in the responsive-image manifest, so the srcset source renders.
+const MANIFEST_SRC = '/images/contraplacado.jpg';
+
+const mountPicture = (props: Record<string, unknown> = {}) =>
+  mount(ResponsivePicture, { props: { src: MANIFEST_SRC, alt: 'Cover', ...props } });
+
+describe('ResponsivePicture', () => {
+  it('renders the image with its src and alt', () => {
+    const img = mountPicture().get('img');
+
+    expect(img.attributes('src')).toBe(MANIFEST_SRC);
+    expect(img.attributes('alt')).toBe('Cover');
+  });
+
+  it('emits a responsive webp source with sizes, plus a plain webp fallback', () => {
+    const sources = mountPicture({ sizes: '90vw' }).findAll('source');
+
+    expect(sources).toHaveLength(2);
+    expect(sources[0].attributes('srcset')).toContain('contraplacado-320w.webp');
+    expect(sources[0].attributes('sizes')).toBe('90vw');
+    expect(sources[1].attributes('srcset')).toBe('/images/contraplacado.webp');
+  });
+
+  it('omits the responsive source for an image not in the manifest', () => {
+    const sources = mountPicture({ src: '/images/not-generated.jpg' }).findAll('source');
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].attributes('srcset')).toBe('/images/not-generated.webp');
+  });
+
+  it('applies an inline image style', () => {
+    const img = mountPicture({ imageStyle: { transform: 'rotate(4deg)' } }).get('img');
+
+    expect(img.attributes('style')).toContain('rotate(4deg)');
+  });
+
+  it('reveals the image only once it loads', async () => {
+    const wrapper = mountPicture();
+    expect(wrapper.get('img').classes()).not.toContain('is-loaded');
+
+    await wrapper.get('img').trigger('load');
+    expect(wrapper.get('img').classes()).toContain('is-loaded');
+  });
+
+  it('emits error when the image fails to load', async () => {
+    const wrapper = mountPicture();
+
+    await wrapper.get('img').trigger('error');
+
+    expect(wrapper.emitted('error')).toHaveLength(1);
+  });
+});

--- a/src/components/ResponsivePicture.vue
+++ b/src/components/ResponsivePicture.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { StyleValue } from 'vue';
+import { computed } from 'vue';
+
+import { useImageLoader } from '@/composables/useImageLoader';
+import { responsiveSrcset } from '@/utils/responsiveImage';
+
+const props = defineProps<{
+  src: string;
+  alt: string;
+  sizes?: string;
+  imageStyle?: StyleValue;
+}>();
+
+const emit = defineEmits<{ error: [] }>();
+
+const { setImageRef, imageLoaded, webpSrc, handleImageLoad, handleImageError } = useImageLoader(props.src);
+
+const srcset = computed(() => responsiveSrcset(props.src));
+
+const onError = (): void => {
+  handleImageError();
+  emit('error');
+};
+</script>
+
+<template>
+  <picture>
+    <source
+      v-if="srcset"
+      :srcset="srcset"
+      :sizes="sizes"
+      type="image/webp"
+    >
+    <source
+      :srcset="webpSrc"
+      type="image/webp"
+    >
+    <img
+      :ref="setImageRef"
+      :src="src"
+      :alt="alt"
+      :style="imageStyle"
+      loading="lazy"
+      decoding="async"
+      :class="{ 'is-loaded': imageLoaded }"
+      @load="handleImageLoad"
+      @error="onError"
+    >
+  </picture>
+</template>
+
+<style scoped lang="scss">
+img {
+  @include image-reveal;
+}
+</style>

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -133,7 +133,6 @@
       height: auto;
       display: block;
       margin: 0;
-      @include image-reveal;
     }
 
     &:focus-visible {

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -3,6 +3,7 @@ import { computed, useTemplateRef } from 'vue';
 
 import LightboxHost from '@/components/LightboxHost.vue';
 import PageShell from '@/components/PageShell.vue';
+import ResponsivePicture from '@/components/ResponsivePicture.vue';
 import { usePageHead } from '@/composables/usePageHead';
 import { aboutSections } from '@/data/about';
 import { pageMeta } from '@/data/pageMeta';
@@ -10,7 +11,6 @@ import { isImageSection } from '@/types';
 import { externalizeLinks } from '@/utils/externalizeLinks';
 import { getImageStyles } from '@/utils/imageStyles';
 import { toLightboxImage } from '@/utils/lightboxAdapters';
-import { responsiveSrcset, toWebp } from '@/utils/responsiveImage';
 
 usePageHead(pageMeta.about);
 
@@ -68,25 +68,12 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number =>
             class="about-image-group__image"
             @click="lightbox?.openLightbox(allImages, getGlobalIndex(sectionIndex, imageIndex))"
           >
-            <picture>
-              <source
-                v-if="responsiveSrcset(image.src)"
-                :srcset="responsiveSrcset(image.src) ?? undefined"
-                sizes="(min-width: 768px) 45vw, 48vw"
-                type="image/webp"
-              >
-              <source
-                :srcset="toWebp(image.src)"
-                type="image/webp"
-              >
-              <img
-                :src="image.src"
-                :alt="image.alt"
-                :style="getImageStyles(image)"
-                loading="lazy"
-                decoding="async"
-              >
-            </picture>
+            <ResponsivePicture
+              :src="image.src"
+              :alt="image.alt"
+              sizes="(min-width: 768px) 45vw, 48vw"
+              :image-style="getImageStyles(image)"
+            />
           </figure>
         </div>
       </template>

--- a/src/views/EpkView.vue
+++ b/src/views/EpkView.vue
@@ -3,12 +3,12 @@ import { RouterLink } from 'vue-router';
 
 import ExternalLink from '@/components/ExternalLink.vue';
 import PageShell from '@/components/PageShell.vue';
+import ResponsivePicture from '@/components/ResponsivePicture.vue';
 import { usePageHead } from '@/composables/usePageHead';
 import { epkManifest } from '@/data/epk';
 import { pageMeta } from '@/data/pageMeta';
 import { epkPdfHref, epkRiderHref, epkZipHref, photoDownloadHref, resolveEpkContent } from '@/utils/epk';
 import { externalizeLinks } from '@/utils/externalizeLinks';
-import { responsiveSrcset, toWebp } from '@/utils/responsiveImage';
 
 usePageHead({ ...pageMeta.epk, noIndex: true });
 
@@ -76,23 +76,10 @@ const epk = resolveEpkContent(epkManifest);
             :key="photo.src"
             class="epk__photo"
           >
-            <picture>
-              <source
-                v-if="responsiveSrcset(photo.src)"
-                :srcset="responsiveSrcset(photo.src) ?? undefined"
-                type="image/webp"
-              >
-              <source
-                :srcset="toWebp(photo.src)"
-                type="image/webp"
-              >
-              <img
-                :src="photo.src"
-                :alt="photo.alt"
-                loading="lazy"
-                decoding="async"
-              >
-            </picture>
+            <ResponsivePicture
+              :src="photo.src"
+              :alt="photo.alt"
+            />
             <figcaption>
               <template v-if="photo.photographer">
                 Photo:


### PR DESCRIPTION
## Description
Bundle C's structural item. The `<picture>` srcset/webp/img scaffold was hand-repeated 3× (ReleaseCover, About, EPK), and only ReleaseCover carried the `useImageLoader` load-in fade. This extracts one `ResponsivePicture` component and gives About + EPK the same fade — **consistent image reveal across the site** (your call: a consistency gain, no loss).

## Changes
- **New `ResponsivePicture.vue`** — owns the `<picture>` + `useImageLoader`; props `src`, `alt`, `sizes?`, `imageStyle?`; emits `error`. Scoped `img { @include image-reveal }`.
- **`ReleaseCover`** delegates to it (keeps its link wrapper + `@error` for the Bandcamp fallback); the redundant `@include image-reveal` moved off `.release-cover img`.
- **About & EPK** use it — each keeps its exact attributes (About's `sizes` + `getImageStyles`, EPK's bare image), and now fade in.

## Rendered output
Preserved: same `<picture> > source×2 > img` DOM, same src/alt/sizes/style — the 3 consumer test suites pass unchanged (13 tests). The only new behavior is the load-time opacity fade; the **final loaded state is identical** (opacity:1), so screenshots taken at networkidle should match. (Note: About's rotated images fade opacity-only, since their inline `transform` overrides the reveal's `translateY` — still a fade, no loss.)

## Testing
- New `ResponsivePicture.test` (6 cases: src/alt, responsive+fallback sources, manifest-absent, inline style, reveal-on-load, error emit). 436 unit tests pass; coverage above floor; type-check, lint, build green.
- **Visual Regression** is the key check — ReleaseCover already combines lazy + reveal and VR is stable, so I expect no baseline change; I'll regenerate baselines only if the final render legitimately shifts.