### PR TITLE
style: unify uppercase labels at font-weight 500

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -308,7 +308,7 @@
   }
 
   h2 {
-    @include label-style($font-weight-medium);
+    @include label-style;
     margin-top: 0;
     margin-bottom: $spacing-4;
   }
@@ -359,7 +359,7 @@
   &__label {
     display: block;
     margin-bottom: $spacing-2;
-    @include label-style($font-weight-medium);
+    @include label-style;
 
     abbr {
       margin-left: $spacing-1;

--- a/src/styles/_pages.scss
+++ b/src/styles/_pages.scss
@@ -371,7 +371,7 @@
 
   &__heading {
     margin-bottom: $spacing-3;
-    @include label-style($font-weight-medium);
+    @include label-style;
   }
 
   &__body {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -93,9 +93,9 @@ $overlay-dark: rgba(0, 0, 0, 0.4);
   }
 }
 
-@mixin label-style($weight: $font-weight-normal) {
+@mixin label-style {
   font-size: $font-size-xs;
-  font-weight: $weight;
+  font-weight: $font-weight-medium;
   text-transform: uppercase;
   letter-spacing: $letter-spacing-wider;
   color: var(--color-text-muted);


### PR DESCRIPTION
## Description
Bundle E's second reconciliation. The `label-style` mixin defaulted to **400**, but three call sites overrode to **500** — an inconsistent label weight across the site. Per your call, **500 is now the single weight** for the whole label family, and the mixin is param-less again (the `$weight` argument added in the mixin-extraction PR is no longer needed).

## Changes
- `_variables.scss`: `label-style` hardcodes `font-weight: $font-weight-medium`; dropped the `$weight` param.
- Removed the now-redundant `($font-weight-medium)` argument from the three explicit call sites.
- Net effect: the previously-400 consumers — **EPK labels, quote attributions (`cite, strong`), and the type-scale label** — move to 500, matching the section/form/heading labels that were already 500.

## Visual + VR
The weight bump is **imperceptible at the real 11px label size** (only visible zoomed in) — I regenerated the Linux baselines on the branch and they came back **byte-identical** to the committed ones, so no baseline update is needed and VR passes against the existing set. The change is really about *consistency* (one weight, no overrides) plus your chosen 500.

## Testing
Build, lint green; SCSS-only, so unit tests/coverage unaffected. VR confirms on CI.