### PR TITLE
feat: add a Clear recents command to the palette

### DIFF
--- a/src/composables/useCommandPalette.test.ts
+++ b/src/composables/useCommandPalette.test.ts
@@ -231,6 +231,35 @@ describe('useCommandPalette', () => {
     expect(afterRepeat[0]).toBe('works:overlapse');
   });
 
+  it('offers a Clear recents action in the default view and via search once recents exist', async () => {
+    const { api, wrapper } = await mountPalette();
+    active = wrapper;
+
+    api.query.value = '';
+    expect(api.results.value.some(command => command.id === 'act:clear-recents')).toBe(false);
+
+    await executeByTitle(api, 'Overlapse');
+
+    api.query.value = '';
+    expect(api.results.value.some(command => command.id === 'act:clear-recents')).toBe(true);
+
+    api.query.value = 'clear';
+    expect(api.results.value.some(command => command.id === 'act:clear-recents')).toBe(true);
+  });
+
+  it('empties stored recents when the Clear recents action runs', async () => {
+    const { api, wrapper } = await mountPalette();
+    active = wrapper;
+
+    await executeByTitle(api, 'Overlapse');
+    expect(JSON.parse(localStorage.getItem('command-palette:recents') ?? '[]')).not.toHaveLength(0);
+
+    api.query.value = '';
+    await api.execute(api.results.value.findIndex(command => command.id === 'act:clear-recents'));
+
+    expect(JSON.parse(localStorage.getItem('command-palette:recents') ?? '[]')).toHaveLength(0);
+  });
+
   it('ignores malformed recents in storage', async () => {
     localStorage.setItem('command-palette:recents', 'not json');
     const { api, wrapper } = await mountPalette();

--- a/src/composables/useCommandPalette.ts
+++ b/src/composables/useCommandPalette.ts
@@ -59,21 +59,36 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
       .filter((command): command is Command => command !== undefined)
       .map(command => ({ ...command, group: 'Recent' as const })));
 
+  const clearRecents = (): void => {
+    recentIds.value = [];
+    saveRecents(recentIds.value);
+  };
+
+  const clearRecentsCommand: Command = {
+    kind: 'action',
+    id: 'act:clear-recents',
+    title: 'Clear recents',
+    keywords: ['clear', 'reset', 'history', 'forget'],
+    group: 'Actions',
+    run: () => clearRecents(),
+  };
+
   const results = computed<Command[]>(() => {
     if (query.value.trim() === '') {
-      // The main routes are always shown under Navigate; Recent holds a few
-      // non-nav items (releases, press, actions). Everything else is searchable.
+      // Main routes always live under Navigate, never Recent.
       const recents = recentCommands.value
         .filter(command => !PRIMARY_ROUTE_IDS.includes(command.id))
         .slice(0, CURATED_RECENTS_MAX);
       const navigation = PRIMARY_ROUTE_IDS
         .map(id => byId.get(id))
         .filter((command): command is Command => command !== undefined);
-      return [...recents, ...navigation];
+      const clear = recents.length ? [clearRecentsCommand] : [];
+      return [...recents, ...clear, ...navigation];
     }
 
     // Cap the list: subsequence matching is permissive, so keep the best-ranked few.
-    return fuzzyRank(query.value, commands).slice(0, MAX_RESULTS);
+    const searchable = recentCommands.value.length ? [...commands, clearRecentsCommand] : commands;
+    return fuzzyRank(query.value, searchable).slice(0, MAX_RESULTS);
   });
 
   watch(results, () => {


### PR DESCRIPTION
## Description
Adds a **Clear recents** command to the ⌘K palette so recently-used commands can be wiped on demand.

## Behaviour
- Shown in the default view **below your recents** (only when recents exist), grouped under **Actions**, and reachable by search (`clear` / `reset` / `history`).
- Running it empties the recents ref and `localStorage`.

## Design
- `useCommandPalette` owns the recents state, so it owns the action — a reactive command bound to its own ref (no shared-state refactor, no test-isolation cost). The static `buildCommands()` registry stays for data-derived commands; this stateful one lives with the state it acts on.
- `execute()` remembers a command *before* running it, so the action's own transient "recent" entry is wiped by its own `run()`, leaving recents genuinely empty.

## Testing
- 3 new unit tests: appears with recents (default view + search), absent without, and clears storage on run.
- 505 unit tests green; lint, type-check, production build clean.
- Independent of the search/data-model refactor (PR B) — self-contained palette feature.
