### PR TITLE
fix: stop collapsed accordion sections leaking document scroll height

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -766,10 +766,14 @@
 .accordion-content {
   display: grid;
   grid-template-rows: 0fr;
+  // Keep collapsed content out of layout — the 0fr grid hides it visually but its
+  // rows still stack to full height and leak into the document's scroll otherwise.
+  content-visibility: hidden;
   transition: grid-template-rows $transition-base;
 
   &[aria-hidden="false"] {
     grid-template-rows: 1fr;
+    content-visibility: visible;
 
     .accordion-content-inner {
       opacity: 1;


### PR DESCRIPTION
**Not a player bug** — this is a pre-existing layout issue (present with the audio player off).

**Cause:** the accordion collapses sections with `grid-template-rows: 0fr`. That hides the content *visually* (0px, clipped), but the section's rows still stack to their full natural height and extend the document's scrollable area — ~1000px of empty space past the footer on **Works**, ~90px on **Live**.

**Fix:** `content-visibility: hidden` on collapsed sections keeps their content out of layout entirely (and out of the a11y tree / find-in-page, which matches `aria-hidden`). Open sections get `content-visibility: visible` and render exactly as before.

Verified at phone width: void = **0** on both pages (was 1076 / 91), open sections still render fully (cover, tracklist, credits), and toggling reveals content. Lint + accordion unit tests clean.