### PR TITLE
feat: play specific tracks from the Works listings

### DIFF
--- a/src/components/ReleaseItem.test.ts
+++ b/src/components/ReleaseItem.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 
 import { audioPlayerEnabled } from '@/composables/useFeatureFlags';
@@ -140,6 +140,63 @@ describe('ReleaseItem', () => {
 
   it('hides the play control when the flag is off', () => {
     expect(mountRelease(bandcamp).find('.release-play').exists()).toBe(false);
+  });
+
+  it('renders a per-track play button when the tracklist aligns with the audio', async () => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    audioPlayerEnabled.value = true;
+    const release: Release = {
+      id: '1714',
+      title: '17:14',
+      meta: { kind: 'music', mediums: ['Digital'], editions: [{ label: { text: 'BRØQN' } }], year: 2010 },
+      tracklist: [{ title: '8:58' }, { title: '2:58' }, { title: '5:18' }],
+    };
+
+    try {
+      const wrapper = mountRelease(release);
+      expect(wrapper.findAll('.track-play')).toHaveLength(3);
+      await wrapper.findAll('.track-play')[1].trigger('click');
+    } finally {
+      audioPlayerEnabled.value = false;
+    }
+  });
+
+  it('toggles playback when the already-playing track is clicked', async () => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    const pause = (HTMLMediaElement.prototype.pause = vi.fn());
+    audioPlayerEnabled.value = true;
+    const release: Release = {
+      id: '1714',
+      title: '17:14',
+      meta: { kind: 'music', mediums: ['Digital'], editions: [{ label: { text: 'BRØQN' } }], year: 2010 },
+      tracklist: [{ title: '8:58' }, { title: '2:58' }, { title: '5:18' }],
+    };
+
+    try {
+      const wrapper = mountRelease(release);
+      await wrapper.findAll('.track-play')[0].trigger('click');
+      await flushPromises();
+      await wrapper.findAll('.track-play')[0].trigger('click');
+      expect(pause).toHaveBeenCalled();
+    } finally {
+      audioPlayerEnabled.value = false;
+    }
+  });
+
+  it('omits per-track buttons when the tracklist does not align with the audio', () => {
+    audioPlayerEnabled.value = true;
+    const release: Release = {
+      id: '2504',
+      title: '2504',
+      meta: { kind: 'music', mediums: ['Digital'], editions: [{ label: { text: 'BRØQN' } }], year: 2024 },
+      tracklist: [{ title: 'I' }, { title: 'II' }, { title: 'III' }, { title: 'IV' }, { title: 'V' }],
+    };
+
+    try {
+      expect(mountRelease(release).findAll('.track-play')).toHaveLength(0);
+    } finally {
+      audioPlayerEnabled.value = false;
+    }
   });
 
   it('emits open-lightbox with converted images from the gallery button', async () => {

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -3,8 +3,8 @@ import { computed, ref } from 'vue';
 
 import { useAccordionVisibility } from '@/composables/useAccordionContext';
 import { audioPlayerEnabled } from '@/composables/useFeatureFlags';
-import { playRelease } from '@/composables/usePlayer';
-import { hasPlayableAudio } from '@/data/audio';
+import { play, playRelease, toggle, usePlayer } from '@/composables/usePlayer';
+import { getReleaseAudio, hasPlayableAudio } from '@/data/audio';
 import type { LightboxItem, Release } from '@/types';
 import { hasBandcampId, hasCoverImage, hasCredits, hasDescription, hasExternalUrl, hasImages, hasTracklist, hasVideos } from '@/types';
 import { externalizeLinks } from '@/utils/externalizeLinks';
@@ -46,10 +46,35 @@ const isBandcampLink = computed(() =>
 
 const playable = computed(() => audioPlayerEnabled.value && hasPlayableAudio(props.release.id));
 
-const playThis = (): Promise<void> => playRelease(props.release.id, {
+const audioTracks = computed(() => getReleaseAudio(props.release.id));
+
+// Per-track play only when the display tracklist lines up 1:1 with the audio
+// (2504's five movements are one continuous file, so it keeps release-level play).
+const perTrackPlayable = computed(() =>
+  playable.value && audioTracks.value.length === (props.release.tracklist?.length ?? 0));
+
+const { currentTrack, status } = usePlayer();
+
+const releaseContext = () => ({
   album: props.release.title,
   ...(hasCoverImage(props.release) ? { artwork: props.release.coverImage } : {}),
 });
+
+const isCurrentTrack = (index: number): boolean =>
+  currentTrack.value?.key === audioTracks.value[index]?.key;
+
+const isTrackPlaying = (index: number): boolean =>
+  isCurrentTrack(index) && ['playing', 'loading', 'buffering'].includes(status.value);
+
+const playThis = (): Promise<void> => playRelease(props.release.id, releaseContext());
+
+const playTrack = (index: number): void => {
+  if (isCurrentTrack(index)) {
+    toggle();
+    return;
+  }
+  void play(audioTracks.value, index, releaseContext());
+};
 </script>
 
 <template>
@@ -105,7 +130,28 @@ const playThis = (): Promise<void> => playRelease(props.release.id, {
         <li
           v-for="(track, index) in release.tracklist"
           :key="index"
+          :class="{ 'track--playing': isCurrentTrack(index) }"
         >
+          <button
+            v-if="perTrackPlayable"
+            type="button"
+            class="track-play"
+            :aria-label="`${isTrackPlaying(index) ? 'Pause' : 'Play'} ${track.title}`"
+            @click="playTrack(index)"
+          >
+            <svg
+              v-if="isTrackPlaying(index)"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+            ><path fill="currentColor" d="M6 5h4v14H6zm8 0h4v14h-4z" /></svg>
+            <svg
+              v-else
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+            ><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
+          </button>
           <TrackListItem :track="track" />
         </li>
       </ol>

--- a/src/styles/_player.scss
+++ b/src/styles/_player.scss
@@ -142,6 +142,39 @@
   }
 }
 
+.track-play {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: $spacing-1;
+  padding: 0;
+  color: var(--color-text-muted);
+  vertical-align: -0.2em;
+  cursor: pointer;
+  background: none;
+  border: none;
+  transition: color $transition-fast;
+
+  svg {
+    width: 0.9rem;
+    height: 0.9rem;
+  }
+
+  &:hover {
+    color: var(--color-text);
+  }
+}
+
+.track--playing {
+  color: var(--color-text);
+
+  .track-play {
+    color: var(--color-text);
+  }
+}
+
 @keyframes player-spin {
   to {
     transform: rotate(360deg);


### PR DESCRIPTION
Per-track playback in the Works tracklists (behind the `?audioPlayer=1` flag).

- Each track gets a play button **only when the display tracklist aligns 1:1 with the encoded audio** — so 2504 (five display movements, one continuous file) correctly keeps just the release-level play, while Overlapse XIII, Overlapse, the Caligari album, etc. get per-track buttons.
- Clicking plays the release queue **from that track**; the currently-playing row is highlighted and its button toggles pause.
- `TrackListItem` stays a pure display component — `ReleaseItem` orchestrates.

Verified: 8 buttons on Overlapse XIII, 0 on 2504, clicking track 3 plays 'Overlapse Supercut' and highlights row 3. ReleaseItem 100% line coverage; lint, type-check, build clean.