### PR TITLE
Expandable full-screen player with a dismiss control

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@ import SiteFooter from '@/components/SiteFooter.vue';
 import SiteHeader from '@/components/SiteHeader.vue';
 import { audioPlayerEnabled, initFeatureFlags } from '@/composables/useFeatureFlags';
 import { helpMounted, paletteMounted, useOverlayHotkeys } from '@/composables/useOverlays';
+import { usePlayer } from '@/composables/usePlayer';
 import { initTheme } from '@/composables/useTheme';
 
 // Lazy-loaded so the palette's registry, fuzzy ranker, and the data it reads stay
@@ -13,6 +14,9 @@ import { initTheme } from '@/composables/useTheme';
 const CommandPalette = defineAsyncComponent(() => import('@/components/CommandPalette.vue'));
 const KeyboardHelp = defineAsyncComponent(() => import('@/components/KeyboardHelp.vue'));
 const PlayerBar = defineAsyncComponent(() => import('@/components/PlayerBar.vue'));
+const PlayerScreen = defineAsyncComponent(() => import('@/components/PlayerScreen.vue'));
+
+const { expanded: playerExpanded } = usePlayer();
 
 useOverlayHotkeys();
 
@@ -97,4 +101,7 @@ onMounted(() => {
   <CommandPalette v-if="paletteMounted" />
   <KeyboardHelp v-if="helpMounted" />
   <PlayerBar v-if="audioPlayerEnabled" />
+  <Transition name="player-slide">
+    <PlayerScreen v-if="audioPlayerEnabled && playerExpanded" />
+  </Transition>
 </template>

--- a/src/components/PlayerBar.test.ts
+++ b/src/components/PlayerBar.test.ts
@@ -97,6 +97,23 @@ describe('PlayerBar', () => {
     expect(previous.attributes('disabled')).toBeUndefined();
   });
 
+  it('expands to the full view when the title is tapped', async () => {
+    await player.play(TRACKS);
+    const wrapper = await mounted();
+
+    await wrapper.find('.player-bar__title').trigger('click');
+    expect(player.usePlayer().expanded.value).toBe(true);
+  });
+
+  it('dismisses the bar when the close button is pressed', async () => {
+    await player.play(TRACKS);
+    const wrapper = await mounted();
+
+    await wrapper.find('.player-bar__close').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.player-bar').exists()).toBe(false);
+  });
+
   it('surfaces an error in the live region', async () => {
     vi.useFakeTimers();
     await player.play(TRACKS);

--- a/src/components/PlayerBar.vue
+++ b/src/components/PlayerBar.vue
@@ -2,22 +2,13 @@
 import { computed } from 'vue';
 
 import { usePlayer } from '@/composables/usePlayer';
+import { formatTime } from '@/utils/formatTime';
 
-const { status, currentTrack, currentTime, duration, error, hasNext, hasPrevious, toggle, next, previous, seek } =
+const { status, currentTrack, currentTime, duration, error, hasNext, hasPrevious, toggle, next, previous, seek, expand, stop } =
   usePlayer();
 
 const isPlaying = computed(() => status.value === 'playing');
 const isBusy = computed(() => status.value === 'loading' || status.value === 'buffering');
-
-const formatTime = (seconds: number): string => {
-  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
-
-  const whole = Math.floor(seconds);
-  const minutes = Math.floor(whole / 60);
-  const remainder = whole % 60;
-
-  return `${minutes}:${remainder.toString().padStart(2, '0')}`;
-};
 
 const statusMessage = computed(() => {
   if (error.value) return error.value;
@@ -40,9 +31,14 @@ const onSeek = (event: Event): void => {
     role="region"
     aria-label="Audio player"
   >
-    <p class="player-bar__title">
+    <button
+      type="button"
+      class="player-bar__title"
+      aria-label="Expand player"
+      @click="expand"
+    >
       {{ currentTrack.title }}
-    </p>
+    </button>
 
     <div class="player-bar__controls">
       <button
@@ -116,6 +112,21 @@ const onSeek = (event: Event): void => {
       >
       <span class="player-bar__time">{{ formatTime(duration) }}</span>
     </div>
+
+    <button
+      type="button"
+      class="player-bar__close"
+      aria-label="Close player"
+      @click="stop"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        d="M6 6l12 12M18 6 6 18"
+      /></svg>
+    </button>
 
     <p
       class="player-bar__status"

--- a/src/components/PlayerScreen.test.ts
+++ b/src/components/PlayerScreen.test.ts
@@ -1,0 +1,101 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TRACKS = [
+  { key: 'x/1.m4a', title: 'One', duration: 100, artist: 'Alpha' },
+  { key: 'x/2.m4a', title: 'Two', duration: 200 },
+];
+
+type PlayerModule = typeof import('@/composables/usePlayer');
+
+describe('PlayerScreen', () => {
+  let player: PlayerModule;
+  let component: typeof import('./PlayerScreen.vue').default;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+    HTMLMediaElement.prototype.load = vi.fn();
+    player = await import('@/composables/usePlayer');
+    component = (await import('./PlayerScreen.vue')).default;
+  });
+
+  const mounted = async (): Promise<VueWrapper> => {
+    const wrapper = mount(component, { attachTo: document.body });
+    await flushPromises();
+    return wrapper;
+  };
+
+  it('shows the current track, artist, album, and queue', async () => {
+    await player.play(TRACKS, 0, { album: 'The Album', artwork: '/cover.jpg' });
+    const wrapper = await mounted();
+
+    expect(wrapper.find('.player-screen__title').text()).toBe('One');
+    expect(wrapper.find('.player-screen__artist').text()).toBe('Alpha');
+    expect(wrapper.find('.player-screen__album').text()).toBe('The Album');
+    expect(wrapper.find('.player-screen__art img').attributes('src')).toBe('/cover.jpg');
+    expect(wrapper.findAll('.player-screen__queue-item')).toHaveLength(2);
+    expect(wrapper.find('.player-screen__queue-item.is-current').text()).toContain('One');
+  });
+
+  it('falls back to Jerome Faria when a track has no artist', async () => {
+    await player.play(TRACKS, 1);
+    const wrapper = await mounted();
+
+    expect(wrapper.find('.player-screen__artist').text()).toBe('Jerome Faria');
+  });
+
+  it('jumps to a track when its queue row is clicked', async () => {
+    await player.play(TRACKS, 0);
+    const wrapper = await mounted();
+
+    await wrapper.findAll('.player-screen__queue-item')[1].trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.player-screen__title').text()).toBe('Two');
+  });
+
+  it('drives playback from the large controls and swaps to the pause icon while playing', async () => {
+    await player.play(TRACKS, 0);
+    const wrapper = await mounted();
+    const buttons = wrapper.findAll('.player-screen__button');
+
+    await buttons[2].trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.player-screen__title').text()).toBe('Two');
+
+    await buttons[0].trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.player-screen__title').text()).toBe('One');
+
+    player.getMediaElement().dispatchEvent(new Event('playing'));
+    await flushPromises();
+    expect(buttons[1].attributes('aria-label')).toBe('Pause');
+
+    await buttons[1].trigger('click');
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+  });
+
+  it('hides the queue and disables prev/next for a single-track context', async () => {
+    await player.play([TRACKS[0]], 0);
+    const wrapper = await mounted();
+
+    expect(wrapper.find('.player-screen__queue').exists()).toBe(false);
+    const buttons = wrapper.findAll('.player-screen__button');
+    expect(buttons[0].attributes('disabled')).toBeDefined();
+    expect(buttons[2].attributes('disabled')).toBeDefined();
+  });
+
+  it('collapses via the button and via Escape', async () => {
+    await player.play(TRACKS);
+    player.expand();
+    const wrapper = await mounted();
+
+    await wrapper.find('.player-screen__collapse').trigger('click');
+    expect(player.usePlayer().expanded.value).toBe(false);
+
+    player.expand();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(player.usePlayer().expanded.value).toBe(false);
+  });
+});

--- a/src/components/PlayerScreen.vue
+++ b/src/components/PlayerScreen.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+
+import { usePlayer } from '@/composables/usePlayer';
+import type { AudioTrack } from '@/types/audio';
+import { formatTime } from '@/utils/formatTime';
+
+const { status, currentTrack, queue, currentTime, duration, context, hasNext, hasPrevious, toggle, next, previous, seek, select, collapse } =
+  usePlayer();
+
+const isPlaying = computed(() => status.value === 'playing');
+const currentIndex = computed(() => queue.value.findIndex(track => track.key === currentTrack.value?.key));
+
+const collapseButton = ref<HTMLButtonElement | null>(null);
+
+const onSeek = (event: Event): void => {
+  seek(Number((event.target as HTMLInputElement).value));
+};
+
+const trackLabel = (track: AudioTrack): string => (track.artist ? `${track.artist} — ${track.title}` : track.title);
+
+const onKeydown = (event: KeyboardEvent): void => {
+  if (event.key === 'Escape') collapse();
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeydown);
+  collapseButton.value?.focus();
+});
+
+onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+</script>
+
+<template>
+  <div
+    class="player-screen"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Now playing"
+  >
+    <button
+      ref="collapseButton"
+      type="button"
+      class="player-screen__collapse"
+      aria-label="Collapse player"
+      @click="collapse"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="m7 10 5 5 5-5z" /></svg>
+    </button>
+
+    <div class="player-screen__art">
+      <img
+        v-if="context.artwork"
+        :src="context.artwork"
+        alt=""
+      >
+    </div>
+
+    <div class="player-screen__meta">
+      <p class="player-screen__title">
+        {{ currentTrack?.title }}
+      </p>
+      <p class="player-screen__artist">
+        {{ currentTrack?.artist ?? 'Jerome Faria' }}
+      </p>
+      <p
+        v-if="context.album"
+        class="player-screen__album"
+      >
+        {{ context.album }}
+      </p>
+    </div>
+
+    <div class="player-screen__seek">
+      <span class="player-screen__time">{{ formatTime(currentTime) }}</span>
+      <input
+        class="player-screen__slider"
+        type="range"
+        min="0"
+        :max="duration || 0"
+        step="1"
+        :value="currentTime"
+        aria-label="Seek"
+        @input="onSeek"
+      >
+      <span class="player-screen__time">{{ formatTime(duration) }}</span>
+    </div>
+
+    <div class="player-screen__controls">
+      <button
+        type="button"
+        class="player-screen__button"
+        :disabled="!hasPrevious && currentTime < 3"
+        aria-label="Previous track"
+        @click="previous"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6 6h2v12H6zm3.5 6 8.5 6V6z" /></svg>
+      </button>
+
+      <button
+        type="button"
+        class="player-screen__button player-screen__button--primary"
+        :aria-label="isPlaying ? 'Pause' : 'Play'"
+        @click="toggle"
+      >
+        <svg
+          v-if="isPlaying"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          focusable="false"
+        ><path fill="currentColor" d="M6 5h4v14H6zm8 0h4v14h-4z" /></svg>
+        <svg
+          v-else
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          focusable="false"
+        ><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
+      </button>
+
+      <button
+        type="button"
+        class="player-screen__button"
+        :disabled="!hasNext"
+        aria-label="Next track"
+        @click="next"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M16 6h2v12h-2zM6 18l8.5-6L6 6z" /></svg>
+      </button>
+    </div>
+
+    <ol
+      v-if="queue.length > 1"
+      class="player-screen__queue"
+      aria-label="Queue"
+    >
+      <li
+        v-for="(track, index) in queue"
+        :key="track.key"
+      >
+        <button
+          type="button"
+          class="player-screen__queue-item"
+          :class="{ 'is-current': index === currentIndex }"
+          @click="select(index)"
+        >
+          <span class="player-screen__queue-num">{{ index + 1 }}</span>
+          <span class="player-screen__queue-title">{{ trackLabel(track) }}</span>
+        </button>
+      </li>
+    </ol>
+  </div>
+</template>

--- a/src/composables/usePlayer.test.ts
+++ b/src/composables/usePlayer.test.ts
@@ -205,6 +205,46 @@ describe('usePlayer', () => {
     expect(mod.usePlayer().currentTrack.value?.key).toContain('BRQN006');
   });
 
+  it('expands and collapses the full view', () => {
+    const api = mod.usePlayer();
+    expect(api.expanded.value).toBe(false);
+
+    mod.expand();
+    expect(api.expanded.value).toBe(true);
+
+    mod.collapse();
+    expect(api.expanded.value).toBe(false);
+  });
+
+  it('selects a track within the current queue and ignores out-of-range', async () => {
+    await mod.play(TRACKS);
+    const api = mod.usePlayer();
+
+    await mod.select(1);
+    expect(api.currentTrack.value?.title).toBe('Two');
+
+    await mod.select(99);
+    expect(api.currentTrack.value?.title).toBe('Two');
+  });
+
+  it('stops playback and clears the queue so the bar unmounts', async () => {
+    await mod.play(TRACKS);
+    const api = mod.usePlayer();
+    mod.expand();
+
+    mod.stop();
+
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+    expect(api.currentTrack.value).toBeNull();
+    expect(api.status.value).toBe('idle');
+    expect(api.expanded.value).toBe(false);
+  });
+
+  it('exposes the play context', async () => {
+    await mod.play(TRACKS, 0, { album: 'An Album', artwork: '/cover.jpg' });
+    expect(mod.usePlayer().context.value.album).toBe('An Album');
+  });
+
   it('wires the Media Session when the API is available', async () => {
     const handlers: Record<string, (event?: { seekTime?: number }) => void> = {};
     Object.assign(navigator, {

--- a/src/composables/usePlayer.ts
+++ b/src/composables/usePlayer.ts
@@ -26,24 +26,25 @@ let generation = 0;
 let retries = 0;
 let element: HTMLAudioElement | null = null;
 
-interface PlayContext {
+export interface PlayContext {
   album?: string;
   artwork?: string;
 }
 
-let nowPlaying: PlayContext = {};
+const nowPlaying = ref<PlayContext>({});
+const expanded = ref(false);
 
 const setMediaSession = (track: AudioTrack): void => {
   if (!('mediaSession' in navigator) || typeof MediaMetadata === 'undefined') return;
 
-  const artwork = nowPlaying.artwork
-    ? [{ src: new URL(nowPlaying.artwork, location.href).href, sizes: '512x512', type: 'image/jpeg' }]
+  const artwork = nowPlaying.value.artwork
+    ? [{ src: new URL(nowPlaying.value.artwork, location.href).href, sizes: '512x512', type: 'image/jpeg' }]
     : [];
 
   navigator.mediaSession.metadata = new MediaMetadata({
     title: track.title,
     artist: track.artist ?? 'Jerome Faria',
-    album: nowPlaying.album ?? '',
+    album: nowPlaying.value.album ?? '',
     artwork,
   });
   navigator.mediaSession.setActionHandler('play', () => void resume());
@@ -122,10 +123,33 @@ const load = async (): Promise<void> => {
 export const play = async (tracks: AudioTrack[], startIndex = 0, context: PlayContext = {}): Promise<void> => {
   if (tracks.length === 0) return;
 
-  nowPlaying = context;
+  nowPlaying.value = context;
   queue.value = tracks;
   index.value = Math.min(Math.max(startIndex, 0), tracks.length - 1);
   await load();
+};
+
+export const select = async (targetIndex: number): Promise<void> => {
+  if (targetIndex < 0 || targetIndex >= queue.value.length) return;
+
+  index.value = targetIndex;
+  await load();
+};
+
+export const expand = (): void => { expanded.value = true; };
+export const collapse = (): void => { expanded.value = false; };
+
+// Clearing the queue empties currentTrack, which unmounts the bar.
+export const stop = (): void => {
+  generation += 1;
+  element?.pause();
+  queue.value = [];
+  index.value = -1;
+  currentTime.value = 0;
+  duration.value = 0;
+  error.value = null;
+  status.value = 'idle';
+  expanded.value = false;
 };
 
 export const playRelease = (releaseId: string, context?: PlayContext): Promise<void> =>
@@ -191,6 +215,8 @@ interface PlayerApi {
   error: Readonly<Ref<string | null>>;
   hasNext: ComputedRef<boolean>;
   hasPrevious: ComputedRef<boolean>;
+  context: Readonly<Ref<PlayContext>>;
+  expanded: Readonly<Ref<boolean>>;
   play: typeof play;
   playRelease: typeof playRelease;
   pause: typeof pause;
@@ -199,6 +225,10 @@ interface PlayerApi {
   next: typeof next;
   previous: typeof previous;
   seek: typeof seek;
+  select: typeof select;
+  expand: typeof expand;
+  collapse: typeof collapse;
+  stop: typeof stop;
 }
 
 export const usePlayer = (): PlayerApi => ({
@@ -210,6 +240,8 @@ export const usePlayer = (): PlayerApi => ({
   error: readonly(error),
   hasNext,
   hasPrevious,
+  context: readonly(nowPlaying),
+  expanded: readonly(expanded),
   play,
   playRelease,
   pause,
@@ -218,6 +250,10 @@ export const usePlayer = (): PlayerApi => ({
   next,
   previous,
   seek,
+  select,
+  expand,
+  collapse,
+  stop,
 });
 
 // Exposed for unit tests to drive media events on the singleton element.

--- a/src/styles/_player.scss
+++ b/src/styles/_player.scss
@@ -17,12 +17,44 @@
 
   &__title {
     align-self: stretch;
+    padding: 0 2.25rem;
     margin: 0;
     overflow: hidden;
+    color: inherit;
+    font: inherit;
     font-weight: 500;
     text-align: center;
     white-space: nowrap;
     text-overflow: ellipsis;
+    cursor: pointer;
+    background: none;
+    border: none;
+  }
+
+  &__close {
+    position: absolute;
+    top: $spacing-3;
+    right: $spacing-3;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    background: none;
+    border: none;
+    transition: color $transition-fast;
+
+    svg {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+
+    &:hover {
+      color: var(--color-text);
+    }
   }
 
   &__controls {
@@ -106,12 +138,19 @@
 
     &__title {
       flex: 0 1 24ch;
+      padding: 0;
       text-align: left;
     }
 
     &__seek {
       flex: 1 1 auto;
       width: auto;
+    }
+
+    // Inline at the far right of the row (out of the corner) once space allows.
+    &__close {
+      position: static;
+      flex: 0 0 auto;
     }
   }
 }
@@ -184,5 +223,205 @@
 @media (prefers-reduced-motion: reduce) {
   .player-bar__spinner {
     animation: none;
+  }
+
+  .player-slide-enter-active,
+  .player-slide-leave-active {
+    transition: none;
+  }
+}
+
+.player-slide-enter-active,
+.player-slide-leave-active {
+  transition: transform $transition-base, opacity $transition-base;
+}
+
+.player-slide-enter-from,
+.player-slide-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+
+.player-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 950;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-5;
+  align-items: center;
+  padding: $spacing-6 $spacing-5;
+  overflow-y: auto;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+
+  &__collapse {
+    display: inline-flex;
+    align-self: flex-start;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    color: var(--color-text);
+    cursor: pointer;
+    background: none;
+    border: none;
+
+    svg {
+      width: 1.75rem;
+      height: 1.75rem;
+    }
+  }
+
+  &__art {
+    width: 100%;
+    max-width: 22rem;
+    aspect-ratio: 1 / 1;
+    background-color: var(--color-border-subtle);
+
+    img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  &__meta {
+    width: 100%;
+    max-width: 30rem;
+    text-align: center;
+
+    p {
+      margin: 0;
+    }
+  }
+
+  &__title {
+    font-size: $font-size-lg;
+    font-weight: 500;
+  }
+
+  &__artist {
+    color: var(--color-text-muted);
+  }
+
+  &__album {
+    margin-top: $spacing-1;
+    font-size: $font-size-sm;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: $letter-spacing-wide;
+  }
+
+  &__seek {
+    display: flex;
+    gap: $spacing-3;
+    align-items: center;
+    width: 100%;
+    max-width: 30rem;
+  }
+
+  &__time {
+    flex: 0 0 auto;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__slider {
+    flex: 1 1 auto;
+    width: 100%;
+    cursor: pointer;
+    accent-color: var(--color-text);
+  }
+
+  &__controls {
+    display: flex;
+    gap: $spacing-6;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    padding: 0;
+    color: var(--color-text);
+    cursor: pointer;
+    background: none;
+    border: none;
+    border-radius: 50%;
+    transition: background-color $transition-fast;
+
+    svg {
+      width: 2rem;
+      height: 2rem;
+    }
+
+    &--primary svg {
+      width: 2.75rem;
+      height: 2.75rem;
+    }
+
+    &:hover:not(:disabled) {
+      background-color: var(--color-border);
+    }
+
+    &:disabled {
+      color: var(--color-text-muted);
+      cursor: default;
+      opacity: 0.5;
+    }
+  }
+
+  &__queue {
+    width: 100%;
+    max-width: 30rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  &__queue-item {
+    display: flex;
+    gap: $spacing-3;
+    align-items: baseline;
+    width: 100%;
+    padding: $spacing-2 $spacing-1;
+    color: var(--color-text-muted);
+    text-align: left;
+    cursor: pointer;
+    background: none;
+    border: none;
+    border-bottom: 1px solid var(--color-border-subtle);
+    transition: color $transition-fast;
+
+    &:hover {
+      color: var(--color-text);
+    }
+
+    &.is-current {
+      color: var(--color-text);
+      font-weight: 500;
+    }
+  }
+
+  &__queue-num {
+    flex: 0 0 1.5rem;
+    font-size: $font-size-sm;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__queue-title {
+    flex: 1 1 auto;
+  }
+
+  @include respond-to(md) {
+    padding: $spacing-10 $spacing-5;
   }
 }

--- a/src/utils/formatTime.test.ts
+++ b/src/utils/formatTime.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatTime } from './formatTime';
+
+describe('formatTime', () => {
+  it('formats seconds as m:ss', () => {
+    expect(formatTime(0)).toBe('0:00');
+    expect(formatTime(9)).toBe('0:09');
+    expect(formatTime(90)).toBe('1:30');
+    expect(formatTime(648)).toBe('10:48');
+  });
+
+  it('returns 0:00 for non-finite or negative input', () => {
+    expect(formatTime(Number.NaN)).toBe('0:00');
+    expect(formatTime(Number.POSITIVE_INFINITY)).toBe('0:00');
+    expect(formatTime(-5)).toBe('0:00');
+  });
+});

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,9 @@
+export const formatTime = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+
+  const whole = Math.floor(seconds);
+  const minutes = Math.floor(whole / 60);
+  const remainder = whole % 60;
+
+  return `${minutes}:${remainder.toString().padStart(2, '0')}`;
+};


### PR DESCRIPTION
## Description
Tap the docked player bar's title to expand into a full-screen now-playing view, and add a way to dismiss the bar so it no longer sits over the footer after a track has played.

## Changes
- **Expand to full view (#5):** tapping the bar title opens `PlayerScreen` — large artwork, seek, big transport controls, and a tappable queue that jumps to any track (`select`). Escape or the collapse chevron returns to the bar. Mounted lazily behind the `audioPlayer` flag with a slide/fade transition.
- **Dismiss control:** a close (×) button on the docked bar calls a new `stop()` that pauses playback and clears the queue, unmounting the bar. Tucks into the top-right corner on mobile, flows inline on wider screens.
- **Refactor:** extracted the shared `formatTime` m:ss helper (with its non-finite/negative guard) into `src/utils/`, used by both bar and screen.
- Bar title and controls now centre on narrow viewports.

## Testing
1. `gh pr checkout <N> && npm ci && npm run dev`
2. Open the site with `?audioPlayer=1` to enable the player, go to **Works**, expand a release, and press a play button.
3. **Expand:** tap the track title in the bottom bar → full-screen view opens with artwork, controls, and the queue. Tap a queue row → it jumps to that track. Press Escape or the down-chevron → returns to the bar.
4. **Dismiss:** press the × on the bar → playback stops and the bar disappears (footer no longer covered).
5. **Mobile:** narrow the viewport → title and controls centre; the × sits in the top-right corner and does not overlap the title.

## Acceptance Criteria
- [x] Bar title tap expands to a full now-playing view
- [x] Queue rows jump to the selected track; current track highlighted
- [x] Escape and the collapse chevron return to the bar
- [x] Close control stops playback and removes the bar
- [x] Coverage holds above thresholds (branches 92%)