### PR TITLE
Refactor: extract useReleasePlayback + unify play intent

### DIFF
--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -2,14 +2,12 @@
 import { computed, ref } from 'vue';
 
 import { useAccordionVisibility } from '@/composables/useAccordionContext';
-import { audioPlayerEnabled } from '@/composables/useFeatureFlags';
-import { play, playFrom, playRelease, toggle, usePlayer } from '@/composables/usePlayer';
-import { getReleaseAudio, hasPlayableAudio } from '@/data/audio';
+import { useReleasePlayback } from '@/composables/useReleasePlayback';
 import type { LightboxItem, Release } from '@/types';
 import { hasBandcampId, hasCoverImage, hasCredits, hasDescription, hasExternalUrl, hasImages, hasTracklist, hasVideos } from '@/types';
 import { externalizeLinks } from '@/utils/externalizeLinks';
 import { toLightboxImage, toLightboxVideo } from '@/utils/lightboxAdapters';
-import { buildReleaseContext, releasePath } from '@/utils/releasePermalink';
+import { releasePath } from '@/utils/releasePermalink';
 import { renderCredits } from '@/utils/renderCredits';
 
 import BandcampPlayer from './BandcampPlayer.vue';
@@ -46,89 +44,22 @@ const videoLightboxItems = computed<LightboxItem[]>(() =>
 const isBandcampLink = computed(() =>
   hasExternalUrl(props.release) && props.release.externalUrl.includes('bandcamp.com'));
 
-const playable = computed(() => audioPlayerEnabled.value && hasPlayableAudio(props.release.id));
-
-const audioTracks = computed(() => getReleaseAudio(props.release.id));
-
-// Per-track play only when the display tracklist lines up 1:1 with the audio
-// (2504's five movements are one continuous file, so it keeps release-level play).
-const perTrackPlayable = computed(() =>
-  playable.value && audioTracks.value.length === (props.release.tracklist?.length ?? 0));
-
-const { currentTrack, currentTime, status } = usePlayer();
-
-// A single audio file whose display tracklist is split into timed movements (2504).
-const chaptered = computed(() =>
-  playable.value
-  && audioTracks.value.length === 1
-  && (props.release.tracklist?.length ?? 0) > 1
-  && (props.release.tracklist ?? []).every(movement => typeof movement.start === 'number'));
-
-// The movement currently under the playhead — the last one whose offset has passed.
-const currentChapterIndex = computed(() => {
-  if (!chaptered.value || !releaseIsCurrent.value) return -1;
-
-  return (props.release.tracklist ?? []).reduce(
-    (current, movement, movementIndex) => ((movement.start ?? 0) <= currentTime.value ? movementIndex : current),
-    -1,
-  );
-});
-
-const isCurrentChapter = (index: number): boolean => chaptered.value && currentChapterIndex.value === index;
-
-const playChapter = (index: number): Promise<void> =>
-  playFrom(audioTracks.value, props.release.tracklist?.[index]?.start ?? 0, releaseContext());
-
-const releaseContext = () => buildReleaseContext(props.release);
-
-// The shareable path for a track: a 1-based index, or a time offset for chaptered single files.
-const trackHref = (index: number): string => {
-  if (perTrackPlayable.value) return releasePath(props.release.id, { track: index + 1 });
-  if (chaptered.value) return releasePath(props.release.id, { t: props.release.tracklist?.[index]?.start ?? 0 });
-  return '';
-};
-
-const activateTrack = (index: number): void => {
-  if (perTrackPlayable.value) {
-    playTrack(index);
-    return;
-  }
-  if (chaptered.value) void playChapter(index);
-};
-
-const isCurrentTrack = (index: number): boolean =>
-  currentTrack.value?.key === audioTracks.value[index]?.key;
-
-const isTrackPlaying = (index: number): boolean =>
-  isCurrentTrack(index) && ['playing', 'loading', 'buffering'].includes(status.value);
-
-// True while any track from this release is the one loaded in the player.
-const releaseIsCurrent = computed(() =>
-  audioTracks.value.some(track => track.key === currentTrack.value?.key));
-
-const releaseActive = computed(() =>
-  releaseIsCurrent.value && ['playing', 'loading', 'buffering'].includes(status.value));
-
-const releaseBusy = computed(() =>
-  releaseIsCurrent.value && ['loading', 'buffering'].includes(status.value));
-
-const playThis = (): Promise<void> => playRelease(props.release.id, releaseContext());
-
-const toggleRelease = (): void => {
-  if (releaseIsCurrent.value) {
-    toggle();
-    return;
-  }
-  void playThis();
-};
-
-const playTrack = (index: number): void => {
-  if (isCurrentTrack(index)) {
-    toggle();
-    return;
-  }
-  void play(audioTracks.value, index, releaseContext());
-};
+const {
+  playable,
+  perTrackPlayable,
+  chaptered,
+  releaseActive,
+  releaseBusy,
+  isCurrentTrack,
+  isTrackPlaying,
+  isCurrentChapter,
+  trackHref,
+  activateTrack,
+  playThis,
+  toggleRelease,
+  playTrack,
+  playChapter,
+} = useReleasePlayback(() => props.release);
 </script>
 
 <template>

--- a/src/composables/usePlayer.ts
+++ b/src/composables/usePlayer.ts
@@ -5,6 +5,14 @@ import type { AudioTrack } from '@/types/audio';
 
 export type PlayerStatus = 'idle' | 'loading' | 'buffering' | 'playing' | 'paused' | 'ended' | 'error';
 
+// "Active" = the user has asked this track to play (already playing or on its way there);
+// "busy" narrows that to the not-yet-audible part, used for buffering affordances.
+const ACTIVE_STATUSES: PlayerStatus[] = ['playing', 'loading', 'buffering'];
+const BUSY_STATUSES: PlayerStatus[] = ['loading', 'buffering'];
+
+export const isActiveStatus = (playerStatus: PlayerStatus): boolean => ACTIVE_STATUSES.includes(playerStatus);
+export const isBusyStatus = (playerStatus: PlayerStatus): boolean => BUSY_STATUSES.includes(playerStatus);
+
 const RETRY_LIMIT = 2;
 const RETRY_BASE_MS = 500;
 const RESTART_THRESHOLD_SEC = 3;
@@ -159,7 +167,7 @@ export const playFrom = async (tracks: AudioTrack[], seconds: number, context: P
 
   if (tracks.length === 1 && currentTrack.value?.key === tracks[0]?.key) {
     seek(seconds);
-    if (status.value !== 'playing' && status.value !== 'loading' && status.value !== 'buffering') await resume();
+    if (!isActiveStatus(status.value)) await resume();
     return;
   }
 
@@ -203,7 +211,7 @@ export const resume = async (): Promise<void> => {
 };
 
 export const toggle = (): void => {
-  if (status.value === 'playing' || status.value === 'buffering' || status.value === 'loading') {
+  if (isActiveStatus(status.value)) {
     pause();
     return;
   }

--- a/src/composables/useReleasePlayback.test.ts
+++ b/src/composables/useReleasePlayback.test.ts
@@ -1,0 +1,72 @@
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Release } from '@/types';
+
+import { audioPlayerEnabled } from './useFeatureFlags';
+import { stop } from './usePlayer';
+import { useReleasePlayback } from './useReleasePlayback';
+
+const music = { kind: 'music', mediums: ['Digital'], editions: [{ label: { text: 'BRØQN' } }], year: 2010 } as const;
+
+// '1714' has three audio tracks in the manifest — its display tracklist lines up 1:1.
+const aligned: Release = {
+  id: '1714',
+  title: '17:14',
+  meta: music,
+  tracklist: [{ title: '8:58' }, { title: '2:58' }, { title: '5:18' }],
+};
+
+// '2504' is one audio file presented as five timed movements.
+const chaptered: Release = {
+  id: '2504',
+  title: '2504',
+  meta: music,
+  tracklist: [
+    { title: 'Prólogo', start: 0 },
+    { title: 'Fado', start: 212 },
+    { title: 'Fátima', start: 572 },
+    { title: 'Futebol', start: 932 },
+    { title: 'Epílogo', start: 1292 },
+  ],
+};
+
+describe('useReleasePlayback', () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+    HTMLMediaElement.prototype.load = vi.fn();
+    audioPlayerEnabled.value = true;
+    stop();
+  });
+
+  it('distinguishes per-track from chaptered releases', () => {
+    expect(useReleasePlayback(() => aligned).perTrackPlayable.value).toBe(true);
+    expect(useReleasePlayback(() => aligned).chaptered.value).toBe(false);
+    expect(useReleasePlayback(() => chaptered).chaptered.value).toBe(true);
+    expect(useReleasePlayback(() => chaptered).perTrackPlayable.value).toBe(false);
+  });
+
+  it('builds track permalinks as a 1-based index or a time offset', () => {
+    expect(useReleasePlayback(() => aligned).trackHref(0)).toBe('/works/1714?track=1');
+    expect(useReleasePlayback(() => chaptered).trackHref(2)).toBe('/works/2504?t=572');
+  });
+
+  it('plays a release and then toggles it when it is already current', async () => {
+    const playback = useReleasePlayback(() => aligned);
+
+    playback.playThis();
+    await flushPromises();
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    expect(playback.releaseActive.value).toBe(true);
+
+    playback.toggleRelease();
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+  });
+
+  it('reports nothing playable when the audio player is disabled', () => {
+    audioPlayerEnabled.value = false;
+    expect(useReleasePlayback(() => aligned).playable.value).toBe(false);
+    expect(useReleasePlayback(() => aligned).trackHref(0)).toBe('');
+  });
+});

--- a/src/composables/useReleasePlayback.ts
+++ b/src/composables/useReleasePlayback.ts
@@ -1,0 +1,101 @@
+import { computed } from 'vue';
+
+import { isActiveStatus, isBusyStatus, toggle, usePlayer } from '@/composables/usePlayer';
+import { getReleaseAudio } from '@/data/audio';
+import type { Release } from '@/types';
+import { canPlayRelease, playReleaseAt, releasePath } from '@/utils/releasePermalink';
+
+// All of a release item's playback behaviour — release-level, per-track, and chaptered single-file.
+export const useReleasePlayback = (releaseGetter: () => Release) => {
+  const release = computed(releaseGetter);
+  const { currentTrack, currentTime, status } = usePlayer();
+
+  const playable = computed(() => canPlayRelease(release.value.id));
+  const audioTracks = computed(() => getReleaseAudio(release.value.id));
+
+  const perTrackPlayable = computed(() =>
+    playable.value && audioTracks.value.length === (release.value.tracklist?.length ?? 0));
+
+  // A single audio file whose display tracklist is split into timed movements (2504).
+  const chaptered = computed(() =>
+    playable.value
+    && audioTracks.value.length === 1
+    && (release.value.tracklist?.length ?? 0) > 1
+    && (release.value.tracklist ?? []).every(movement => typeof movement.start === 'number'));
+
+  const releaseIsCurrent = computed(() =>
+    audioTracks.value.some(track => track.key === currentTrack.value?.key));
+
+  const releaseActive = computed(() => releaseIsCurrent.value && isActiveStatus(status.value));
+  const releaseBusy = computed(() => releaseIsCurrent.value && isBusyStatus(status.value));
+
+  // The movement currently under the playhead — the last one whose offset has passed.
+  const currentChapterIndex = computed(() => {
+    if (!chaptered.value || !releaseIsCurrent.value) return -1;
+
+    return (release.value.tracklist ?? []).reduce(
+      (current, movement, movementIndex) => ((movement.start ?? 0) <= currentTime.value ? movementIndex : current),
+      -1,
+    );
+  });
+
+  const isCurrentTrack = (index: number): boolean =>
+    currentTrack.value?.key === audioTracks.value[index]?.key;
+
+  const isTrackPlaying = (index: number): boolean => isCurrentTrack(index) && isActiveStatus(status.value);
+
+  const isCurrentChapter = (index: number): boolean => chaptered.value && currentChapterIndex.value === index;
+
+  // The shareable path for a track: a 1-based index, or a time offset for chaptered single files.
+  const trackHref = (index: number): string => {
+    if (perTrackPlayable.value) return releasePath(release.value.id, { track: index + 1 });
+    if (chaptered.value) return releasePath(release.value.id, { t: release.value.tracklist?.[index]?.start ?? 0 });
+    return '';
+  };
+
+  const playThis = (): void => playReleaseAt(release.value);
+
+  const toggleRelease = (): void => {
+    if (releaseIsCurrent.value) {
+      toggle();
+      return;
+    }
+    playThis();
+  };
+
+  const playTrack = (index: number): void => {
+    if (isCurrentTrack(index)) {
+      toggle();
+      return;
+    }
+    playReleaseAt(release.value, { track: index + 1 });
+  };
+
+  const playChapter = (index: number): void =>
+    playReleaseAt(release.value, { t: release.value.tracklist?.[index]?.start ?? 0 });
+
+  const activateTrack = (index: number): void => {
+    if (perTrackPlayable.value) {
+      playTrack(index);
+      return;
+    }
+    if (chaptered.value) playChapter(index);
+  };
+
+  return {
+    playable,
+    perTrackPlayable,
+    chaptered,
+    releaseActive,
+    releaseBusy,
+    isCurrentTrack,
+    isTrackPlaying,
+    isCurrentChapter,
+    trackHref,
+    activateTrack,
+    playThis,
+    toggleRelease,
+    playTrack,
+    playChapter,
+  };
+};

--- a/src/utils/releasePermalink.ts
+++ b/src/utils/releasePermalink.ts
@@ -1,4 +1,6 @@
-import type { PlayContext } from '@/composables/usePlayer';
+import { audioPlayerEnabled } from '@/composables/useFeatureFlags';
+import { play, type PlayContext, playFrom } from '@/composables/usePlayer';
+import { getReleaseAudio, hasPlayableAudio } from '@/data/audio';
 import { worksData } from '@/data/works';
 import type { Release } from '@/types';
 import { hasCoverImage } from '@/types';
@@ -22,6 +24,28 @@ export const buildReleaseContext = (release: Release): PlayContext => ({
   album: release.title,
   ...(hasCoverImage(release) ? { artwork: release.coverImage } : {}),
 });
+
+export const canPlayRelease = (releaseId: string): boolean =>
+  audioPlayerEnabled.value && hasPlayableAudio(releaseId);
+
+// The one place that turns a release + optional {track (1-based), t (seconds)} into a play call,
+// shared by the works view (URL params) and the release item (movement / track clicks).
+export const playReleaseAt = (release: Release, { track, t }: ReleasePermalinkOptions = {}): void => {
+  const tracks = getReleaseAudio(release.id);
+  if (tracks.length === 0) return;
+
+  const context = buildReleaseContext(release);
+
+  if (typeof t === 'number' && Number.isFinite(t) && t > 0) {
+    void playFrom(tracks, t, context);
+    return;
+  }
+  if (typeof track === 'number' && Number.isFinite(track) && track >= 1 && track <= tracks.length) {
+    void play(tracks, track - 1, context);
+    return;
+  }
+  void play(tracks, 0, context);
+};
 
 interface ReleaseHead {
   title: string;

--- a/src/views/WorksView.vue
+++ b/src/views/WorksView.vue
@@ -4,13 +4,10 @@ import { useRoute } from 'vue-router';
 
 import AccordionPage from '@/components/AccordionPage.vue';
 import ReleaseItem from '@/components/ReleaseItem.vue';
-import { audioPlayerEnabled } from '@/composables/useFeatureFlags';
-import { play, playFrom } from '@/composables/usePlayer';
-import { getReleaseAudio, hasPlayableAudio } from '@/data/audio';
 import { pageMeta } from '@/data/pageMeta';
 import { worksData, worksSections } from '@/data/works';
 import { createWorksPageSchema } from '@/utils/pageSchemas';
-import { buildReleaseContext, findRelease, releaseHead } from '@/utils/releasePermalink';
+import { canPlayRelease, findRelease, playReleaseAt, releaseHead } from '@/utils/releasePermalink';
 
 const route = useRoute();
 
@@ -26,22 +23,9 @@ const head = computed(() => {
 // Best-effort playback from a shared link; a blocked autoplay leaves the player cued and paused.
 const playFromRoute = (): void => {
   const release = focusRelease.value;
-  if (!release || !audioPlayerEnabled.value || !hasPlayableAudio(release.id)) return;
+  if (!release || !canPlayRelease(release.id)) return;
 
-  const tracks = getReleaseAudio(release.id);
-  const context = buildReleaseContext(release);
-  const offset = Number(route.query['t']);
-  const track = Number(route.query['track']);
-
-  if (Number.isFinite(offset) && offset > 0) {
-    void playFrom(tracks, offset, context);
-    return;
-  }
-  if (Number.isFinite(track) && track >= 1 && track <= tracks.length) {
-    void play(tracks, track - 1, context);
-    return;
-  }
-  void play(tracks, 0, context);
+  playReleaseAt(release, { track: Number(route.query['track']), t: Number(route.query['t']) });
 };
 
 onMounted(playFromRoute);


### PR DESCRIPTION
## Description
Behaviour-preserving cleanup from the post-audio refactoring assessment. No user-facing change (no visual-baseline change).

## Changes
- **`useReleasePlayback` composable** — the ~18-member playback cluster (release-level, per-track, and chaptered single-file) moves out of `ReleaseItem.vue` into `src/composables/useReleasePlayback.ts`, with its own unit test. `ReleaseItem` keeps cover selection, lightbox, and template wiring.
- **`playReleaseAt(release, {track?, t?})` + `canPlayRelease(id)`** — one helper for "a release + optional track (1-based) / time offset → play", shared by `WorksView` (URL params) and the release item (track/movement clicks), replacing two encodings of the same model.
- **`isActiveStatus` / `isBusyStatus`** — named predicates replace the `['playing','loading','buffering']` membership checks duplicated across `usePlayer` and `ReleaseItem`.
- Comment sweep on the touched files (dropped two comments that restated code; kept the genuine gotchas).

## Testing
- Pure refactor: the full existing suite (602 tests) stays green, plus a new `useReleasePlayback` test. Coverage holds (lines 99.25%, branches 92.4%).
- No behaviour change: covers, cover-play, per-track play, 2504 movement seek, and `/works/:id` play-on-open all work exactly as before.

## Acceptance Criteria
- [x] ReleaseItem playback logic extracted to a testable composable
- [x] Single `playReleaseAt` + `canPlayRelease` used by both call sites
- [x] Status predicates deduped
- [x] All tests green; coverage holds; no visual-baseline change