### PR TITLE
Extend the command palette: audio transport + SoundCloud openers

### DIFF
--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -64,6 +64,22 @@ test.describe('Command palette (⌘K)', () => {
     await expect(html).not.toHaveAttribute('data-theme', 'dark');
   });
 
+  test('plays a release from search, then exposes transport controls', async ({ page }) => {
+    await gotoHydrated(page, '/');
+
+    await page.keyboard.press('Control+k');
+    await page.locator(INPUT).fill('play 2504');
+    await expect(page.locator(OPTION).first()).toContainText("Play '2504'");
+
+    await page.keyboard.press('Enter');
+    await expect(page.locator(PALETTE)).toHaveCount(0);
+    await expect(page.locator('.player-bar')).toBeVisible();
+
+    await page.keyboard.press('Control+k');
+    await expect(page.locator('.command-palette__group').first()).toContainText('Now Playing');
+    await expect(page.locator(OPTION).first()).toContainText(/^(Pause|Play)/);
+  });
+
   test('matches its snapshot @visual', async ({ page }) => {
     await gotoHydrated(page, '/');
 

--- a/src/composables/useCommandPalette.test.ts
+++ b/src/composables/useCommandPalette.test.ts
@@ -4,7 +4,9 @@ import { defineComponent } from 'vue';
 import { createMemoryHistory, createRouter, type Router } from 'vue-router';
 
 import { useCommandPalette } from './useCommandPalette';
+import { audioPlayerEnabled } from './useFeatureFlags';
 import { paletteOpen } from './useOverlays';
+import { play, stop } from './usePlayer';
 
 type Api = ReturnType<typeof useCommandPalette>;
 
@@ -288,5 +290,49 @@ describe('useCommandPalette', () => {
     api.query.value = '';
 
     expect(api.results.value.filter(command => command.title === 'Privacy')).toHaveLength(1);
+  });
+
+  describe('audio commands', () => {
+    beforeEach(() => {
+      HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+      HTMLMediaElement.prototype.pause = vi.fn();
+      HTMLMediaElement.prototype.load = vi.fn();
+      audioPlayerEnabled.value = true;
+      stop();
+    });
+
+    afterEach(() => stop());
+
+    it('surfaces transport at the top of the default view while a track plays', async () => {
+      const { api, wrapper } = await mountPalette();
+      active = wrapper;
+      paletteOpen.value = true;
+
+      expect(api.results.value.some(command => command.group === 'Now Playing')).toBe(false);
+
+      await play([{ key: 'a', title: 'A movement', duration: 100 }]);
+      expect(api.results.value[0]?.group).toBe('Now Playing');
+      expect(api.results.value[0]?.id).toBe('play:toggle');
+    });
+
+    it('finds a Play action for a streamable release by name', async () => {
+      const { api, wrapper } = await mountPalette();
+      active = wrapper;
+
+      api.query.value = 'play 2504';
+      expect(api.results.value.some(command => command.id === 'play:release:2504')).toBe(true);
+    });
+
+    it('does not record transient audio actions in recents', async () => {
+      const { api, wrapper } = await mountPalette();
+      active = wrapper;
+
+      await play([{ key: 'a', title: 'A movement', duration: 100 }]);
+      const stopIndex = api.results.value.findIndex(command => command.id === 'play:stop');
+      expect(stopIndex).toBeGreaterThanOrEqual(0);
+
+      await api.execute(stopIndex);
+      expect(localStorage.getItem('command-palette:recents') ?? '[]').not.toContain('play:');
+    });
   });
 });

--- a/src/composables/useCommandPalette.ts
+++ b/src/composables/useCommandPalette.ts
@@ -2,7 +2,7 @@ import type { ComputedRef, Ref } from 'vue';
 import { computed, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { buildCommands } from '@/data/commands';
+import { buildCommands, playbackCommands, playReleaseCommands } from '@/data/commands';
 import type { Command } from '@/types/command';
 import { fuzzyRank } from '@/utils/fuzzy';
 import { openInNewTab } from '@/utils/openInNewTab';
@@ -49,6 +49,11 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
   const commands = buildCommands();
   const byId = new Map(commands.map(command => [command.id, command]));
 
+  // Reactive slices layered over the static registry: transport reflects live
+  // player state; the searchable set adds every streamable release.
+  const transportCommands = computed<Command[]>(() => playbackCommands());
+  const audioCommands = computed<Command[]>(() => [...transportCommands.value, ...playReleaseCommands()]);
+
   const query = ref('');
   const activeIndex = ref(0);
   const recentIds = ref<string[]>(loadRecents());
@@ -83,11 +88,13 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
         .map(id => byId.get(id))
         .filter((command): command is Command => command !== undefined);
       const clear = recents.length ? [clearRecentsCommand] : [];
-      return [...recents, ...clear, ...navigation];
+      // Transport sits at the top while a track plays — the palette doubles as a remote.
+      return [...transportCommands.value, ...recents, ...clear, ...navigation];
     }
 
     // Cap the list: subsequence matching is permissive, so keep the best-ranked few.
-    const searchable = recentCommands.value.length ? [...commands, clearRecentsCommand] : commands;
+    const recentsTail = recentCommands.value.length ? [clearRecentsCommand] : [];
+    const searchable = [...commands, ...audioCommands.value, ...recentsTail];
     return fuzzyRank(query.value, searchable).slice(0, MAX_RESULTS);
   });
 
@@ -124,7 +131,8 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
     const command = results.value[index];
     if (!command) return;
 
-    remember(command.id);
+    // Ephemeral actions (transport, play-a-release) must not take a recents slot.
+    if (!(command.kind === 'action' && command.transient)) remember(command.id);
     close();
 
     if (command.kind === 'action') {

--- a/src/composables/useCommandPalette.ts
+++ b/src/composables/useCommandPalette.ts
@@ -49,8 +49,7 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
   const commands = buildCommands();
   const byId = new Map(commands.map(command => [command.id, command]));
 
-  // Reactive slices layered over the static registry: transport reflects live
-  // player state; the searchable set adds every streamable release.
+  // Reactive slices over the static registry: transport, plus every streamable release.
   const transportCommands = computed<Command[]>(() => playbackCommands());
   const audioCommands = computed<Command[]>(() => [...transportCommands.value, ...playReleaseCommands()]);
 
@@ -88,7 +87,6 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
         .map(id => byId.get(id))
         .filter((command): command is Command => command !== undefined);
       const clear = recents.length ? [clearRecentsCommand] : [];
-      // Transport sits at the top while a track plays — the palette doubles as a remote.
       return [...transportCommands.value, ...recents, ...clear, ...navigation];
     }
 
@@ -131,7 +129,6 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
     const command = results.value[index];
     if (!command) return;
 
-    // Ephemeral actions (transport, play-a-release) must not take a recents slot.
     if (!(command.kind === 'action' && command.transient)) remember(command.id);
     close();
 

--- a/src/data/commands.test.ts
+++ b/src/data/commands.test.ts
@@ -80,6 +80,14 @@ describe('buildCommands', () => {
     expect(bandcamp.every(command => command.title.includes('Bandcamp'))).toBe(true);
   });
 
+  it('adds a SoundCloud action for each release that has a SoundCloud URL', () => {
+    const soundcloud = commands.filter(command => command.id.startsWith('act:soundcloud:'));
+
+    expect(soundcloud.length).toBeGreaterThan(0);
+    expect(soundcloud.every(command => command.kind === 'action' && command.external)).toBe(true);
+    expect(soundcloud.every(command => command.title.includes('SoundCloud'))).toBe(true);
+  });
+
   it('gives every command a unique id', () => {
     const ids = commands.map(command => command.id);
     expect(new Set(ids).size).toBe(ids.length);

--- a/src/data/commands.test.ts
+++ b/src/data/commands.test.ts
@@ -1,6 +1,12 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildCommands } from './commands';
+import { audioPlayerEnabled } from '@/composables/useFeatureFlags';
+import { getMediaElement, next, play, stop, usePlayer } from '@/composables/usePlayer';
+import type { AudioTrack } from '@/types/audio';
+
+import { buildCommands, playbackCommands, playReleaseCommands } from './commands';
+
+const idsOf = (commands: ReturnType<typeof playbackCommands>): string[] => commands.map(command => command.id);
 
 describe('buildCommands', () => {
   const commands = buildCommands();
@@ -77,5 +83,99 @@ describe('buildCommands', () => {
   it('gives every command a unique id', () => {
     const ids = commands.map(command => command.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+const twoTracks: AudioTrack[] = [
+  { key: 'a', title: 'First movement', duration: 120 },
+  { key: 'b', title: 'Second movement', duration: 90 },
+];
+
+describe('playbackCommands', () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+    HTMLMediaElement.prototype.load = vi.fn();
+    stop();
+  });
+
+  afterEach(() => stop());
+
+  it('is empty until a track is loaded', () => {
+    expect(playbackCommands()).toEqual([]);
+  });
+
+  it('exposes transport that tracks the queue position and player state', async () => {
+    await play(twoTracks);
+
+    const atStart = playbackCommands();
+    expect(idsOf(atStart)).toEqual(['play:toggle', 'play:next', 'play:expand', 'play:stop']);
+    expect(atStart[0]?.subtitle).toBe('First movement');
+    expect(atStart.every(command => command.kind === 'action' && command.transient)).toBe(true);
+
+    getMediaElement().dispatchEvent(new Event('playing'));
+    const toggle = playbackCommands()[0];
+    if (toggle?.kind === 'action') await toggle.run();
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+
+    await next();
+    const atEnd = idsOf(playbackCommands());
+    expect(atEnd).toContain('play:previous');
+    expect(atEnd).not.toContain('play:next');
+  });
+
+  it('labels the toggle and expand controls from live state', async () => {
+    const { expanded } = usePlayer();
+    await play(twoTracks);
+    const media = getMediaElement();
+
+    const toggleTitle = (): string | undefined =>
+      playbackCommands().find(command => command.id === 'play:toggle')?.title;
+
+    media.dispatchEvent(new Event('playing'));
+    expect(toggleTitle()).toBe('Pause');
+
+    media.dispatchEvent(new Event('pause'));
+    expect(toggleTitle()).toBe('Play');
+
+    const expand = playbackCommands().find(command => command.id === 'play:expand');
+    if (expand?.kind === 'action') await expand.run();
+    expect(expanded.value).toBe(true);
+    expect(playbackCommands().find(command => command.id === 'play:expand')?.title).toBe('Collapse player');
+  });
+});
+
+describe('playReleaseCommands', () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+    HTMLMediaElement.prototype.load = vi.fn();
+    audioPlayerEnabled.value = true;
+    stop();
+  });
+
+  afterEach(() => {
+    stop();
+    audioPlayerEnabled.value = true;
+  });
+
+  it('offers a Play action for every streamable release, gated on the flag', () => {
+    const commands = playReleaseCommands();
+
+    expect(commands.length).toBeGreaterThan(0);
+    expect(commands.every(command => command.id.startsWith('play:release:'))).toBe(true);
+    expect(commands.every(command => command.title.startsWith("Play '"))).toBe(true);
+    expect(commands.every(command => command.kind === 'action' && command.transient)).toBe(true);
+
+    audioPlayerEnabled.value = false;
+    expect(playReleaseCommands()).toEqual([]);
+  });
+
+  it('starts the chosen release when run', async () => {
+    const { currentTrack } = usePlayer();
+    const command = playReleaseCommands().find(entry => entry.id === 'play:release:2504');
+
+    if (command?.kind === 'action') await command.run();
+    expect(currentTrack.value).not.toBeNull();
   });
 });

--- a/src/data/commands.ts
+++ b/src/data/commands.ts
@@ -5,7 +5,7 @@ import { matchSystemTheme, toggleTheme } from '@/composables/useTheme';
 import { liveEvents } from '@/data/live';
 import { siteConfig, social } from '@/data/navigation';
 import { worksData } from '@/data/works';
-import type { Command } from '@/types/command';
+import type { ActionCommand, Command } from '@/types/command';
 import type { LiveEvent } from '@/types/live';
 import type { Release, ReleaseMeta } from '@/types/works';
 import { epkPdfHref, epkRiderHref, epkZipHref } from '@/utils/epk';
@@ -116,25 +116,24 @@ const pressCommands = (): Command[] =>
     to: `/press#${quote.id}`,
   }));
 
-// One "Open '<release>' on <platform>" action per release that carries the given
-// link. Shared by the Bandcamp and SoundCloud openers so a new platform is a line.
-const releaseLinkCommands = (platform: string, keyword: string, urlOf: (release: Release) => string | undefined): Command[] =>
-  Object.values(worksData)
-    .flatMap(section => section.items)
-    .flatMap(release => {
-      const url = urlOf(release);
-      if (!url) return [];
+const allReleases = (): Release[] => Object.values(worksData).flatMap(section => section.items);
 
-      return [{
-        kind: 'action',
-        id: `act:${keyword}:${release.id}`,
-        title: `Open '${release.title}' on ${platform}`,
-        keywords: [release.title, keyword, 'listen', 'play'],
-        group: 'Actions',
-        external: true,
-        run: () => openInNewTab(url),
-      } satisfies Command];
-    });
+// One "Open '<release>' on <platform>" action per release that carries that link.
+const releaseLinkCommands = (platform: string, keyword: string, urlOf: (release: Release) => string | undefined): Command[] =>
+  allReleases().flatMap(release => {
+    const url = urlOf(release);
+    if (!url) return [];
+
+    return [{
+      kind: 'action',
+      id: `act:${keyword}:${release.id}`,
+      title: `Open '${release.title}' on ${platform}`,
+      keywords: [release.title, keyword, 'listen', 'play'],
+      group: 'Actions',
+      external: true,
+      run: () => openInNewTab(url),
+    } satisfies Command];
+  });
 
 const actionCommands = (): Command[] => {
   const downloads: Command[] = [
@@ -182,53 +181,41 @@ const actionCommands = (): Command[] => {
   return [...downloads, help, ...appearance, contact, ...socials, ...bandcamp, ...soundcloud];
 };
 
-// Live transport controls that reflect the player's current state. Built inside a
-// computed (not part of the static registry) so they surface only while a track is
-// loaded and their labels track play/pause and expand/collapse.
+// Transport for the active track — merged reactively in useCommandPalette, so it is
+// kept out of the static registry and returns nothing when no track is loaded.
 export const playbackCommands = (): Command[] => {
   const { currentTrack, status, hasNext, hasPrevious, expanded, toggle, next, previous, expand, collapse, stop } = usePlayer();
   const track = currentTrack.value;
   if (!track) return [];
 
-  const commands: Command[] = [{
+  const control = (fields: Pick<ActionCommand, 'id' | 'title' | 'keywords' | 'run'> & { subtitle?: string }): Command => ({
     kind: 'action',
-    id: 'play:toggle',
-    title: isActiveStatus(status.value) ? 'Pause' : 'Play',
-    subtitle: track.title,
-    keywords: ['pause', 'play', 'resume', 'music', 'audio', 'playback'],
     group: 'Now Playing',
     transient: true,
-    run: () => toggle(),
-  }];
+    ...fields,
+  });
+
+  const commands: Command[] = [
+    control({ id: 'play:toggle', title: isActiveStatus(status.value) ? 'Pause' : 'Play', subtitle: track.title, keywords: ['pause', 'play', 'resume', 'music', 'audio', 'playback'], run: () => toggle() }),
+  ];
 
   if (hasNext.value) {
-    commands.push({ kind: 'action', id: 'play:next', title: 'Next track', keywords: ['next', 'skip', 'forward'], group: 'Now Playing', transient: true, run: () => void next() });
+    commands.push(control({ id: 'play:next', title: 'Next track', keywords: ['next', 'skip', 'forward'], run: () => void next() }));
   }
   if (hasPrevious.value) {
-    commands.push({ kind: 'action', id: 'play:previous', title: 'Previous track', keywords: ['previous', 'back', 'prev'], group: 'Now Playing', transient: true, run: () => void previous() });
+    commands.push(control({ id: 'play:previous', title: 'Previous track', keywords: ['previous', 'back', 'prev'], run: () => void previous() }));
   }
 
-  commands.push({
-    kind: 'action',
-    id: 'play:expand',
-    title: expanded.value ? 'Collapse player' : 'Expand player',
-    keywords: ['expand', 'collapse', 'now playing', 'minimise', 'minimize'],
-    group: 'Now Playing',
-    transient: true,
-    run: () => (expanded.value ? collapse() : expand()),
-  });
-  commands.push({ kind: 'action', id: 'play:stop', title: 'Stop playback', keywords: ['stop', 'close', 'dismiss', 'end'], group: 'Now Playing', transient: true, run: () => stop() });
+  commands.push(control({ id: 'play:expand', title: expanded.value ? 'Collapse player' : 'Expand player', keywords: ['expand', 'collapse', 'now playing', 'minimise', 'minimize'], run: () => (expanded.value ? collapse() : expand()) }));
+  commands.push(control({ id: 'play:stop', title: 'Stop playback', keywords: ['stop', 'close', 'dismiss', 'end'], run: () => stop() }));
 
   return commands;
 };
 
-// The native-audio counterpart to the Bandcamp openers: start any streamable
-// release from search. Gated on the flag so they vanish when the player is off.
 export const playReleaseCommands = (): Command[] => {
   if (!audioPlayerEnabled.value) return [];
 
-  return Object.values(worksData)
-    .flatMap(section => section.items)
+  return allReleases()
     .filter(release => canPlayRelease(release.id))
     .map((release): Command => ({
       kind: 'action',

--- a/src/data/commands.ts
+++ b/src/data/commands.ts
@@ -1,4 +1,6 @@
+import { audioPlayerEnabled } from '@/composables/useFeatureFlags';
 import { openKeyboardHelp } from '@/composables/useOverlays';
+import { isActiveStatus, usePlayer } from '@/composables/usePlayer';
 import { matchSystemTheme, toggleTheme } from '@/composables/useTheme';
 import { liveEvents } from '@/data/live';
 import { siteConfig, social } from '@/data/navigation';
@@ -8,6 +10,7 @@ import type { LiveEvent } from '@/types/live';
 import type { ReleaseMeta } from '@/types/works';
 import { epkPdfHref, epkRiderHref, epkZipHref } from '@/utils/epk';
 import { openInNewTab } from '@/utils/openInNewTab';
+import { canPlayRelease, playReleaseAt } from '@/utils/releasePermalink';
 import { plainCredits } from '@/utils/renderCredits';
 import { stripHtml } from '@/utils/stripHtml';
 
@@ -171,6 +174,65 @@ const actionCommands = (): Command[] => {
     });
 
   return [...downloads, help, ...appearance, contact, ...socials, ...bandcamp];
+};
+
+// Live transport controls that reflect the player's current state. Built inside a
+// computed (not part of the static registry) so they surface only while a track is
+// loaded and their labels track play/pause and expand/collapse.
+export const playbackCommands = (): Command[] => {
+  const { currentTrack, status, hasNext, hasPrevious, expanded, toggle, next, previous, expand, collapse, stop } = usePlayer();
+  const track = currentTrack.value;
+  if (!track) return [];
+
+  const commands: Command[] = [{
+    kind: 'action',
+    id: 'play:toggle',
+    title: isActiveStatus(status.value) ? 'Pause' : 'Play',
+    subtitle: track.title,
+    keywords: ['pause', 'play', 'resume', 'music', 'audio', 'playback'],
+    group: 'Now Playing',
+    transient: true,
+    run: () => toggle(),
+  }];
+
+  if (hasNext.value) {
+    commands.push({ kind: 'action', id: 'play:next', title: 'Next track', keywords: ['next', 'skip', 'forward'], group: 'Now Playing', transient: true, run: () => void next() });
+  }
+  if (hasPrevious.value) {
+    commands.push({ kind: 'action', id: 'play:previous', title: 'Previous track', keywords: ['previous', 'back', 'prev'], group: 'Now Playing', transient: true, run: () => void previous() });
+  }
+
+  commands.push({
+    kind: 'action',
+    id: 'play:expand',
+    title: expanded.value ? 'Collapse player' : 'Expand player',
+    keywords: ['expand', 'collapse', 'now playing', 'minimise', 'minimize'],
+    group: 'Now Playing',
+    transient: true,
+    run: () => (expanded.value ? collapse() : expand()),
+  });
+  commands.push({ kind: 'action', id: 'play:stop', title: 'Stop playback', keywords: ['stop', 'close', 'dismiss', 'end'], group: 'Now Playing', transient: true, run: () => stop() });
+
+  return commands;
+};
+
+// The native-audio counterpart to the Bandcamp openers: start any streamable
+// release from search. Gated on the flag so they vanish when the player is off.
+export const playReleaseCommands = (): Command[] => {
+  if (!audioPlayerEnabled.value) return [];
+
+  return Object.values(worksData)
+    .flatMap(section => section.items)
+    .filter(release => canPlayRelease(release.id))
+    .map((release): Command => ({
+      kind: 'action',
+      id: `play:release:${release.id}`,
+      title: `Play '${release.title}'`,
+      keywords: [release.title, 'play', 'listen', 'audio', 'music'],
+      group: 'Actions',
+      transient: true,
+      run: () => playReleaseAt(release),
+    }));
 };
 
 export const buildCommands = (): Command[] => [

--- a/src/data/commands.ts
+++ b/src/data/commands.ts
@@ -7,7 +7,7 @@ import { siteConfig, social } from '@/data/navigation';
 import { worksData } from '@/data/works';
 import type { Command } from '@/types/command';
 import type { LiveEvent } from '@/types/live';
-import type { ReleaseMeta } from '@/types/works';
+import type { Release, ReleaseMeta } from '@/types/works';
 import { epkPdfHref, epkRiderHref, epkZipHref } from '@/utils/epk';
 import { openInNewTab } from '@/utils/openInNewTab';
 import { canPlayRelease, playReleaseAt } from '@/utils/releasePermalink';
@@ -116,6 +116,26 @@ const pressCommands = (): Command[] =>
     to: `/press#${quote.id}`,
   }));
 
+// One "Open '<release>' on <platform>" action per release that carries the given
+// link. Shared by the Bandcamp and SoundCloud openers so a new platform is a line.
+const releaseLinkCommands = (platform: string, keyword: string, urlOf: (release: Release) => string | undefined): Command[] =>
+  Object.values(worksData)
+    .flatMap(section => section.items)
+    .flatMap(release => {
+      const url = urlOf(release);
+      if (!url) return [];
+
+      return [{
+        kind: 'action',
+        id: `act:${keyword}:${release.id}`,
+        title: `Open '${release.title}' on ${platform}`,
+        keywords: [release.title, keyword, 'listen', 'play'],
+        group: 'Actions',
+        external: true,
+        run: () => openInNewTab(url),
+      } satisfies Command];
+    });
+
 const actionCommands = (): Command[] => {
   const downloads: Command[] = [
     { kind: 'action', id: 'act:press-kit-pdf', title: 'Download press kit (PDF)', keywords: ['epk', 'pdf', 'press'], group: 'Actions', external: true, run: () => openInNewTab(epkPdfHref) },
@@ -156,24 +176,10 @@ const actionCommands = (): Command[] => {
     run: () => openInNewTab(link.url),
   }));
 
-  const bandcamp: Command[] = Object.values(worksData)
-    .flatMap(section => section.items)
-    .flatMap(release => {
-      const url = release.bandcampUrl;
-      if (!url) return [];
+  const bandcamp = releaseLinkCommands('Bandcamp', 'bandcamp', release => release.bandcampUrl);
+  const soundcloud = releaseLinkCommands('SoundCloud', 'soundcloud', release => release.soundcloudUrl);
 
-      return [{
-        kind: 'action',
-        id: `act:bandcamp:${release.id}`,
-        title: `Open '${release.title}' on Bandcamp`,
-        keywords: [release.title, 'bandcamp', 'listen', 'play'],
-        group: 'Actions',
-        external: true,
-        run: () => openInNewTab(url),
-      } satisfies Command];
-    });
-
-  return [...downloads, help, ...appearance, contact, ...socials, ...bandcamp];
+  return [...downloads, help, ...appearance, contact, ...socials, ...bandcamp, ...soundcloud];
 };
 
 // Live transport controls that reflect the player's current state. Built inside a

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,4 +1,4 @@
-export type CommandGroup = 'Recent' | 'Navigate' | 'Works' | 'Live' | 'Press' | 'Actions';
+export type CommandGroup = 'Recent' | 'Now Playing' | 'Navigate' | 'Works' | 'Live' | 'Press' | 'Actions';
 
 interface CommandBase {
   id: string;
@@ -22,11 +22,14 @@ export interface ResultCommand extends CommandBase {
 }
 
 // Anything the palette *does* rather than navigates to. `external` links open in
-// a new tab; `run` may be async so the execute path can await it.
+// a new tab; `run` may be async so the execute path can await it. `transient`
+// marks an ephemeral action (transport, play-a-release) that must not take a
+// recents slot.
 export interface ActionCommand extends CommandBase {
   kind: 'action';
   run: () => void | Promise<void>;
   external?: boolean;
+  transient?: boolean;
 }
 
 export type Command = NavigateCommand | ResultCommand | ActionCommand;


### PR DESCRIPTION
## Description
Extends the command palette into a keyboard remote for the audio player. While a track plays, transport controls appear at the top of the palette; every streamable release gains a searchable **Play** action. The commands reflect live player state and disappear when nothing is playing.

## Plumbing
The static command registry (`buildCommands()`, built once) is left untouched — rebuilding ~115 fixed commands on every play/pause would be wasteful. Instead a **reactive slice** is merged only where needed (the `results` computed): a `computed` that reads live player state and the `audioPlayerEnabled` flag. The one general addition is an opt-in **`transient?: boolean`** on `ActionCommand`, so ephemeral runs (transport, play-a-release) skip `remember()` and never take a recents slot — a primitive any future ephemeral command reuses.

## Changes
- **types/command.ts** — `transient?` on `ActionCommand`; new `'Now Playing'` command group.
- **data/commands.ts** — `playbackCommands()` (state-aware transport: Play/Pause, Next/Previous when available, Expand/Collapse, Stop) and `playReleaseCommands()` (a Play action per streamable release, flag-gated).
- **SoundCloud openers** — the release data already carried `soundcloudUrl` (7 releases); a shared `releaseLinkCommands` builder now drives both the existing Bandcamp openers and new SoundCloud ones, so a future platform is a single line.
- **composables/useCommandPalette.ts** — reactive audio slice; transport pinned to the top of the curated view while playing; full slice searchable; `execute()` skips recents for transient actions.

## Testing
- `gh pr checkout <N> && npm ci && npm run dev`, then **Ctrl/⌘-K**:
  - Type `play 2504` → run **Play '2504'** → the docked player starts and the palette closes.
  - Re-open the palette → a **Now Playing** group tops the list with **Pause / Next / Expand / Stop**; the toggle label flips with playback.
  - Nothing playing → no audio transport in the default view (unchanged behaviour).
- Unit: `npm run test` (new `playbackCommands` / `playReleaseCommands` + palette integration specs). Coverage floor holds.
- E2E: `e2e/command-palette.spec.ts` gains a play-from-search → transport-controls flow.

## Notes
- No new visual baselines: the palette `@visual` snapshot opens with nothing playing, so transport never appears in it.
