### PR TITLE
Route internal prose links through the SPA (no reload flash)

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -66,6 +66,18 @@ test.describe('Navigation', () => {
     await expect(page.locator('[data-page="about"]')).toBeVisible();
   });
 
+  test('routes internal bio links via the SPA, without a full reload', async ({ page }) => {
+    await gotoHydrated(page, PAGES.ABOUT);
+    // Survives a client-side route but is wiped by a full page reload.
+    await page.evaluate(() => ((window as unknown as { __spa?: boolean }).__spa = true));
+
+    await page.locator('.prose a[href^="/works#"]').first().click();
+
+    await expect(page).toHaveURL(/\/works#/);
+    await expect(page.locator('[data-page="works"]')).toBeAttached();
+    expect(await page.evaluate(() => (window as unknown as { __spa?: boolean }).__spa)).toBe(true);
+  });
+
   test('should navigate to Contact page', async ({ page }) => {
     await page.goto(PAGES.HOME);
     await openMobileMenuIfNeeded(page);

--- a/src/composables/useProseLinks.test.ts
+++ b/src/composables/useProseLinks.test.ts
@@ -1,0 +1,99 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+
+import { useProseLinks } from './useProseLinks';
+
+const mountHandler = async (): Promise<{ handle: (event: MouseEvent) => void; router: Router }> => {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+  });
+  await router.push('/');
+  await router.isReady();
+
+  let handle: ((event: MouseEvent) => void) | null = null;
+  mount(
+    defineComponent({
+      setup() {
+        handle = useProseLinks();
+        return () => null;
+      },
+    }),
+    { global: { plugins: [router] } },
+  );
+
+  if (!handle) throw new Error('useProseLinks did not initialise');
+  return { handle, router };
+};
+
+const anchor = (attributes: Record<string, string>): HTMLAnchorElement => {
+  const element = document.createElement('a');
+  for (const [name, value] of Object.entries(attributes)) element.setAttribute(name, value);
+  return element;
+};
+
+const clickOn = (target: HTMLElement, overrides: Partial<MouseEvent> = {}): MouseEvent => {
+  const event = new MouseEvent('click', { cancelable: true, button: 0 });
+  Object.defineProperty(event, 'target', { value: target });
+  Object.assign(event, overrides);
+  return event;
+};
+
+describe('useProseLinks', () => {
+  let handle: (event: MouseEvent) => void;
+  let router: Router;
+  let push: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    ({ handle, router } = await mountHandler());
+    push = vi.spyOn(router, 'push');
+  });
+
+  it('routes an internal link through the router and prevents the reload', () => {
+    const event = clickOn(anchor({ href: '/contact' }));
+
+    handle(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(push).toHaveBeenCalledWith('/contact');
+  });
+
+  it('preserves the hash on a deep link', () => {
+    const link = anchor({ href: '/works#nny' });
+    const child = document.createElement('em');
+    link.appendChild(child);
+
+    handle(clickOn(child));
+
+    expect(push).toHaveBeenCalledWith('/works#nny');
+  });
+
+  it.each([
+    ['external', anchor({ href: 'https://example.com' })],
+    ['protocol-relative', anchor({ href: '//example.com' })],
+    ['hash-only', anchor({ href: '#section' })],
+    ['new-tab', anchor({ href: '/works', target: '_blank' })],
+    ['download', anchor({ href: '/press-kit.zip', download: '' })],
+  ])('leaves a %s link to the browser', (_label, link) => {
+    const event = clickOn(link);
+
+    handle(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('ignores clicks that miss an anchor', () => {
+    handle(clickOn(document.createElement('p')));
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('respects modifier and non-primary clicks (new-tab intent)', () => {
+    handle(clickOn(anchor({ href: '/contact' }), { metaKey: true }));
+    handle(clickOn(anchor({ href: '/contact' }), { button: 1 }));
+
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/useProseLinks.ts
+++ b/src/composables/useProseLinks.ts
@@ -1,0 +1,22 @@
+import { useRouter } from 'vue-router';
+
+// Internal links inside v-html prose are raw anchors, so a click triggers a full
+// page reload — which flashes the theme and unstyled content on the SSG page.
+// This routes those clicks through the SPA router instead. External, download,
+// new-tab, hash-only, and modifier/middle clicks are left to the browser.
+export const useProseLinks = (): ((event: MouseEvent) => void) => {
+  const router = useRouter();
+
+  return (event: MouseEvent): void => {
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+    const anchor = (event.target as HTMLElement).closest('a');
+    if (!anchor || anchor.target === '_blank' || anchor.hasAttribute('download')) return;
+
+    const href = anchor.getAttribute('href');
+    if (!href || !href.startsWith('/') || href.startsWith('//')) return;
+
+    event.preventDefault();
+    void router.push(href);
+  };
+};

--- a/src/views/AboutView.test.ts
+++ b/src/views/AboutView.test.ts
@@ -48,4 +48,13 @@ describe('AboutView', () => {
     expect(lightbox.props('currentIndex')).toBe(targetIndex);
     expect(lightbox.props('currentItem')).toMatchObject({ type: 'image', src: expectedSrc });
   });
+
+  it('routes internal prose links through the router instead of reloading', async () => {
+    const wrapper = await mountView(AboutView, '/about');
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    wrapper.get('.prose a[href^="/"]').element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
 });

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -5,6 +5,7 @@ import LightboxHost from '@/components/LightboxHost.vue';
 import PageShell from '@/components/PageShell.vue';
 import ResponsivePicture from '@/components/ResponsivePicture.vue';
 import { usePageHead } from '@/composables/usePageHead';
+import { useProseLinks } from '@/composables/useProseLinks';
 import { aboutSections } from '@/data/about';
 import { pageMeta } from '@/data/pageMeta';
 import { isImageSection } from '@/types';
@@ -13,6 +14,8 @@ import { getImageStyles } from '@/utils/imageStyles';
 import { toLightboxImage } from '@/utils/lightboxAdapters';
 
 usePageHead(pageMeta.about);
+
+const routeProseLink = useProseLinks();
 
 const lightbox = useTemplateRef<InstanceType<typeof LightboxHost>>('lightbox');
 
@@ -49,12 +52,14 @@ const getGlobalIndex = (sectionIndex: number, imageIndex: number): number =>
         <div
           v-if="section.type === 'short-bio'"
           class="short-bio"
+          @click="routeProseLink"
           v-html="externalizeLinks(section.content)"
         />
 
         <div
           v-else-if="!section.type"
           class="prose"
+          @click="routeProseLink"
           v-html="externalizeLinks(section.content)"
         />
 

--- a/src/views/PrivacyView.test.ts
+++ b/src/views/PrivacyView.test.ts
@@ -35,4 +35,13 @@ describe('PrivacyView', () => {
     expect(paletteOpen.value).toBe(true);
     paletteOpen.value = false;
   });
+
+  it('routes the internal contact link through the router instead of reloading', async () => {
+    const wrapper = await mountView(PrivacyView);
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    wrapper.get('a[href="/contact"]').element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
 });

--- a/src/views/PrivacyView.vue
+++ b/src/views/PrivacyView.vue
@@ -2,17 +2,24 @@
 import PageShell from '@/components/PageShell.vue';
 import { openCommandPalette } from '@/composables/useOverlays';
 import { usePageHead } from '@/composables/usePageHead';
+import { useProseLinks } from '@/composables/useProseLinks';
 import { pageMeta } from '@/data/pageMeta';
 import { privacyContent } from '@/data/privacy';
 import { externalizeLinks } from '@/utils/externalizeLinks';
 
 usePageHead(pageMeta.privacy);
 
-// The notice names the (otherwise hidden) command palette; reward the careful reader
-// who clicks it by actually opening it. The cue lives inside a v-html body, so it's
-// caught by delegation rather than a bound handler.
-const revealCommandPalette = (event: MouseEvent): void => {
-  if ((event.target as HTMLElement).closest('.palette-cue')) openCommandPalette();
+const routeProseLink = useProseLinks();
+
+// The palette cue is a button inside the v-html body; a careful reader who clicks it
+// gets the hidden palette. Everything else falls through to internal-link routing.
+const onProseClick = (event: MouseEvent): void => {
+  if ((event.target as HTMLElement).closest('.palette-cue')) {
+    openCommandPalette();
+    return;
+  }
+
+  routeProseLink(event);
 };
 </script>
 
@@ -24,7 +31,7 @@ const revealCommandPalette = (event: MouseEvent): void => {
     >
       <div
         class="privacy"
-        @click="revealCommandPalette"
+        @click="onProseClick"
       >
         <p class="privacy__intro">
           {{ privacyContent.intro }}


### PR DESCRIPTION
## Description
Fixes a flash you spotted on the privacy notice's "get in touch" link — and the same latent issue across the About bio's many cross-links.

Internal links live inside `v-html` prose, so they render as **raw anchors**. Clicking one triggers a *full page reload* of the SSG page instead of a client-side route — and that reload is the flash (the SSG HTML paints before JS re-applies the theme and the async CSS styles the content).

## Fix
A shared `useProseLinks()` composable returns a delegated click handler that intercepts **internal** link clicks (`href` starting with `/`, not `//`) and routes them via the router. Everything else is left to the browser: external links, `download`, `target="_blank"`, hash-only anchors, and modifier / middle-click (new-tab intent).

## Scope — two views, not four
Only the prose that actually contains internal links is wired:
- **AboutView** — the long bio (`bios.long`) is full of `/works#…`, `/live#…`, `/press#…` cross-links.
- **PrivacyView** — the `/contact` link (composed with the existing palette-cue handler).

**EpkView and PressView are deliberately left out:** EPK renders `bios.short` + `bios.press`, and press quotes are external attributions — none carry internal links, so wiring them would be dead code. (If EPK ever adopts `bios.long`, add the one `@click`.)

## Testing
- `gh pr checkout <N> && npm ci && npm run dev` → **/about**: click any in-bio link (e.g. a release name) → it navigates client-side, **no white flash / no theme flicker**. Same for **/privacy** → "get in touch".
- Unit: `useProseLinks` covers internal routing + every pass-through case (external, protocol-relative, hash-only, new-tab, download, modifier, non-anchor).
- Integration: About + Privacy assert an internal prose link's default is prevented (routed, not reloaded).
- E2E: `navigation.spec.ts` clicks an in-bio `/works#…` link and asserts SPA routing — window state survives, proving no full reload.
- Coverage floor holds; production build clean.