### PR TITLE
Enforce TS + Vue invariants with lint rules (Wave 1)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -81,6 +81,15 @@ const baseRules = {
     argsIgnorePattern: '^_',
     varsIgnorePattern: '^_',
   }],
+  '@typescript-eslint/no-non-null-assertion': 'error',
+  '@typescript-eslint/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
+  '@typescript-eslint/ban-ts-comment': 'error',
+
+  // Complexity ceilings — ratcheted just above today's real max so only growth
+  // trips them (source peaks at 19 in the palette key-dispatcher; a keymap
+  // refactor would let this ratchet back down).
+  complexity: ['error', 20],
+  'max-depth': ['error', 4],
 };
 
 const vueRules = {
@@ -98,6 +107,11 @@ const vueRules = {
   'vue/html-closing-bracket-newline': ['error', {
     singleline: 'never',
     multiline: 'always',
+  }],
+  'vue/max-lines-per-block': ['error', {
+    script: 120,
+    template: 160,
+    style: 200,
   }],
 };
 
@@ -169,12 +183,14 @@ export default [
     rules: typeAwareRules,
   },
   {
-    // vue/one-component-per-file (from flat/recommended, which also lints .ts)
-    // guards source SFCs. Tests legitimately define several throwaway
-    // components to exercise composables, so scope it off for them.
+    // Rules that guard source but are legitimate in tests: several throwaway
+    // components to exercise composables, non-null assertions on known-present
+    // fixtures/mocks, and complex arrange-heavy setup blocks.
     files: ['**/*.test.ts', '**/*.test.tsx'],
     rules: {
       'vue/one-component-per-file': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      complexity: 'off',
     },
   },
 ];


### PR DESCRIPTION
## Description
Wave 1 of the A+ strategy: turn **clean-by-discipline** invariants into **CI-gated guarantees**. The audits found TypeScript (A) and Vue architecture (A−) both cap below A+ for the same reason — the good state is held by a careful hand, not a rule that fails the build. This adds those rules.

## Rules added
**TypeScript (baseRules):**
- `no-non-null-assertion` — no `!` in source (tests relaxed; `!` on known fixtures is fine)
- `ban-ts-comment` — no silent `@ts-ignore`
- `consistent-type-imports` (with `disallowTypeAnnotations: false` so the `typeof import()` mock pattern in tests still works)

**Vue / complexity ceilings:**
- `vue/max-lines-per-block` (script 120 / template 160 / style 200)
- `complexity` 20, `max-depth` 4

## Calibration (honest)
The auditors slightly under-estimated today's maxima, so ceilings are **ratcheted to just above the real max** (template peaks at 152, complexity at 19 in the palette key-dispatcher) — a floor-that-can-only-tighten, exactly like the coverage ratchet. Nothing is refactored to fit; only *growth* trips these. Tests relax `no-non-null-assertion` + `complexity` (legitimate in arrange-heavy fixtures/mocks), extending the existing test-override block.

## Neutral
**No source files change** — pure enforcement config. Lint + type-check green.

## Deferred (need triage or sign-off, not in this PR)
- `no-unsafe-*` family + `no-unnecessary-condition` — need triage of ~10 idiomatic DOM casts / may flag defensive checks.
- A keymap refactor of the palette `handleKeydown` dispatcher, which would let the complexity ceiling ratchet back down toward 12.