### PR TITLE
Make visual regression a blocking CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [quality-checks, build, lighthouse, e2e-tests, worker]
+    needs: [quality-checks, build, lighthouse, e2e-tests, visual-tests, worker]
     if: always()
 
     steps:
@@ -300,14 +300,18 @@ jobs:
           echo "| Build | ${{ needs.build.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Lighthouse | ${{ needs.lighthouse.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| E2E Tests | ${{ needs.e2e-tests.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Visual Regression | ${{ needs.visual-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Worker | ${{ needs.worker.result }} |" >> $GITHUB_STEP_SUMMARY
 
-          # Fail if any job failed
+          # Fail if any job failed. Visual Regression is PR-only, so "skipped"
+          # (the deploy path) is acceptable — only a real failure blocks.
           if [ "${{ needs.quality-checks.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ] || \
              [ "${{ needs.lighthouse.result }}" != "success" ] || \
              [ "${{ needs.e2e-tests.result }}" != "success" ] || \
-             [ "${{ needs.worker.result }}" != "success" ]; then
+             [ "${{ needs.worker.result }}" != "success" ] || \
+             { [ "${{ needs.visual-tests.result }}" != "success" ] && \
+               [ "${{ needs.visual-tests.result }}" != "skipped" ]; }; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "❌ **CI Pipeline Failed**" >> $GITHUB_STEP_SUMMARY
             exit 1


### PR DESCRIPTION
## Description
Closes the enforcement hole the testing audit found: the `summary` job's `needs` list omitted `visual-tests`, so a pixel diff **failed its own job but didn't block the PR**. Visual regression is the guardrail the whole styling workstream leans on — it should be blocking.

## Change
- Add `visual-tests` to the summary `needs` and status table.
- Because `visual-tests` is `pull_request`-only (skipped on the deploy path), the gate accepts **`skipped`** for it — only a real **failure** blocks. Verified the bash truth table locally: VR success → pass, VR skipped → pass, VR failure → block, plus the existing jobs unchanged.

## Neutral
No code, no deps, no output change — CI policy only. This PR's own `pull_request` run exercises the new gate (VR runs and must pass).