### PR TITLE
Add husky pre-commit + pre-push local gate

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run type-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,9 @@
         "exiftool-vendored": "^37.2.0",
         "fontkit": "^2.0.4",
         "happy-dom": "^20.11.6",
+        "husky": "^9.1.7",
         "jiti": "^2.6.1",
+        "lint-staged": "^17.4.1",
         "sass": "^1.103.1",
         "sharp": "^0.35.3",
         "stylelint": "^17.14.1",
@@ -6223,6 +6225,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7702,6 +7720,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
+      "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.7",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.3.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
@@ -8632,9 +8674,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9862,6 +9904,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,12 @@
     "epk:bundle": "node scripts/generate-epk-bundle.mjs",
     "rider:pdf": "node scripts/generate-tech-rider.mjs",
     "downloads:build": "npm run epk:bundle && npm run rider:pdf",
-    "epk:kit": "npm run epk:photos && npm run downloads:build"
+    "epk:kit": "npm run epk:photos && npm run downloads:build",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,vue,js}": "eslint --fix",
+    "*.scss": "stylelint --fix"
   },
   "repository": {
     "type": "git",
@@ -70,7 +75,9 @@
     "exiftool-vendored": "^37.2.0",
     "fontkit": "^2.0.4",
     "happy-dom": "^20.11.6",
+    "husky": "^9.1.7",
     "jiti": "^2.6.1",
+    "lint-staged": "^17.4.1",
     "sass": "^1.103.1",
     "sharp": "^0.35.3",
     "stylelint": "^17.14.1",


### PR DESCRIPTION
## Description
Closes the biggest local-enforcement hole the build/CI audit found: **nothing ran before push**, so a broken commit was caught only after CI fired. Adds a local gate mirroring what CI enforces.

## Hooks (husky v9)
- **pre-commit** → `lint-staged`: `eslint --fix` on staged `*.{ts,tsx,vue,js}`, `stylelint --fix` on staged `*.scss` — fast, per-file, auto-fixing.
- **pre-push** → `npm run type-check` (whole-project `vue-tsc`).
- Both bypassable with `--no-verify` in a pinch.

## Verified end-to-end
- pre-commit fired on this PR's own commit (lint-staged ran, no matching staged files → passed).
- pre-push fired on push — `type-check` ran and passed (the push only completed because it did).
- Proved lint-staged executes stylelint on staged SCSS (auto-fixed a deliberately sloppy temp file).

## Deps (pre-approved)
`husky` + `lint-staged`, dev-only, standard, reversible.

## Neutral
No source, no output, no visual change.