### PR TITLE
Announce seek slider position as time (a11y)

### DIFF
--- a/src/components/PlayerBar.vue
+++ b/src/components/PlayerBar.vue
@@ -108,6 +108,7 @@ const onSeek = (event: Event): void => {
         step="1"
         :value="currentTime"
         :aria-label="`Seek within ${currentTrack.title}`"
+        :aria-valuetext="`${formatTime(currentTime)} of ${formatTime(duration)}`"
         @input="onSeek"
       >
       <span class="player-bar__time">{{ formatTime(duration) }}</span>

--- a/src/components/PlayerScreen.vue
+++ b/src/components/PlayerScreen.vue
@@ -81,6 +81,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown));
         step="1"
         :value="currentTime"
         aria-label="Seek"
+        :aria-valuetext="`${formatTime(currentTime)} of ${formatTime(duration)}`"
         @input="onSeek"
       >
       <span class="player-screen__time">{{ formatTime(duration) }}</span>


### PR DESCRIPTION
## Description
Small accessibility fix from the a11y audit: both player seek sliders (`PlayerBar`, `PlayerScreen`) exposed only their numeric `value`, so a screen reader announced the raw seconds (`142`) instead of a time. Add `aria-valuetext` formatted as `<current> of <total>` (e.g. "2:22 of 5:30") via the existing `formatTime` helper.

## Neutral
An ARIA attribute only — no visual or behavioural change. Lint + type-check green; VR unaffected.

## Related
The larger `PlayerScreen` dialog fix (focus trap / restore / background inert) is a separate, more deliberate PR.