### PR TITLE
Fix PlayerScreen dialog a11y: focus trap, restore, scroll-lock

### DIFF
--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue';
 
+import { useFocusTrap } from '@/composables/useFocusTrap';
 import type { LightboxItem } from '@/types';
 import { isLightboxImage, isLightboxVideo } from '@/types';
 import { toWebp } from '@/utils/responsiveImage';
@@ -51,38 +52,7 @@ const dialogLabel = computed(() => {
 // Move focus into the dialog on open and trap Tab within it, so keyboard users
 // can't reach the inert background behind the overlay.
 const dialogRef = ref<HTMLElement | null>(null);
-
-const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
-
-const getFocusable = (): HTMLElement[] =>
-  dialogRef.value ? Array.from(dialogRef.value.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)) : [];
-
-const handleKeydown = (event: KeyboardEvent): void => {
-  if (event.key !== 'Tab') return;
-
-  const focusable = getFocusable();
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-
-  if (!first || !last) {
-    event.preventDefault();
-    dialogRef.value?.focus();
-    return;
-  }
-
-  const active = document.activeElement;
-
-  if (event.shiftKey && (active === first || active === dialogRef.value)) {
-    event.preventDefault();
-    last.focus();
-    return;
-  }
-
-  if (!event.shiftKey && active === last) {
-    event.preventDefault();
-    first.focus();
-  }
-};
+const { onKeydown } = useFocusTrap(dialogRef);
 
 onMounted(async () => {
   await nextTick();
@@ -101,7 +71,7 @@ onMounted(async () => {
       :aria-label="dialogLabel"
       tabindex="-1"
       @click="handleClose"
-      @keydown="handleKeydown"
+      @keydown="onKeydown"
       @touchstart="handleTouchStart"
       @touchend="handleTouchEnd"
     >

--- a/src/components/PlayerScreen.test.ts
+++ b/src/components/PlayerScreen.test.ts
@@ -95,7 +95,36 @@ describe('PlayerScreen', () => {
     expect(player.usePlayer().expanded.value).toBe(false);
 
     player.expand();
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.trigger('keydown', { key: 'Escape' });
     expect(player.usePlayer().expanded.value).toBe(false);
+  });
+
+  it('restores focus to the trigger when it closes', async () => {
+    await player.play(TRACKS);
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const wrapper = await mounted();
+    expect(document.activeElement).not.toBe(trigger);
+
+    wrapper.unmount();
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  it('traps Tab focus within the dialog', async () => {
+    await player.play(TRACKS);
+    const wrapper = await mounted();
+
+    const dialog = wrapper.get('.player-screen').element;
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first.focus();
+
+    await wrapper.trigger('keydown', { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
   });
 });

--- a/src/components/PlayerScreen.vue
+++ b/src/components/PlayerScreen.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
+import { useFocusTrap } from '@/composables/useFocusTrap';
 import { usePlayer } from '@/composables/usePlayer';
+import { useScrollLock } from '@/composables/useScrollLock';
 import type { AudioTrack } from '@/types/audio';
 import { formatTime } from '@/utils/formatTime';
 
@@ -11,35 +13,52 @@ const { status, currentTrack, queue, currentTime, duration, context, hasNext, ha
 const isPlaying = computed(() => status.value === 'playing');
 const currentIndex = computed(() => queue.value.findIndex(track => track.key === currentTrack.value?.key));
 
-const collapseButton = ref<HTMLButtonElement | null>(null);
-
 const onSeek = (event: Event): void => {
   seek(Number((event.target as HTMLInputElement).value));
 };
 
 const trackLabel = (track: AudioTrack): string => (track.artist ? `${track.artist} — ${track.title}` : track.title);
 
+// role="dialog" aria-modal: trap Tab within the screen, restore focus to the
+// trigger on close, and lock background scroll — matching the palette/lightbox.
+const dialog = ref<HTMLElement | null>(null);
+const { onKeydown: trapTab } = useFocusTrap(dialog);
+const { lock, unlock } = useScrollLock();
+
+let previouslyFocused: HTMLElement | null = null;
+
 const onKeydown = (event: KeyboardEvent): void => {
-  if (event.key === 'Escape') collapse();
+  if (event.key === 'Escape') {
+    collapse();
+    return;
+  }
+
+  trapTab(event);
 };
 
 onMounted(() => {
-  window.addEventListener('keydown', onKeydown);
-  collapseButton.value?.focus();
+  previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  lock();
+  dialog.value?.focus();
 });
 
-onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+onBeforeUnmount(() => {
+  unlock();
+  previouslyFocused?.focus();
+});
 </script>
 
 <template>
   <div
+    ref="dialog"
     class="player-screen"
     role="dialog"
     aria-modal="true"
     aria-label="Now playing"
+    tabindex="-1"
+    @keydown="onKeydown"
   >
     <button
-      ref="collapseButton"
       type="button"
       class="player-screen__collapse"
       aria-label="Collapse player"

--- a/src/composables/useFocusTrap.test.ts
+++ b/src/composables/useFocusTrap.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { shallowRef } from 'vue';
+
+import { useFocusTrap } from './useFocusTrap';
+
+const makeDialog = (buttonCount: number): { dialog: HTMLElement; buttons: HTMLButtonElement[] } => {
+  const dialog = document.createElement('div');
+  dialog.tabIndex = -1;
+
+  const buttons = Array.from({ length: buttonCount }, (_, index) => {
+    const button = document.createElement('button');
+    button.textContent = `button-${index}`;
+    dialog.appendChild(button);
+    return button;
+  });
+
+  document.body.appendChild(dialog);
+  return { dialog, buttons };
+};
+
+const tab = (shiftKey = false): KeyboardEvent => new KeyboardEvent('keydown', { key: 'Tab', shiftKey, cancelable: true });
+
+describe('useFocusTrap', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('wraps Tab from the last focusable to the first', () => {
+    const { dialog, buttons } = makeDialog(3);
+    const { onKeydown } = useFocusTrap(shallowRef(dialog));
+    buttons[2].focus();
+
+    const event = tab();
+    onKeydown(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('wraps Shift+Tab from the first focusable to the last', () => {
+    const { dialog, buttons } = makeDialog(3);
+    const { onKeydown } = useFocusTrap(shallowRef(dialog));
+    buttons[0].focus();
+
+    const event = tab(true);
+    onKeydown(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(buttons[2]);
+  });
+
+  it('leaves a non-boundary Tab to the browser', () => {
+    const { dialog, buttons } = makeDialog(3);
+    const { onKeydown } = useFocusTrap(shallowRef(dialog));
+    buttons[1].focus();
+
+    const event = tab();
+    onKeydown(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('ignores non-Tab keys', () => {
+    const { dialog } = makeDialog(2);
+    const { onKeydown } = useFocusTrap(shallowRef(dialog));
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true });
+    onKeydown(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('focuses the container when it holds no focusable children', () => {
+    const { dialog } = makeDialog(0);
+    const { onKeydown } = useFocusTrap(shallowRef(dialog));
+
+    const event = tab();
+    onKeydown(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(dialog);
+  });
+});

--- a/src/composables/useFocusTrap.ts
+++ b/src/composables/useFocusTrap.ts
@@ -1,0 +1,41 @@
+import type { Ref } from 'vue';
+
+const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), input:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
+
+// Keeps Tab focus within `containerRef` (WCAG 2.4.3) so keyboard users can't
+// reach the inert background behind a modal dialog. Returns the keydown handler
+// to bind on the dialog element; initial focus and restore stay with the caller,
+// which differ per overlay. Shared by the lightbox and the expanded player.
+export const useFocusTrap = (containerRef: Ref<HTMLElement | null>): { onKeydown: (event: KeyboardEvent) => void } => {
+  const getFocusable = (): HTMLElement[] =>
+    containerRef.value ? Array.from(containerRef.value.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)) : [];
+
+  const onKeydown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Tab') return;
+
+    const focusable = getFocusable();
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (!first || !last) {
+      event.preventDefault();
+      containerRef.value?.focus();
+      return;
+    }
+
+    const active = document.activeElement;
+
+    if (event.shiftKey && (active === first || active === containerRef.value)) {
+      event.preventDefault();
+      last.focus();
+      return;
+    }
+
+    if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return { onKeydown };
+};


### PR DESCRIPTION
## ⚠️ Please eyeball before merge
This is `[neutral]` (gated by tests + VR), but a11y **focus behaviour** isn't fully provable by automated gates — so I'm leaving this one for your review rather than auto-merging, per our contract.

## Description
The a11y audit's weakest link: `PlayerScreen` (the expanded now-playing view) declares `role="dialog"` `aria-modal="true"` but did **not** trap focus (Tab escaped to the background behind it), did **not** restore focus on close, and did **not** lock background scroll — unlike the palette and lightbox, which do all three. `aria-modal` without a trap misleads assistive tech.

## Change
- **Extract `useFocusTrap`** — the lightbox already had the Tab-cycling trap inline; pulled it into a shared composable (just the trap, so each overlay keeps its own initial-focus → the lightbox is **behaviour-identical**). Also dedups.
- **PlayerScreen** now: traps Tab, restores focus to the trigger on close (capture on mount → restore on unmount), and locks background scroll — matching the palette/lightbox pattern (`aria-modal` + trap is how the others signal the background is inert; no app-root `inert` needed).

## Tests
- `useFocusTrap` unit tests (wrap both directions, non-boundary passthrough, no-focusable fallback, non-Tab ignore).
- PlayerScreen: **focus restore on close**, **Tab trapped**, Escape collapse. Coverage floor holds.
- Lightbox's own 16 tests still green (retrofit is behaviour-preserving).

## How to verify by hand
Open a release → expand the player (chevron) → **Tab** repeatedly: focus should cycle *within* the player, never landing on the page behind it. **Esc** or the collapse chevron closes it and returns focus to where you were.

## VR
Expected unchanged (focus/aria/scroll-lock don't alter screenshots; lightbox initial-focus preserved).