### PR TITLE
Reserve image space with intrinsic dimensions (CLS)

### DIFF
--- a/scripts/generate-responsive-images.mjs
+++ b/scripts/generate-responsive-images.mjs
@@ -52,11 +52,12 @@ for (const { src, widths } of targets) {
     generated += 1;
     savedKb += info.size / 1024;
   }
-  manifest[name] = produced;
+  manifest[name] = { widths: produced, width: meta.width, height: meta.height };
 }
 
-// Committed manifest of the widths actually generated per image, so the runtime
-// srcset only ever lists variants that exist.
+// Committed manifest of the widths actually generated per image (so the runtime
+// srcset only lists variants that exist) plus the intrinsic dimensions (so the
+// <img> can reserve load-time space and avoid layout shift).
 writeFileSync(
   join(root, 'src/data/responsiveImages.json'),
   `${JSON.stringify(manifest, null, 2)}\n`,

--- a/src/components/ResponsivePicture.vue
+++ b/src/components/ResponsivePicture.vue
@@ -3,7 +3,7 @@ import type { StyleValue } from 'vue';
 import { computed } from 'vue';
 
 import { useImageLoader } from '@/composables/useImageLoader';
-import { responsiveSrcset } from '@/utils/responsiveImage';
+import { imageDimensions, responsiveSrcset } from '@/utils/responsiveImage';
 
 const props = defineProps<{
   src: string;
@@ -17,6 +17,7 @@ const emit = defineEmits<{ error: [] }>();
 const { setImageRef, imageLoaded, webpSrc, handleImageLoad, handleImageError } = useImageLoader(props.src);
 
 const srcset = computed(() => responsiveSrcset(props.src));
+const dimensions = computed(() => imageDimensions(props.src));
 
 const onError = (): void => {
   handleImageError();
@@ -40,6 +41,8 @@ const onError = (): void => {
       :ref="setImageRef"
       :src="src"
       :alt="alt"
+      :width="dimensions?.width"
+      :height="dimensions?.height"
       :style="imageStyle"
       loading="lazy"
       decoding="async"

--- a/src/data/responsiveImages.json
+++ b/src/data/responsiveImages.json
@@ -1,171 +1,319 @@
 {
-  "1714": [
-    320,
-    640,
-    960
-  ],
-  "2504": [
-    320,
-    640,
-    960
-  ],
-  "contraplacado": [
-    320,
-    640,
-    960
-  ],
-  "en-veille": [
-    320,
-    640,
-    960
-  ],
-  "caligari": [
-    320,
-    640,
-    960
-  ],
-  "overlapse": [
-    320,
-    640,
-    960
-  ],
-  "nny": [
-    320,
-    640
-  ],
-  "coil": [
-    320,
-    640
-  ],
-  "readerror": [
-    320,
-    640
-  ],
-  "ect": [
-    320
-  ],
-  "offear": [
-    320,
-    640,
-    960
-  ],
-  "overlapse-xiii": [
-    320,
-    640,
-    960
-  ],
-  "altar": [
-    320,
-    640,
-    960
-  ],
-  "depolarized": [
-    320,
-    640
-  ],
-  "aragao": [
-    320,
-    640,
-    960
-  ],
-  "invisible-other": [
-    320,
-    640,
-    960
-  ],
-  "caligari-live": [
-    320,
-    640,
-    960
-  ],
-  "hyphema": [
-    320
-  ],
-  "glitch": [
-    320,
-    640,
-    960
-  ],
-  "about-2005-madeiradig": [
-    480,
-    960
-  ],
-  "about-2007-madeiradig": [
-    480,
-    960
-  ],
-  "about-2008-eme": [
-    480,
-    960,
-    1440
-  ],
-  "about-2009-madeiradig": [
-    480,
-    960,
-    1440
-  ],
-  "about-2007-stfu": [
-    480,
-    960,
-    1440
-  ],
-  "about-2008-storung": [
-    480,
-    960,
-    1440
-  ],
-  "about-2009-olhares": [
-    480,
-    960,
-    1440
-  ],
-  "about-2010-olhares": [
-    480,
-    960
-  ],
-  "about-2011-migractions": [
-    480,
-    960
-  ],
-  "about-2011-madeiradig": [
-    480,
-    960,
-    1440
-  ],
-  "about-2015-fica": [
-    480,
-    960
-  ],
-  "about-2015-heineken": [
-    480,
-    960,
-    1440
-  ],
-  "about-2021-nariz": [
-    480,
-    960,
-    1440
-  ],
-  "about-2022-jejum": [
-    480,
-    960,
-    1440
-  ],
-  "about-2022-amess-museu": [
-    480,
-    960
-  ],
-  "about-2022-amess-teatro": [
-    480,
-    960
-  ],
-  "about-2025-fim": [
-    480,
-    960,
-    1440
-  ],
-  "about-2025-showcase": [
-    480,
-    960
-  ]
+  "1714": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "2504": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "contraplacado": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "en-veille": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "caligari": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "overlapse": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "nny": {
+    "widths": [
+      320,
+      640
+    ],
+    "width": 733,
+    "height": 733
+  },
+  "coil": {
+    "widths": [
+      320,
+      640
+    ],
+    "width": 709,
+    "height": 709
+  },
+  "readerror": {
+    "widths": [
+      320,
+      640
+    ],
+    "width": 709,
+    "height": 709
+  },
+  "ect": {
+    "widths": [
+      320
+    ],
+    "width": 600,
+    "height": 600
+  },
+  "offear": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "overlapse-xiii": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "altar": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1200,
+    "height": 1200
+  },
+  "depolarized": {
+    "widths": [
+      320,
+      640
+    ],
+    "width": 800,
+    "height": 800
+  },
+  "aragao": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1448,
+    "height": 2048
+  },
+  "invisible-other": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1280,
+    "height": 720
+  },
+  "caligari-live": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1280,
+    "height": 853
+  },
+  "hyphema": {
+    "widths": [
+      320
+    ],
+    "width": 468,
+    "height": 674
+  },
+  "glitch": {
+    "widths": [
+      320,
+      640,
+      960
+    ],
+    "width": 1500,
+    "height": 1829
+  },
+  "about-2005-madeiradig": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1280,
+    "height": 960
+  },
+  "about-2007-madeiradig": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1283,
+    "height": 855
+  },
+  "about-2008-eme": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 3872,
+    "height": 2592
+  },
+  "about-2009-madeiradig": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 2592,
+    "height": 1944
+  },
+  "about-2007-stfu": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 1536,
+    "height": 2048
+  },
+  "about-2008-storung": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 1772,
+    "height": 1181
+  },
+  "about-2009-olhares": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 1800,
+    "height": 1200
+  },
+  "about-2010-olhares": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1024,
+    "height": 744
+  },
+  "about-2011-migractions": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1000,
+    "height": 1504
+  },
+  "about-2011-madeiradig": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 3888,
+    "height": 2592
+  },
+  "about-2015-fica": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1082,
+    "height": 720
+  },
+  "about-2015-heineken": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 2160,
+    "height": 1440
+  },
+  "about-2021-nariz": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 3000,
+    "height": 2000
+  },
+  "about-2022-jejum": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 2000,
+    "height": 1334
+  },
+  "about-2022-amess-museu": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1363,
+    "height": 2048
+  },
+  "about-2022-amess-teatro": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1334,
+    "height": 2000
+  },
+  "about-2025-fim": {
+    "widths": [
+      480,
+      960,
+      1440
+    ],
+    "width": 1602,
+    "height": 2400
+  },
+  "about-2025-showcase": {
+    "widths": [
+      480,
+      960
+    ],
+    "width": 1365,
+    "height": 2048
+  }
 }

--- a/src/utils/responsiveImage.test.ts
+++ b/src/utils/responsiveImage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { toWebp } from './responsiveImage';
+import { imageDimensions, toWebp } from './responsiveImage';
 
 describe('toWebp', () => {
   it('swaps a trailing .jpg for .webp', () => {
@@ -14,5 +14,18 @@ describe('toWebp', () => {
   it('leaves non-jpg sources unchanged', () => {
     expect(toWebp('/images/logo.png')).toBe('/images/logo.png');
     expect(toWebp('/images/hero.webp')).toBe('/images/hero.webp');
+  });
+});
+
+describe('imageDimensions', () => {
+  it('returns positive intrinsic dimensions for a manifest image', () => {
+    const dimensions = imageDimensions('/images/1714.jpg');
+
+    expect(dimensions?.width).toBeGreaterThan(0);
+    expect(dimensions?.height).toBeGreaterThan(0);
+  });
+
+  it('returns null for an image absent from the manifest', () => {
+    expect(imageDimensions('/images/not-a-real-image.jpg')).toBeNull();
   });
 });

--- a/src/utils/responsiveImage.ts
+++ b/src/utils/responsiveImage.ts
@@ -1,6 +1,12 @@
 import manifestData from '@/data/responsiveImages.json';
 
-const manifest: Record<string, number[]> = manifestData;
+interface ResponsiveImage {
+  widths: number[];
+  width: number;
+  height: number;
+}
+
+const manifest: Record<string, ResponsiveImage> = manifestData;
 
 const RESPONSIVE_DIR = '/images/responsive';
 
@@ -11,8 +17,14 @@ export const toWebp = (imagePath: string): string => imagePath.replace(/\.jpg$/,
 
 export const responsiveSrcset = (imagePath: string): string | null => {
   const name = baseName(imagePath);
-  const widths = manifest[name];
-  if (!widths || widths.length === 0) return null;
+  const entry = manifest[name];
+  if (!entry || entry.widths.length === 0) return null;
 
-  return widths.map(width => `${RESPONSIVE_DIR}/${name}-${width}w.webp ${width}w`).join(', ');
+  return entry.widths.map(width => `${RESPONSIVE_DIR}/${name}-${width}w.webp ${width}w`).join(', ');
+};
+
+// Intrinsic dimensions, so the <img> can reserve load-time space (no layout shift).
+export const imageDimensions = (imagePath: string): { width: number; height: number } | null => {
+  const entry = manifest[baseName(imagePath)];
+  return entry ? { width: entry.width, height: entry.height } : null;
 };


### PR DESCRIPTION
## Description
The performance audit's CLS finding: `ResponsivePicture` emitted `<img>` with **no `width`/`height`**, so images occupied zero space until they loaded — the likeliest layout-shift source.

## Change
- The responsive-image **manifest now records intrinsic `width`/`height`** per image (the generator already read them via sharp — just weren't stored). Manifest reshaped `number[]` → `{ widths, width, height }`; `responsiveSrcset` updated; new `imageDimensions()` helper.
- `ResponsivePicture` sets `:width`/`:height` on the `<img>` (omitted gracefully for images not in the manifest).

## Why it should be VR-neutral
Covers and about-images use `object-fit: cover` in CSS-sized containers, and the attributes equal the **intrinsic** aspect — so the browser reserves the *same* space it rendered before, just earlier. Final layout is unchanged; only load-time reservation improves. **CI visual regression is the check**: green confirms neutrality.

## Tests
`imageDimensions` unit tests; existing `responsiveSrcset`/image tests still pass; build emits `width="1200" height="1200"` etc. in the HTML.

## Follow-up
A mobile Lighthouse profile (the audit's companion perf item) is separate — not in this PR.