### PR TITLE
Name the global z-index layers

### DIFF
--- a/src/styles/_lightbox.scss
+++ b/src/styles/_lightbox.scss
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 9999;
+  z-index: $z-overlay;
   cursor: pointer;
   padding: $spacing-4;
   contain: layout style paint;

--- a/src/styles/_masthead.scss
+++ b/src/styles/_masthead.scss
@@ -3,7 +3,7 @@
 .masthead {
   position: sticky;
   top: 0;
-  z-index: 100;
+  z-index: $z-masthead;
   background: var(--color-bg);
   padding: $spacing-4 $spacing-5;
 

--- a/src/styles/_overlays.scss
+++ b/src/styles/_overlays.scss
@@ -23,7 +23,7 @@
 .command-palette {
   position: fixed;
   inset: 0;
-  z-index: 10000;
+  z-index: $z-overlay;
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -116,7 +116,7 @@
 .keyboard-help {
   position: fixed;
   inset: 0;
-  z-index: 10000;
+  z-index: $z-overlay;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/_player.scss
+++ b/src/styles/_player.scss
@@ -5,7 +5,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 900;
+  z-index: $z-player;
   display: flex;
   flex-direction: column;
   gap: $spacing-2;
@@ -246,7 +246,7 @@
 .player-screen {
   position: fixed;
   inset: 0;
-  z-index: 950;
+  z-index: $z-player-expanded;
   display: flex;
   flex-direction: column;
   gap: $spacing-5;

--- a/src/styles/_utilities.scss
+++ b/src/styles/_utilities.scss
@@ -15,7 +15,7 @@
   position: absolute;
   top: -100%;
   left: $spacing-4;
-  z-index: 1000;
+  z-index: $z-skip-link;
   padding: $spacing-2 $spacing-4;
   background: var(--color-bg);
   color: var(--color-text);

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -43,6 +43,15 @@ $footer-height: 160px;                   // Measured total height - update if fo
 $nav-max-height: 20rem;
 $release-media-width: 200px;
 $loading-dot-size: 6px;
+
+// Global stacking order, named so new layers slot in without a z-index war.
+// (Local, within-component stacking keeps small literal values.)
+$z-masthead: 100;
+$z-player: 900;
+$z-player-expanded: 950;
+$z-skip-link: 1000;
+$z-overlay: 10000; // palette, keyboard help, lightbox — full-screen modals
+
 $transition-fast: 120ms ease;
 $transition-base: 300ms ease;
 $opacity-20: 0.2;


### PR DESCRIPTION
## Description
Wave 3 styling: the audit found twelve ad-hoc `z-index` values with no scale and a `9999`/`10000` mix at the top. Add named layer tokens and apply them:

```
$z-masthead: 100 < $z-player: 900 < $z-player-expanded: 950 < $z-skip-link: 1000 < $z-overlay: 10000
```

Local, within-component stacking (the lightbox's own `__` children, a release cover's `z-index: 1`) keeps small literal values — those aren't global layers.

## Near-provably neutral
Diffing the compiled CSS, the **only** change is the lightbox container unifying `9999 → 10000` (one byte). It's behaviourally inert: the lightbox and palette are never open at once, and nothing has a z-index between 9999 and 10000. Everything else is byte-identical — same values, now named. VR confirms.