### PR TITLE
Fluid content-rhythm spacing via clamp()

### DIFF
--- a/src/styles/_pages.scss
+++ b/src/styles/_pages.scss
@@ -48,14 +48,13 @@
 
 .page[data-page="about"] {
   .about-image-group {
-    margin: $spacing-12 0;
+    margin: fluid($spacing-12, $spacing-16) 0;
     display: grid;
     gap: $spacing-4;
     grid-template-columns: repeat(2, 1fr);
     grid-auto-rows: minmax(150px, 200px);
 
     @include respond-to(md) {
-      margin: $spacing-16 0;
       gap: $spacing-6;
       grid-template-columns: repeat(4, 1fr);
       grid-auto-rows: minmax(200px, auto);
@@ -66,11 +65,7 @@
     }
 
     + .about-image-group {
-      margin-top: $spacing-4;
-
-      @include respond-to(md) {
-        margin-top: $spacing-6;
-      }
+      margin-top: fluid($spacing-4, $spacing-6);
     }
 
     &:has(.about-image-group__image:first-child:nth-last-child(2)),
@@ -169,14 +164,9 @@
   }
 
   .short-bio {
-    margin-bottom: $spacing-8;
-    padding-bottom: $spacing-8;
+    margin-bottom: fluid($spacing-8, $spacing-12);
+    padding-bottom: fluid($spacing-8, $spacing-12);
     border-bottom: 1px solid var(--color-border);
-
-    @include respond-to(md) {
-      margin-bottom: $spacing-12;
-      padding-bottom: $spacing-12;
-    }
 
     p {
       font-size: $font-size-lg;
@@ -192,18 +182,10 @@
   }
 
   .prose {
-    margin-bottom: $spacing-8;
-
-    @include respond-to(md) {
-      margin-bottom: $spacing-12;
-    }
+    margin-bottom: fluid($spacing-8, $spacing-12);
 
     .about-image-group + & {
-      margin-top: $spacing-12;
-
-      @include respond-to(md) {
-        margin-top: $spacing-16;
-      }
+      margin-top: fluid($spacing-12, $spacing-16);
     }
   }
 }

--- a/src/styles/_type.scss
+++ b/src/styles/_type.scss
@@ -19,13 +19,11 @@ h2 {
   text-transform: uppercase;
   letter-spacing: $letter-spacing-wide;
   color: var(--color-text-muted);
-  margin-top: $spacing-8;
-  margin-bottom: $spacing-3;
+  margin-top: fluid($spacing-8, $spacing-12);
+  margin-bottom: fluid($spacing-3, $spacing-4);
 
   @include respond-to(md) {
     letter-spacing: $letter-spacing-wider;
-    margin-top: $spacing-12;
-    margin-bottom: $spacing-4;
   }
 }
 
@@ -117,11 +115,7 @@ blockquote {
 hr {
   border: 0;
   border-top: 1px solid var(--color-border);
-  margin: $spacing-8 0;
-
-  @include respond-to(md) {
-    margin: $spacing-12 0;
-  }
+  margin: fluid($spacing-8, $spacing-12) 0;
 }
 
 .prose {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 $font-mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
 $font-size-xs: 0.6875rem;
@@ -64,6 +66,18 @@ $opacity-80: 0.8;
 $opacity-90: 0.9;
 $overlay-dark: rgb(0 0 0 / 40%);
 $overlay-scrim: rgb(0 0 0 / 50%);
+
+// Smoothly interpolate a rem value between two viewport widths, clamped to
+// [$min, $max] — replaces a hard breakpoint step with a fluid ramp. Reaches
+// $max at $to-vw (the desktop VR width), so wide layouts are unchanged.
+@function fluid($min, $max, $from-vw: $breakpoint-sm, $to-vw: $breakpoint-xl) {
+  $from-rem: math.div($from-vw, 16px) * 1rem;
+  $to-rem: math.div($to-vw, 16px) * 1rem;
+  $slope: math.div($max - $min, $to-rem - $from-rem);
+  $intercept: $min - $slope * $from-rem;
+
+  @return clamp(#{$min}, #{$intercept} + #{$slope * 100}vw, #{$max});
+}
 
 @mixin respond-to($breakpoint) {
   @if $breakpoint == sm {


### PR DESCRIPTION
## ⚠️ Visual checkpoint — please review before merge

The fluid-spacing pass, done **properly** this time — applied where the reading rhythm actually renders, not the dead `h2`/`hr` base.

## What it does
Adds a `fluid($min, $max)` helper (a `clamp()` between two viewport widths) and converts the **content vertical rhythm** from a hard 768px step to a smooth ramp:
- `_type.scss`: `h2` margins (the base — applies to section headings on /works, /live, /privacy)
- `_pages.scss` (about page): `.short-bio`, `.prose`, and the image-group vertical margins

## Neutral at the ends, smoother in between
Every `clamp()` reaches its **old desktop value at 1280px**, so wide layouts — and the VR snapshots — are unchanged. The grid's discrete 2→4 column change stays a breakpoint step (it can't be fluid). The only difference is mid-range widths (~5–10px tighter, smoother on resize) and no more 768px "pop".

## Honest note
Even done properly, this is a ~2/10 visible change — the before/after screenshots at 900px are nearly indistinguishable. It's a rhythm/elegance refinement and a documented `fluid()` tool, not something a visitor would notice.
