### PR TITLE
Fail the build on unresolved credit markers

### DIFF
--- a/scripts/check-anchors.js
+++ b/scripts/check-anchors.js
@@ -51,17 +51,46 @@ for (const [source, data] of Object.entries(sources)) {
 
 const broken = anchors.filter(anchor => !validTargets[anchor.page].has(anchor.fragment));
 
-console.log('\n🔗 Internal Anchor Check:');
+// Credit markers: every [[Name]] in a release's credits must resolve to a
+// contributor that has a URL — renderCredits silently renders an unresolved
+// marker as plain text, so a typo or missing contributor drops the link.
+const MARKER_PATTERN = /\[\[([^\]]+)\]\]/g;
+const unresolvedMarkers = [];
+
+for (const section of Object.values(worksData)) {
+  for (const item of section.items ?? []) {
+    if (typeof item.credits !== 'string') continue;
+
+    const linked = new Set((item.contributors ?? []).filter(contributor => contributor.url).map(contributor => contributor.name));
+    for (const match of item.credits.matchAll(MARKER_PATTERN)) {
+      if (!linked.has(match[1])) unresolvedMarkers.push({ id: item.id, name: match[1] });
+    }
+  }
+}
+
+console.log('\n🔗 Content Integrity Check:');
 console.log('━'.repeat(50));
-console.log(`Scanned ${anchors.length} internal anchor links across ${Object.keys(sources).length} data files.`);
+console.log(`Scanned ${anchors.length} internal anchor link(s) and credit markers across ${Object.keys(sources).length} data files.`);
 console.log('━'.repeat(50));
 
+let failed = false;
+
 if (broken.length > 0) {
+  failed = true;
   console.error(`\n❌ ${broken.length} unresolved anchor link(s):`);
   broken.forEach(anchor => console.error(`  - ${anchor.link} (in ${anchor.source}) — no matching target on /${anchor.page}`));
+}
+
+if (unresolvedMarkers.length > 0) {
+  failed = true;
+  console.error(`\n❌ ${unresolvedMarkers.length} unresolved credit marker(s) — no url-bearing contributor:`);
+  unresolvedMarkers.forEach(marker => console.error(`  - [[${marker.name}]] in works.ts release '${marker.id}'`));
+}
+
+if (failed) {
   console.error('');
   process.exit(1);
 }
 
-console.log('\n✅ All internal anchor links resolve!\n');
+console.log('\n✅ All anchor links and credit markers resolve!\n');
 process.exit(0);


### PR DESCRIPTION
## Description
The data-integrity item from the SEO/data audit. `renderCredits` silently renders an unresolved `[[Name]]` marker as plain text — so a typo or a missing/url-less contributor quietly drops the intended link with no error.

## Change
Extend `scripts/check-anchors.js` (already in the `build` chain) into a **content-integrity** check: every `[[Name]]` in a release's `credits` must resolve to a **url-bearing contributor** (mirroring `renderCredits`' `linked` map).

## Verified
- Current data is **clean** — all markers resolve.
- Proved it **catches** a bogus marker (injected `[[ZZZ_NOEXIST]]` → `❌ unresolved credit marker in release 'contraplacado'`, non-zero exit), then restored.

## Neutral
Build-time check only — no runtime, output, or visual change.