### PR TITLE
Add a mobile Lighthouse profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -152,6 +152,14 @@ jobs:
       # image weight are advisory (warn) in .lighthouserc.json.
       - name: Run Lighthouse CI
         run: npm run lighthouse
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+
+      # Mobile emulation (Moto G4 + slow 4G). CWV assertions are advisory (warn)
+      # so a variable CI runner never hard-fails on mobile timings; the desktop
+      # run keeps the deterministic gates (a11y, resource sizes, compression).
+      - name: Run Lighthouse CI (mobile)
+        run: npm run lighthouse:mobile
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 

--- a/.lighthouserc.mobile.json
+++ b/.lighthouserc.mobile.json
@@ -1,0 +1,29 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "url": [
+        "http://localhost/index.html",
+        "http://localhost/works.html",
+        "http://localhost/live.html",
+        "http://localhost/press.html",
+        "http://localhost/about.html",
+        "http://localhost/contact.html"
+      ],
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", {"minScore": 0.85}],
+        "first-contentful-paint": ["warn", {"maxNumericValue": 3000}],
+        "largest-contentful-paint": ["warn", {"maxNumericValue": 4000}],
+        "cumulative-layout-shift": ["warn", {"maxNumericValue": 0.1}],
+        "total-blocking-time": ["warn", {"maxNumericValue": 600}],
+        "speed-index": ["warn", {"maxNumericValue": 5800}]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
     "lighthouse": "lhci autorun",
+    "lighthouse:mobile": "lhci autorun --config=.lighthouserc.mobile.json",
     "fonts:subset": "node scripts/subset-fonts.mjs",
     "test:e2e:visual": "playwright test --grep @visual",
     "test:e2e:visual:update": "playwright test --grep @visual --update-snapshots",


### PR DESCRIPTION
## Description
The performance audit's last item: LHCI ran **desktop only**, so mobile Core Web Vitals regressions were never measured.

## Change
- **`.lighthouserc.mobile.json`** — default mobile emulation (Moto G4 + slow 4G + 4× CPU), same six URLs.
- **Second CI step** in the Lighthouse job (`npm run lighthouse:mobile`); job timeout 15→20m for the extra run.
- CWV/perf assertions are **advisory (warn)** — a variable CI runner should never hard-fail on mobile timings. The desktop run keeps the deterministic gates (a11y, resource sizes, compression), so nothing is duplicated.

## Verified
Ran locally (via arm64 Node): all six pages collected + asserted, **exit 0**. It immediately surfaced mobile `cumulative-layout-shift` and `performance` warnings the desktop run doesn't — the profile working as intended. Those warnings are a follow-up to investigate, not a blocker.

## Neutral
CI config only — no source, output, or visual change.