### PR TITLE
Comment sweep + palette refactor tidy-up from the A+ work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   # rather than standalone, so the checks execute exactly once per push.
   workflow_call:
 
-# Cancel in-progress runs when a new workflow with the same group name is triggered
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,29 +1,20 @@
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
-import pluginVue from 'eslint-plugin-vue';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import pluginVue from 'eslint-plugin-vue';
 import vueParser from 'vue-eslint-parser';
 
-// Shared across the TypeScript and Vue configs so the rule set lives in one place.
 const sharedPlugins = {
   '@typescript-eslint': tseslint,
   'simple-import-sort': simpleImportSort,
 };
 
 const baseRules = {
-  // Semicolons
   'semi': ['error', 'always'],
-
-  // Quotes
   'quotes': ['error', 'single', { avoidEscape: true }],
-
-  // Indentation
   'indent': ['error', 2, { SwitchCase: 1 }],
-
-  // Trailing commas in multiline
   'comma-dangle': ['error', 'always-multiline'],
 
-  // Spacing
   'object-curly-spacing': ['error', 'always'],
   'array-bracket-spacing': ['error', 'never'],
   'comma-spacing': ['error', { before: false, after: true }],
@@ -36,46 +27,33 @@ const baseRules = {
   'space-infix-ops': 'error',
   'keyword-spacing': ['error', { before: true, after: true }],
   'space-before-blocks': 'error',
-
-  // Arrow functions
   'arrow-spacing': ['error', { before: true, after: true }],
   'arrow-parens': ['error', 'as-needed'],
 
-  // Variable declarations
   'prefer-const': 'error',
   'no-var': 'error',
   'prefer-destructuring': ['error', {
     array: false,
     object: true,
   }],
-
-  // Template literals
   'prefer-template': 'error',
-
-  // Object shorthand
   'object-shorthand': ['error', 'always'],
-
-  // Modern JavaScript over legacy patterns
   'eqeqeq': ['error', 'always'],
   'prefer-object-spread': 'error',
   'no-array-constructor': 'error',
   'prefer-spread': 'error',
   'prefer-rest-params': 'error',
 
-  // Early returns
   'no-else-return': ['error', { allowElseIf: false }],
   'no-lonely-if': 'error',
 
-  // General formatting
   'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0 }],
   'eol-last': ['error', 'always'],
   'no-trailing-spaces': 'error',
 
-  // Import sorting
   'simple-import-sort/imports': 'error',
   'simple-import-sort/exports': 'error',
 
-  // TypeScript-specific rules (only rules that don't require type information)
   '@typescript-eslint/no-explicit-any': 'error',
   '@typescript-eslint/no-unused-vars': ['error', {
     argsIgnorePattern: '^_',
@@ -85,9 +63,7 @@ const baseRules = {
   '@typescript-eslint/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
   '@typescript-eslint/ban-ts-comment': 'error',
 
-  // Complexity ceilings — ratcheted just above today's real max so only growth
-  // trips them (source peaks at 19 in the palette key-dispatcher; a keymap
-  // refactor would let this ratchet back down).
+  // Ceilings sit just above the current source peak so only new growth trips them.
   complexity: ['error', 20],
   'max-depth': ['error', 4],
 };
@@ -115,8 +91,7 @@ const vueRules = {
   }],
 };
 
-// Rules that need type information. Scoped to the app source (src, excluding
-// tests), which is covered by tsconfig.json.
+// Scoped to src — co-located tests aren't in tsconfig.json, so type-aware rules would error there.
 const typeAwareRules = {
   '@typescript-eslint/prefer-nullish-coalescing': 'error',
   '@typescript-eslint/prefer-optional-chain': 'error',
@@ -152,8 +127,6 @@ export default [
     rules: baseRules,
   },
   {
-    // Type-aware rules for the app source (excludes co-located tests + helpers,
-    // which tsconfig.json does not include).
     files: ['src/**/*.ts'],
     ignores: ['src/**/*.test.ts', 'src/test-support/**', 'src/test-setup.ts'],
     languageOptions: {
@@ -183,9 +156,7 @@ export default [
     rules: typeAwareRules,
   },
   {
-    // Rules that guard source but are legitimate in tests: several throwaway
-    // components to exercise composables, non-null assertions on known-present
-    // fixtures/mocks, and complex arrange-heavy setup blocks.
+    // Relaxed for tests: throwaway components, non-null assertions on known fixtures, arrange-heavy setup.
     files: ['**/*.test.ts', '**/*.test.tsx'],
     rules: {
       'vue/one-component-per-file': 'off',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -64,7 +64,7 @@ const baseRules = {
   '@typescript-eslint/ban-ts-comment': 'error',
 
   // Ceilings sit just above the current source peak so only new growth trips them.
-  complexity: ['error', 20],
+  complexity: ['error', 15],
   'max-depth': ['error', 4],
 };
 

--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -14,9 +14,11 @@ const showHeaders = computed(() => query.value.trim() === '');
 const announcement = computed(() =>
   (isOpen.value ? `${results.value.length} result${results.value.length === 1 ? '' : 's'}` : ''));
 
+const optionId = (index: number): string => `command-palette-option-${index}`;
+
 watch(activeIndex, async () => {
   await nextTick();
-  document.getElementById(`command-palette-option-${activeIndex.value}`)?.scrollIntoView({ block: 'nearest' });
+  document.getElementById(optionId(activeIndex.value))?.scrollIntoView({ block: 'nearest' });
 });
 </script>
 
@@ -42,7 +44,7 @@ watch(activeIndex, async () => {
             role="combobox"
             aria-expanded="true"
             aria-controls="command-palette-listbox"
-            :aria-activedescendant="results.length ? `command-palette-option-${activeIndex}` : undefined"
+            :aria-activedescendant="results.length ? optionId(activeIndex) : undefined"
             aria-label="Search, navigate, or run a command"
             placeholder="Search, navigate, or run a command…"
             autocomplete="off"
@@ -68,7 +70,7 @@ watch(activeIndex, async () => {
                 {{ command.group }}
               </li>
               <li
-                :id="`command-palette-option-${index}`"
+                :id="optionId(index)"
                 class="command-palette__option"
                 :class="{ 'command-palette__option--active': index === activeIndex }"
                 role="option"

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -23,8 +23,6 @@ const emit = defineEmits<{
 
 const formattedDate = computed(() => formatEventDateRange(props.event.date, props.event.endDate));
 
-// Surfaced as a trailing icon link, not wrapping the title, since the title is
-// already a permalink anchor and anchors can't nest.
 const titleHref = computed(() => props.event.titleUrl ?? null);
 
 const titleHrefIsExternal = computed(() => /^https?:/i.test(titleHref.value ?? ''));

--- a/src/components/LightboxOverlay.vue
+++ b/src/components/LightboxOverlay.vue
@@ -49,8 +49,6 @@ const dialogLabel = computed(() => {
   return `${noun} viewer`;
 });
 
-// Move focus into the dialog on open and trap Tab within it, so keyboard users
-// can't reach the inert background behind the overlay.
 const dialogRef = ref<HTMLElement | null>(null);
 const { onKeydown } = useFocusTrap(dialogRef);
 

--- a/src/components/PlayerScreen.vue
+++ b/src/components/PlayerScreen.vue
@@ -19,8 +19,6 @@ const onSeek = (event: Event): void => {
 
 const trackLabel = (track: AudioTrack): string => (track.artist ? `${track.artist} — ${track.title}` : track.title);
 
-// role="dialog" aria-modal: trap Tab within the screen, restore focus to the
-// trigger on close, and lock background scroll — matching the palette/lightbox.
 const dialog = ref<HTMLElement | null>(null);
 const { onKeydown: trapTab } = useFocusTrap(dialog);
 const { lock, unlock } = useScrollLock();

--- a/src/components/ReleaseItem.test.ts
+++ b/src/components/ReleaseItem.test.ts
@@ -12,7 +12,6 @@ import ReleaseItem from './ReleaseItem.vue';
 const mountRelease = (release: Release, textOnly = false) =>
   mount(ReleaseItem, { props: { release, textOnly } });
 
-// A Bandcamp release with no native audio (collaboration/compilation) — keeps the embed.
 const bandcamp: Release = {
   id: 'bandcamp-only',
   title: 'ALTAR',
@@ -24,7 +23,6 @@ const bandcamp: Release = {
   credits: 'Music by Jerome Faria.',
 };
 
-// A solo/curated release with native audio in the manifest — gets the cover player + Listen links.
 const audioBacked: Release = {
   id: 'overlapse',
   title: 'Overlapse',
@@ -46,7 +44,6 @@ const external: Release = {
   credits: 'Music by Jerome Faria.',
 };
 
-// A single audio file whose display tracklist is split into timed movements.
 const chaptered: Release = {
   id: '2504',
   title: '2504',

--- a/src/components/ReleaseItem.vue
+++ b/src/components/ReleaseItem.vue
@@ -29,8 +29,6 @@ const emit = defineEmits<{
   'open-lightbox': [items: LightboxItem[], index: number];
 }>();
 
-// Collapsed accordion sections sit at zero height, defeating native
-// lazy-loading; defer cover loading until the section is first opened.
 const coverVisible = useAccordionVisibility();
 
 const coverErrored = ref(false);

--- a/src/components/ResponsivePicture.test.ts
+++ b/src/components/ResponsivePicture.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 import ResponsivePicture from './ResponsivePicture.vue';
 
-// A src present in the responsive-image manifest, so the srcset source renders.
 const MANIFEST_SRC = '/images/contraplacado.jpg';
 
 const mountPicture = (props: Record<string, unknown> = {}) =>

--- a/src/components/SiteHeader.test.ts
+++ b/src/components/SiteHeader.test.ts
@@ -94,7 +94,7 @@ describe('SiteHeader', () => {
   it('closes when a pointer interaction happens outside the menu', async () => {
     const { wrapper } = await mountHeader();
     await wrapper.get('.nav-toggle').trigger('click');
-    await nextTick();  // the outside-pointer listener binds on the next tick
+    await nextTick();
     expect(wrapper.find('.nav--open').exists()).toBe(true);
 
     document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }));

--- a/src/composables/useCommandPalette.ts
+++ b/src/composables/useCommandPalette.ts
@@ -49,7 +49,6 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
   const commands = buildCommands();
   const byId = new Map(commands.map(command => [command.id, command]));
 
-  // Reactive slices over the static registry: transport, plus every streamable release.
   const transportCommands = computed<Command[]>(() => playbackCommands());
   const audioCommands = computed<Command[]>(() => [...transportCommands.value, ...playReleaseCommands()]);
 
@@ -90,7 +89,6 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
       return [...transportCommands.value, ...recents, ...clear, ...navigation];
     }
 
-    // Cap the list: subsequence matching is permissive, so keep the best-ranked few.
     const recentsTail = recentCommands.value.length ? [clearRecentsCommand] : [];
     const searchable = [...commands, ...audioCommands.value, ...recentsTail];
     return fuzzyRank(query.value, searchable).slice(0, MAX_RESULTS);
@@ -118,7 +116,6 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
   };
 
   const remember = (id: string): void => {
-    // Main-nav routes always sit in Navigate, so they never take a Recent slot.
     if (PRIMARY_ROUTE_IDS.includes(id)) return;
 
     recentIds.value = [id, ...recentIds.value.filter(existing => existing !== id)].slice(0, RECENTS_MAX);
@@ -145,42 +142,27 @@ export const useCommandPalette = (): UseCommandPaletteReturn => {
     await router.push(command.to);
   };
 
-  const handleKeydown = (event: KeyboardEvent): void => {
-    const ctrl = event.ctrlKey;
+  const keyActions: Record<string, (event: KeyboardEvent) => void> = {
+    Tab: () => {},
+    Escape: () => close(),
+    'ctrl+c': () => close(),
+    ArrowDown: () => move(1),
+    'ctrl+j': () => move(1),
+    'ctrl+n': () => move(1),
+    ArrowUp: () => move(-1),
+    'ctrl+k': () => move(-1),
+    'ctrl+p': () => move(-1),
+    'ctrl+d': () => move(PAGE),
+    'ctrl+u': () => move(-PAGE),
+    Enter: event => void execute(activeIndex.value, event.metaKey || event.ctrlKey),
+  };
 
-    if (event.key === 'Tab') {
-      event.preventDefault();
-      return;
-    }
-    if (event.key === 'Escape' || (ctrl && event.key === 'c')) {
-      event.preventDefault();
-      close();
-      return;
-    }
-    if (event.key === 'ArrowDown' || (ctrl && (event.key === 'j' || event.key === 'n'))) {
-      event.preventDefault();
-      move(1);
-      return;
-    }
-    if (event.key === 'ArrowUp' || (ctrl && (event.key === 'k' || event.key === 'p'))) {
-      event.preventDefault();
-      move(-1);
-      return;
-    }
-    if (ctrl && event.key === 'd') {
-      event.preventDefault();
-      move(PAGE);
-      return;
-    }
-    if (ctrl && event.key === 'u') {
-      event.preventDefault();
-      move(-PAGE);
-      return;
-    }
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      void execute(activeIndex.value, event.metaKey || event.ctrlKey);
-    }
+  const handleKeydown = (event: KeyboardEvent): void => {
+    const action = keyActions[event.ctrlKey ? `ctrl+${event.key}` : event.key] ?? keyActions[event.key];
+    if (!action) return;
+
+    event.preventDefault();
+    action(event);
   };
 
   return { isOpen: paletteOpen, query, activeIndex, results, close, handleKeydown, execute };

--- a/src/composables/useFocusTrap.ts
+++ b/src/composables/useFocusTrap.ts
@@ -2,10 +2,6 @@ import type { Ref } from 'vue';
 
 const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), input:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
 
-// Keeps Tab focus within `containerRef` (WCAG 2.4.3) so keyboard users can't
-// reach the inert background behind a modal dialog. Returns the keydown handler
-// to bind on the dialog element; initial focus and restore stay with the caller,
-// which differ per overlay. Shared by the lightbox and the expanded player.
 export const useFocusTrap = (containerRef: Ref<HTMLElement | null>): { onKeydown: (event: KeyboardEvent) => void } => {
   const getFocusable = (): HTMLElement[] =>
     containerRef.value ? Array.from(containerRef.value.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)) : [];

--- a/src/composables/useLightbox.test.ts
+++ b/src/composables/useLightbox.test.ts
@@ -142,7 +142,7 @@ describe('useLightbox', () => {
       it('should not navigate past last item', () => {
         const wrapper = mount(createTestComponent());
 
-        wrapper.vm.openLightbox(mockImages, 2); // Last item
+        wrapper.vm.openLightbox(mockImages, 2);
         wrapper.vm.goToNext();
 
         expect(wrapper.vm.currentIndex).toBe(2);

--- a/src/composables/useLightbox.ts
+++ b/src/composables/useLightbox.ts
@@ -22,7 +22,6 @@ export const useLightbox = (): UseLightboxReturn => {
   const currentIndex = ref(0);
   const items = ref<LightboxItem[]>([]);
 
-  // Element focused before opening, restored on close (WCAG 2.4.3)
   let previouslyFocused: HTMLElement | null = null;
 
   const { lock, unlock } = useScrollLock();

--- a/src/composables/useOverlay.ts
+++ b/src/composables/useOverlay.ts
@@ -3,7 +3,6 @@ import { nextTick, onUnmounted, watch } from 'vue';
 
 import { useScrollLock } from './useScrollLock';
 
-// Focus capture/restore (WCAG 2.4.3) + scroll-lock shared by the keyboard overlays.
 export const useOverlay = (isOpen: Ref<boolean>, focusTarget: Ref<HTMLElement | null>): void => {
   const { lock, unlock } = useScrollLock();
 

--- a/src/composables/useOverlays.ts
+++ b/src/composables/useOverlays.ts
@@ -3,7 +3,7 @@ import { onMounted, onUnmounted, ref } from 'vue';
 export const paletteOpen = ref(false);
 export const helpOpen = ref(false);
 
-// Latches true on first use so the async component stays mounted (instant re-open).
+// Latches true on first use so the async component stays mounted.
 export const paletteMounted = ref(false);
 export const helpMounted = ref(false);
 

--- a/src/composables/usePlayer.ts
+++ b/src/composables/usePlayer.ts
@@ -5,8 +5,7 @@ import type { AudioTrack } from '@/types/audio';
 
 export type PlayerStatus = 'idle' | 'loading' | 'buffering' | 'playing' | 'paused' | 'ended' | 'error';
 
-// "Active" = the user has asked this track to play (already playing or on its way there);
-// "busy" narrows that to the not-yet-audible part, used for buffering affordances.
+// "Busy" narrows "active" to the not-yet-audible part, used for buffering affordances.
 const ACTIVE_STATUSES: PlayerStatus[] = ['playing', 'loading', 'buffering'];
 const BUSY_STATUSES: PlayerStatus[] = ['loading', 'buffering'];
 
@@ -144,8 +143,7 @@ export const play = async (tracks: AudioTrack[], startIndex = 0, context: PlayCo
   await load();
 };
 
-// Seek once the media can report its duration; the generation guard drops the
-// offset if the user has since jumped elsewhere.
+// The generation guard drops this offset if the user has since jumped to another track.
 const applyStartOffset = (gen: number, seconds: number): void => {
   if (!element || gen !== generation) return;
 
@@ -161,7 +159,6 @@ const applyStartOffset = (gen: number, seconds: number): void => {
   element.addEventListener('loadedmetadata', onReady);
 };
 
-// Start (or seek within) a track at a given offset — used for chaptered single-file releases.
 export const playFrom = async (tracks: AudioTrack[], seconds: number, context: PlayContext = {}): Promise<void> => {
   if (tracks.length === 0) return;
 

--- a/src/composables/useProseLinks.ts
+++ b/src/composables/useProseLinks.ts
@@ -1,9 +1,6 @@
 import { useRouter } from 'vue-router';
 
-// Internal links inside v-html prose are raw anchors, so a click triggers a full
-// page reload — which flashes the theme and unstyled content on the SSG page.
-// This routes those clicks through the SPA router instead. External, download,
-// new-tab, hash-only, and modifier/middle clicks are left to the browser.
+// Internal links in v-html prose are raw anchors — a click full-reloads and flashes the SSG theme; route them through the SPA router instead.
 export const useProseLinks = (): ((event: MouseEvent) => void) => {
   const router = useRouter();
 

--- a/src/composables/useReleasePlayback.test.ts
+++ b/src/composables/useReleasePlayback.test.ts
@@ -9,7 +9,6 @@ import { useReleasePlayback } from './useReleasePlayback';
 
 const music = { kind: 'music', mediums: ['Digital'], editions: [{ label: { text: 'BRØQN' } }], year: 2010 } as const;
 
-// '1714' has three audio tracks in the manifest — its display tracklist lines up 1:1.
 const aligned: Release = {
   id: '1714',
   title: '17:14',
@@ -17,7 +16,6 @@ const aligned: Release = {
   tracklist: [{ title: '8:58' }, { title: '2:58' }, { title: '5:18' }],
 };
 
-// '2504' is one audio file presented as five timed movements.
 const chaptered: Release = {
   id: '2504',
   title: '2504',

--- a/src/composables/useReleasePlayback.ts
+++ b/src/composables/useReleasePlayback.ts
@@ -5,7 +5,6 @@ import { getReleaseAudio } from '@/data/audio';
 import type { Release } from '@/types';
 import { canPlayRelease, playReleaseAt, releasePath } from '@/utils/releasePermalink';
 
-// All of a release item's playback behaviour — release-level, per-track, and chaptered single-file.
 export const useReleasePlayback = (releaseGetter: () => Release) => {
   const release = computed(releaseGetter);
   const { currentTrack, currentTime, status } = usePlayer();
@@ -16,7 +15,6 @@ export const useReleasePlayback = (releaseGetter: () => Release) => {
   const perTrackPlayable = computed(() =>
     playable.value && audioTracks.value.length === (release.value.tracklist?.length ?? 0));
 
-  // A single audio file whose display tracklist is split into timed movements (2504).
   const chaptered = computed(() =>
     playable.value
     && audioTracks.value.length === 1
@@ -29,7 +27,6 @@ export const useReleasePlayback = (releaseGetter: () => Release) => {
   const releaseActive = computed(() => releaseIsCurrent.value && isActiveStatus(status.value));
   const releaseBusy = computed(() => releaseIsCurrent.value && isBusyStatus(status.value));
 
-  // The movement currently under the playhead — the last one whose offset has passed.
   const currentChapterIndex = computed(() => {
     if (!chaptered.value || !releaseIsCurrent.value) return -1;
 
@@ -46,7 +43,6 @@ export const useReleasePlayback = (releaseGetter: () => Release) => {
 
   const isCurrentChapter = (index: number): boolean => chaptered.value && currentChapterIndex.value === index;
 
-  // The shareable path for a track: a 1-based index, or a time offset for chaptered single files.
   const trackHref = (index: number): string => {
     if (perTrackPlayable.value) return releasePath(release.value.id, { track: index + 1 });
     if (chaptered.value) return releasePath(release.value.id, { t: release.value.tracklist?.[index]?.start ?? 0 });

--- a/src/data/__fixtures__/credits.golden.ts
+++ b/src/data/__fixtures__/credits.golden.ts
@@ -1,5 +1,4 @@
-// Pre-migration credit HTML captured as the golden baseline that renderCredits must reproduce
-// byte-for-byte. Guards the contributors migration against dropped names or changed URLs.
+// Golden baseline that renderCredits must reproduce byte-for-byte.
 export const creditsGolden: Record<string, string> = {
   '1714': 'Music and artwork by Jerome Faria.',
   '2504': 'Music by Jerome Faria.',

--- a/src/data/commands.ts
+++ b/src/data/commands.ts
@@ -16,7 +16,6 @@ import { stripHtml } from '@/utils/stripHtml';
 
 import { pressQuotes } from './press';
 
-// Authored (not router-derived) so each has a title + keywords, incl. routes not in the nav.
 const routeCommands = (): Command[] => [
   { kind: 'navigate', id: 'nav:home', title: 'Home', keywords: ['start', 'index'], group: 'Navigate', to: '/' },
   { kind: 'navigate', id: 'nav:works', title: 'Works', keywords: ['discography', 'releases', 'music', 'albums'], group: 'Navigate', to: '/works' },
@@ -39,8 +38,6 @@ const sectionCommands = (): Command[] => [
   })),
 ];
 
-// Every named entity attached to a release's metadata — labels, catalog numbers,
-// collaborators, compilation, publisher, director, venue, mastered artist.
 const metaText = (meta: ReleaseMeta): string[] => {
   const out: string[] = [];
 
@@ -55,11 +52,9 @@ const metaText = (meta: ReleaseMeta): string[] => {
   return out.filter(Boolean);
 };
 
-// Every field is indexed word-by-word after stripping HTML, so a query matches a discrete
-// word rather than scattering across a passage or raw markup (e.g. URLs inside a note).
+// Indexed word-by-word after stripping HTML, so a query matches discrete words, not raw markup like URLs.
 const words = (text: string): string[] => stripHtml(text).split(' ').filter(Boolean);
 
-// Everyone attached to a show — collaborators, the rest of the bill, photographers, poster artists.
 const eventPeople = (event: LiveEvent): string[] => {
   const { setup } = event;
   const names: string[] = [];
@@ -76,7 +71,6 @@ const eventPeople = (event: LiveEvent): string[] => {
   return names.filter(Boolean);
 };
 
-// Each release deep-links to its entry; the accordion opens the owning section.
 // Engineering credits are skipped — they carry no in-page anchor (they link out or to a real entry).
 const releaseCommands = (): Command[] =>
   Object.values(worksData).flatMap(section =>
@@ -118,7 +112,6 @@ const pressCommands = (): Command[] =>
 
 const allReleases = (): Release[] => Object.values(worksData).flatMap(section => section.items);
 
-// One "Open '<release>' on <platform>" action per release that carries that link.
 const releaseLinkCommands = (platform: string, keyword: string, urlOf: (release: Release) => string | undefined): Command[] =>
   allReleases().flatMap(release => {
     const url = urlOf(release);
@@ -181,8 +174,7 @@ const actionCommands = (): Command[] => {
   return [...downloads, help, ...appearance, contact, ...socials, ...bandcamp, ...soundcloud];
 };
 
-// Transport for the active track — merged reactively in useCommandPalette, so it is
-// kept out of the static registry and returns nothing when no track is loaded.
+// Empty when no track is loaded; merged in reactively by useCommandPalette, not the static registry.
 export const playbackCommands = (): Command[] => {
   const { currentTrack, status, hasNext, hasPrevious, expanded, toggle, next, previous, expand, collapse, stop } = usePlayer();
   const track = currentTrack.value;

--- a/src/data/live.test.ts
+++ b/src/data/live.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import { liveEvents, liveYears, sortedLiveData } from './live';
 
-// Golden of each event's image alt text — must match src/data/live.ts, guards against drift.
 const IMAGE_ALT: Record<string, string> = {
   'showcase-casa-amarela': 'NOx performing at Showcase Casa Amarela, Cooperativa Mula, Barreiro, 2025',
   'fim-de-emissao-45': 'Jerome Faria performing at Fim de Emissão #45, Desterro, Lisbon, 2025',
@@ -46,7 +45,6 @@ describe('liveData image alts', () => {
 });
 
 describe('liveData posters', () => {
-  // Golden of each event's poster alt text — must match src/data/live.ts, guards against drift.
   const POSTERS: Record<string, { src: string; alt: string; artist?: { name: string; url?: string } }[]> = {
     'aragao-funchal': [
       {
@@ -107,7 +105,6 @@ describe('liveData posters', () => {
 });
 
 describe('liveData year grouping (derived)', () => {
-  // Golden grouping — groupEventsByYear must reproduce this.
   const YEARS = ['2026', '2025', '2024', '2022', '2021', '2015', '2013', '2012', '2011', '2010', '2009', '2008', '2007', '2006', '2005'];
   const EVENTS_BY_YEAR: Record<string, string[]> = {
     '2005': ['madeiradig-2005'],

--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -722,7 +722,6 @@ export const worksData: WorksData = {
   },
 };
 
-// Generate a Mixing & Mastering credit for each own release carrying an `engineering` field.
 const ownEngineeringCredits: Release[] = Object.values(worksData).flatMap(section =>
   section.items
     .filter((release): release is Release & { engineering: EngineeringRole[] } => Boolean(release.engineering?.length))

--- a/src/styles/_pages.scss
+++ b/src/styles/_pages.scss
@@ -379,7 +379,6 @@
       }
     }
 
-    // The command-palette cue reads as an ordinary link (a button, since it fires an action).
     .palette-cue {
       padding: 0;
       font: inherit;

--- a/src/styles/_player.scss
+++ b/src/styles/_player.scss
@@ -99,7 +99,6 @@
     animation: player-spin 0.8s linear infinite;
   }
 
-  // Full width so it wraps onto its own row on narrow screens; inline from md up.
   &__seek {
     display: flex;
     width: 100%;
@@ -147,7 +146,6 @@
       width: auto;
     }
 
-    // Inline at the far right of the row (out of the corner) once space allows.
     &__close {
       position: static;
       flex: 0 0 auto;

--- a/src/styles/_release.scss
+++ b/src/styles/_release.scss
@@ -270,7 +270,6 @@
         line-height: $line-height-base;
       }
 
-      // A shareable track permalink that reads as plain text until hovered/focused.
       .track-title-link {
         color: inherit;
         text-decoration: none;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -46,14 +46,12 @@ $nav-max-height: 20rem;
 $release-media-width: 200px;
 $loading-dot-size: 6px;
 
-// Global stacking order, named so new layers slot in without a z-index war.
-// (Local, within-component stacking keeps small literal values.)
+// Global stacking order; local within-component stacking keeps small literal values.
 $z-masthead: 100;
 $z-player: 900;
 $z-player-expanded: 950;
 $z-skip-link: 1000;
-$z-overlay: 10000; // palette, keyboard help, lightbox — full-screen modals
-
+$z-overlay: 10000;
 $transition-fast: 120ms ease;
 $transition-base: 300ms ease;
 $opacity-20: 0.2;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,10 +6,10 @@ export const TIMING = {
 
 // Keep in sync with _variables.scss
 export const LAYOUT = {
-  BREAKPOINT_MD: 768,           // $breakpoint-md
-  HEADER_HEIGHT_MOBILE: 57,     // $header-height-mobile
-  HEADER_HEIGHT_DESKTOP: 77,    // $header-height-desktop
-  SPACING_4: 16,                // $spacing-4
+  BREAKPOINT_MD: 768,
+  HEADER_HEIGHT_MOBILE: 57,
+  HEADER_HEIGHT_DESKTOP: 77,
+  SPACING_4: 16,
 } as const;
 
 export const ID_PREFIX = {

--- a/src/utils/externalizeLinks.ts
+++ b/src/utils/externalizeLinks.ts
@@ -1,5 +1,3 @@
-// Runs at render time (not a mounted directive) so target/rel land in the
-// pre-rendered SSG output, not only after hydration. Safe as a string rewrite
-// because the prose is our own trusted static data.
+// Runs at render time (not a mounted directive) so target/rel land in the pre-rendered SSG HTML.
 export const externalizeLinks = (html: string): string =>
   html.replace(/<a href="(https?:\/\/[^"]*)">/gi, '<a href="$1" target="_blank" rel="noopener noreferrer">');

--- a/src/utils/fuzzy.ts
+++ b/src/utils/fuzzy.ts
@@ -1,9 +1,5 @@
-// A dependency-free subsequence matcher. `query`'s characters must appear in
-// `target` in order; the score rewards contiguous runs and word starts, and
-// mildly favours earlier matches, so "sw" ranks "Solo Works" above "Password".
 const WORD_BOUNDARY = /[\s\-_/]/;
 
-// Lowercase and strip diacritics so "saude" matches "saúde" and "vitor" matches "Vítor".
 const normalize = (value: string): string =>
   value.toLowerCase().normalize('NFKD').replace(/[̀-ͯ]/g, '');
 
@@ -32,8 +28,6 @@ const scoreAgainst = (query: string, target: string): number | null => {
   return score;
 };
 
-// Deliberate entities (labels, people, tracks, aliases) outrank incidental prose
-// (descriptions, credits, quotes), and the visible title outranks both.
 const KEYWORD_WEIGHT = 0.6;
 const TEXT_WEIGHT = 0.2;
 
@@ -62,8 +56,6 @@ const bestScore = (query: string, item: Fuzzable): number | null => {
   return scores.length > 0 ? Math.max(...scores) : null;
 };
 
-// Every whitespace-separated token must match (fzf-style AND), so each extra word
-// narrows the results; the score is their sum.
 const scoreItem = (tokens: string[], item: Fuzzable): number | null => {
   let total = 0;
 
@@ -76,8 +68,7 @@ const scoreItem = (tokens: string[], item: Fuzzable): number | null => {
   return total;
 };
 
-// Rank `items` by fuzzy relevance to `query`, dropping non-matches. An empty
-// query returns the input unchanged, so callers can show a curated default set.
+// An empty query returns the input unchanged, so callers can show a curated default set.
 export const fuzzyRank = <T extends Fuzzable>(query: string, items: T[]): T[] => {
   const tokens = query.trim().split(/\s+/).filter(Boolean);
   if (tokens.length === 0) return items;

--- a/src/utils/releasePermalink.ts
+++ b/src/utils/releasePermalink.ts
@@ -28,8 +28,6 @@ export const buildReleaseContext = (release: Release): PlayContext => ({
 export const canPlayRelease = (releaseId: string): boolean =>
   audioPlayerEnabled.value && hasPlayableAudio(releaseId);
 
-// The one place that turns a release + optional {track (1-based), t (seconds)} into a play call,
-// shared by the works view (URL params) and the release item (movement / track clicks).
 export const playReleaseAt = (release: Release, { track, t }: ReleasePermalinkOptions = {}): void => {
   const tracks = getReleaseAudio(release.id);
   if (tracks.length === 0) return;
@@ -63,7 +61,6 @@ export const releaseHead = (release: Release): ReleaseHead => ({
   ...(hasCoverImage(release) ? { image: release.coverImage } : {}),
 });
 
-// The shareable path for a release, optionally pinned to a track (1-based) or a time offset.
 export const releasePath = (releaseId: string, { track, t }: ReleasePermalinkOptions = {}): string => {
   const params = new URLSearchParams();
 


### PR DESCRIPTION
## Description
Post-A+ tidy-up in two parts: a codebase-wide **comment sweep** removing restate-the-obvious / decision-narrating comments introduced during the ~20-PR A+ effort, plus two low-risk, well-tested **palette refactors** surfaced by the same audit. No user-facing behaviour change.

## Changes
### Comment sweep (commit 1)
- Removed **46** comments that restate a well-named construct, narrate a past decision, or label an obvious block — ESLint rule-group labels (`// Semicolons`, `// Quotes`…), function-header narration, fixture-variant labels, per-line SCSS-var labels.
- Trimmed **11** multi-line blocks to their single load-bearing gotcha.
- **Kept** genuine one-line gotchas: timing/race guards (usePlayer generation token, autoplay/AbortError branches), the two `{ immediate: true }` watcher notes, SSG-before-hydration, cached-image fast-path, cross-file sync invariants (constants.ts), timezone `parseLocalDate`, WCAG contrast/target-size provenance, and the enforced-vs-advisory CI notes.
- Net: 30 files, −114 comment lines.

### Palette refactors (commit 2)
- Replaced the eight-branch keydown cascade in `useCommandPalette` with a **combo-keyed action map** — the pattern `useLightbox` already uses — dropping the handler's cyclomatic complexity from ~19 to ~3. Behaviour-identical: the 338-line palette test suite passes unchanged (Tab-swallow and Enter new-tab flag preserved).
- Extracted a local `optionId()` helper for the three `aria-activedescendant`/`:id` sites that must stay in lockstep.
- With the palette no longer the source complexity peak (now **14**), ratcheted the ESLint `complexity` ceiling **20 → 15**.

## Testing
Automated only (no behaviour change to smoke):
- `npm run lint` — clean (eslint + stylelint, complexity ceiling 15)
- `npm run type-check` — clean
- `npx vitest run` — **635/635** pass
- coverage — Lines 99.28 / Stmts 98.09 / Funcs 96.54 / Branches 92.22 (all above thresholds)
- `npm run build` — SSG build + 41-URL sitemap OK

## Surfaced findings (NOT in this PR — your call)
The refactor audit flagged two more opportunities I deliberately did not bundle:
1. **`useFocusReturn()` extraction (MED).** The focus capture/restore dance is triplicated across `useOverlay`, `useLightbox`, and `PlayerScreen` (3rd-instance threshold met). Worth extracting, but it touches subtle user-visible focus behaviour — I'd want your manual a11y sign-off first, as with the #227 focus-trap work. The focus-*trap* divergence (palette/help swallow Tab; lightbox/player cycle) is defensible and I'd leave it.
2. **`PlayerBar`/`PlayerScreen` view duplication (MED, judgment call).** ~6 duplicated concerns (transport SVG paths, seek block, derived `isPlaying`) between the two surfaces — each individually a 2-site dup, below the strict 3rd-instance bar. A shared `<TransportControls>`/`<PlayerSeek>` would dedupe, only if the two surfaces aren't expected to diverge visually.

Also considered and NOT recommended: `useReleasePlayback` exposing `activateTrack` plus its constituents `playTrack`/`playChapter` with `ReleaseItem` re-deriving the branch — mild inappropriate-intimacy, but the two call paths have a real reason to differ. Below the bar; noting it was considered.