### PR TITLE
Extract useFocusReturn for the overlay focus-restore dance

### DIFF
--- a/src/components/PlayerScreen.vue
+++ b/src/components/PlayerScreen.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
+import { useFocusReturn } from '@/composables/useFocusReturn';
 import { useFocusTrap } from '@/composables/useFocusTrap';
 import { usePlayer } from '@/composables/usePlayer';
 import { useScrollLock } from '@/composables/useScrollLock';
@@ -22,8 +23,7 @@ const trackLabel = (track: AudioTrack): string => (track.artist ? `${track.artis
 const dialog = ref<HTMLElement | null>(null);
 const { onKeydown: trapTab } = useFocusTrap(dialog);
 const { lock, unlock } = useScrollLock();
-
-let previouslyFocused: HTMLElement | null = null;
+const { capture, restore } = useFocusReturn();
 
 const onKeydown = (event: KeyboardEvent): void => {
   if (event.key === 'Escape') {
@@ -35,14 +35,14 @@ const onKeydown = (event: KeyboardEvent): void => {
 };
 
 onMounted(() => {
-  previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  capture();
   lock();
   dialog.value?.focus();
 });
 
 onBeforeUnmount(() => {
   unlock();
-  previouslyFocused?.focus();
+  restore();
 });
 </script>
 

--- a/src/composables/useFocusReturn.test.ts
+++ b/src/composables/useFocusReturn.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useFocusReturn } from './useFocusReturn';
+
+describe('useFocusReturn', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('restores focus to the element active at capture time', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { capture, restore } = useFocusReturn();
+    capture();
+
+    const other = document.createElement('button');
+    document.body.appendChild(other);
+    other.focus();
+    expect(document.activeElement).toBe(other);
+
+    restore();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('is a no-op when nothing was captured', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { restore } = useFocusReturn();
+    expect(() => restore()).not.toThrow();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('captures null when no HTMLElement is focused, so restore does nothing', () => {
+    const { capture, restore } = useFocusReturn();
+
+    const activeElement = vi.spyOn(document, 'activeElement', 'get').mockReturnValue(null);
+    capture();
+    activeElement.mockRestore();
+
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    restore();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('clears the captured element after restoring', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { capture, restore } = useFocusReturn();
+    capture();
+
+    const other = document.createElement('button');
+    document.body.appendChild(other);
+    other.focus();
+    restore();
+    expect(document.activeElement).toBe(trigger);
+
+    other.focus();
+    restore();
+    expect(document.activeElement).toBe(other);
+  });
+});

--- a/src/composables/useFocusReturn.ts
+++ b/src/composables/useFocusReturn.ts
@@ -1,0 +1,19 @@
+export interface UseFocusReturn {
+  capture: () => void;
+  restore: () => void;
+}
+
+export const useFocusReturn = (): UseFocusReturn => {
+  let previouslyFocused: HTMLElement | null = null;
+
+  const capture = (): void => {
+    previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  };
+
+  const restore = (): void => {
+    previouslyFocused?.focus();
+    previouslyFocused = null;
+  };
+
+  return { capture, restore };
+};

--- a/src/composables/useLightbox.ts
+++ b/src/composables/useLightbox.ts
@@ -3,6 +3,7 @@ import { onMounted, onUnmounted, ref } from 'vue';
 
 import type { LightboxItem } from '@/types/lightbox';
 
+import { useFocusReturn } from './useFocusReturn';
 import { useScrollLock } from './useScrollLock';
 
 export interface UseLightboxReturn {
@@ -22,12 +23,11 @@ export const useLightbox = (): UseLightboxReturn => {
   const currentIndex = ref(0);
   const items = ref<LightboxItem[]>([]);
 
-  let previouslyFocused: HTMLElement | null = null;
-
   const { lock, unlock } = useScrollLock();
+  const { capture, restore } = useFocusReturn();
 
   const openLightbox = (allItems: LightboxItem[] = [], index = 0): void => {
-    previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    capture();
     items.value = allItems;
     currentIndex.value = index;
     updateCurrentItem(index);
@@ -41,8 +41,7 @@ export const useLightbox = (): UseLightboxReturn => {
     items.value = [];
     currentIndex.value = 0;
     unlock();
-    previouslyFocused?.focus();
-    previouslyFocused = null;
+    restore();
   };
 
   const updateCurrentItem = (index: number): void => {

--- a/src/composables/useOverlay.ts
+++ b/src/composables/useOverlay.ts
@@ -1,16 +1,16 @@
 import type { Ref } from 'vue';
 import { nextTick, onUnmounted, watch } from 'vue';
 
+import { useFocusReturn } from './useFocusReturn';
 import { useScrollLock } from './useScrollLock';
 
 export const useOverlay = (isOpen: Ref<boolean>, focusTarget: Ref<HTMLElement | null>): void => {
   const { lock, unlock } = useScrollLock();
-
-  let previouslyFocused: HTMLElement | null = null;
+  const { capture, restore } = useFocusReturn();
 
   watch(isOpen, async open => {
     if (open) {
-      previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      capture();
       lock();
       await nextTick();
       focusTarget.value?.focus();
@@ -18,8 +18,7 @@ export const useOverlay = (isOpen: Ref<boolean>, focusTarget: Ref<HTMLElement | 
     }
 
     unlock();
-    previouslyFocused?.focus();
-    previouslyFocused = null;
+    restore();
     // Immediate so a lazily-mounted overlay that is already open still initialises.
   }, { immediate: true });
 


### PR DESCRIPTION
## Description
Finding 1 from the A+ refactor audit (surfaced in #242). The focus **capture-on-open / restore-on-close** dance (WCAG 2.4.3 — a closed modal returns focus to whatever opened it) was reimplemented in three overlays, each inside a different lifecycle. This extracts a shared `useFocusReturn()` and delegates from all three.

> ⚠️ **Held for your manual a11y sign-off before merge** — focus behaviour is only partly provable by gates, and this is the same area as #227 (the PlayerScreen focus-trap), which we also gated on your review. See the smoke steps below.

## Changes
- New `src/composables/useFocusReturn.ts` — a `capture()` / `restore()` pair owning the `previouslyFocused` ref.
- Retrofitted the three call sites, each keeping its own lifecycle:
  - `useOverlay.ts` (reactive `watch`) — command palette + help
  - `useLightbox.ts` (imperative `open`/`close`)
  - `PlayerScreen.vue` (`onMounted`/`onBeforeUnmount`)
- Meets the 3rd-instance extraction threshold, and mirrors the already-shared `useScrollLock`.
- **Scope:** only the capture/restore is shared — no `useDialog` mega-composable (the three lifecycles genuinely differ). The focus-*trap* (Tab-cycling) is untouched: palette/help swallow Tab by design, lightbox/player cycle via `useFocusTrap`. That divergence is intentional.

## Testing
- `npm run lint` / `type-check` — clean
- `npx vitest run` — **639/639** pass (4 new `useFocusReturn` tests: restore-to-trigger, no-op when uncaptured, null-capture branch, clears-after-restore)
- coverage — above all thresholds (branches 92.43)
- `npm run build` — OK

### Manual a11y smoke (please verify)
For each overlay: with the keyboard, focus a trigger, open the overlay, then close it (Esc) — focus must return to the **exact trigger**, not the top of the page.
1. **Command palette** — `⌘K` from a focused link → Esc → focus returns to that link.
2. **Lightbox** — Tab to a gallery thumbnail, Enter to open → Esc → focus returns to the thumbnail.
3. **Expanded player** — Tab to the player bar's expand control, open the now-playing screen → close → focus returns to the expand control.