### PR TITLE
Extract TransportControls + PlayerSeek from the player surfaces

### DIFF
--- a/src/components/PlayerBar.test.ts
+++ b/src/components/PlayerBar.test.ts
@@ -36,19 +36,19 @@ describe('PlayerBar', () => {
     const wrapper = await mounted();
 
     expect(wrapper.find('.player-bar__title').text()).toBe('One');
-    expect(wrapper.findAll('.player-bar__button')).toHaveLength(3);
+    expect(wrapper.findAll('.transport-controls__button')).toHaveLength(3);
     expect(wrapper.find('input[type="range"]').attributes('aria-label')).toContain('One');
-    expect(wrapper.findAll('.player-bar__time')[1].text()).toBe('1:40');
+    expect(wrapper.findAll('.player-seek__time')[1].text()).toBe('1:40');
   });
 
   it('shows a spinner while busy and hides it once playing', async () => {
     await player.play(TRACKS);
     const wrapper = await mounted();
-    expect(wrapper.find('.player-bar__spinner').exists()).toBe(true);
+    expect(wrapper.find('.transport-controls__spinner').exists()).toBe(true);
 
     player.getMediaElement().dispatchEvent(new Event('playing'));
     await flushPromises();
-    expect(wrapper.find('.player-bar__spinner').exists()).toBe(false);
+    expect(wrapper.find('.transport-controls__spinner').exists()).toBe(false);
   });
 
   it('announces playback state in the live region', async () => {
@@ -67,7 +67,7 @@ describe('PlayerBar', () => {
     player.getMediaElement().dispatchEvent(new Event('playing'));
     await flushPromises();
 
-    await wrapper.findAll('.player-bar__button')[1].trigger('click');
+    await wrapper.findAll('.transport-controls__button')[1].trigger('click');
     expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
   });
 
@@ -75,7 +75,7 @@ describe('PlayerBar', () => {
     await player.play(TRACKS, 0);
     const wrapper = await mounted();
 
-    await wrapper.findAll('.player-bar__button')[2].trigger('click');
+    await wrapper.findAll('.transport-controls__button')[2].trigger('click');
     await flushPromises();
     expect(wrapper.find('.player-bar__title').text()).toBe('Two');
   });
@@ -85,13 +85,13 @@ describe('PlayerBar', () => {
     const wrapper = await mounted();
 
     await wrapper.find('input[type="range"]').setValue(50);
-    expect(wrapper.findAll('.player-bar__time')[0].text()).toBe('0:50');
+    expect(wrapper.findAll('.player-seek__time')[0].text()).toBe('0:50');
   });
 
   it('disables previous at the queue head and next at the tail', async () => {
     await player.play(TRACKS, 1);
     const wrapper = await mounted();
-    const [previous, , next] = wrapper.findAll('.player-bar__button');
+    const [previous, , next] = wrapper.findAll('.transport-controls__button');
 
     expect(next.attributes('disabled')).toBeDefined();
     expect(previous.attributes('disabled')).toBeUndefined();

--- a/src/components/PlayerBar.vue
+++ b/src/components/PlayerBar.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+import PlayerSeek from '@/components/PlayerSeek.vue';
+import TransportControls from '@/components/TransportControls.vue';
 import { usePlayer } from '@/composables/usePlayer';
-import { formatTime } from '@/utils/formatTime';
 
 const { status, currentTrack, currentTime, duration, error, hasNext, hasPrevious, toggle, next, previous, seek, expand, stop } =
   usePlayer();
@@ -18,10 +19,6 @@ const statusMessage = computed(() => {
 
   return `${verb}: ${currentTrack.value.title}`;
 });
-
-const onSeek = (event: Event): void => {
-  seek(Number((event.target as HTMLInputElement).value));
-};
 </script>
 
 <template>
@@ -40,79 +37,23 @@ const onSeek = (event: Event): void => {
       {{ currentTrack.title }}
     </button>
 
-    <div class="player-bar__controls">
-      <button
-        type="button"
-        class="player-bar__button"
-        :disabled="!hasPrevious && currentTime < 3"
-        aria-label="Previous track"
-        @click="previous"
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6 6h2v12H6zm3.5 6 8.5 6V6z" /></svg>
-      </button>
+    <TransportControls
+      :playing="isPlaying"
+      :busy="isBusy"
+      :has-previous="hasPrevious"
+      :has-next="hasNext"
+      :current-time="currentTime"
+      @previous="previous"
+      @toggle="toggle"
+      @next="next"
+    />
 
-      <button
-        type="button"
-        class="player-bar__button player-bar__button--primary"
-        :aria-label="isPlaying ? 'Pause' : 'Play'"
-        @click="toggle"
-      >
-        <svg
-          v-if="isBusy"
-          class="player-bar__spinner"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        ><circle
-          cx="12"
-          cy="12"
-          r="9"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-dasharray="44 20"
-          stroke-linecap="round"
-        /></svg>
-        <svg
-          v-else-if="isPlaying"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        ><path fill="currentColor" d="M6 5h4v14H6zm8 0h4v14h-4z" /></svg>
-        <svg
-          v-else
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        ><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
-      </button>
-
-      <button
-        type="button"
-        class="player-bar__button"
-        :disabled="!hasNext"
-        aria-label="Next track"
-        @click="next"
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M16 6h2v12h-2zM6 18l8.5-6L6 6z" /></svg>
-      </button>
-    </div>
-
-    <div class="player-bar__seek">
-      <span class="player-bar__time">{{ formatTime(currentTime) }}</span>
-      <input
-        class="player-bar__slider"
-        type="range"
-        min="0"
-        :max="duration || 0"
-        step="1"
-        :value="currentTime"
-        :aria-label="`Seek within ${currentTrack.title}`"
-        :aria-valuetext="`${formatTime(currentTime)} of ${formatTime(duration)}`"
-        @input="onSeek"
-      >
-      <span class="player-bar__time">{{ formatTime(duration) }}</span>
-    </div>
+    <PlayerSeek
+      :current-time="currentTime"
+      :duration="duration"
+      :label="`Seek within ${currentTrack.title}`"
+      @seek="seek"
+    />
 
     <button
       type="button"

--- a/src/components/PlayerScreen.test.ts
+++ b/src/components/PlayerScreen.test.ts
@@ -58,7 +58,7 @@ describe('PlayerScreen', () => {
   it('drives playback from the large controls and swaps to the pause icon while playing', async () => {
     await player.play(TRACKS, 0);
     const wrapper = await mounted();
-    const buttons = wrapper.findAll('.player-screen__button');
+    const buttons = wrapper.findAll('.transport-controls__button');
 
     await buttons[2].trigger('click');
     await flushPromises();
@@ -81,7 +81,7 @@ describe('PlayerScreen', () => {
     const wrapper = await mounted();
 
     expect(wrapper.find('.player-screen__queue').exists()).toBe(false);
-    const buttons = wrapper.findAll('.player-screen__button');
+    const buttons = wrapper.findAll('.transport-controls__button');
     expect(buttons[0].attributes('disabled')).toBeDefined();
     expect(buttons[2].attributes('disabled')).toBeDefined();
   });

--- a/src/components/PlayerScreen.vue
+++ b/src/components/PlayerScreen.vue
@@ -1,22 +1,20 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
+import PlayerSeek from '@/components/PlayerSeek.vue';
+import TransportControls from '@/components/TransportControls.vue';
 import { useFocusReturn } from '@/composables/useFocusReturn';
 import { useFocusTrap } from '@/composables/useFocusTrap';
 import { usePlayer } from '@/composables/usePlayer';
 import { useScrollLock } from '@/composables/useScrollLock';
 import type { AudioTrack } from '@/types/audio';
-import { formatTime } from '@/utils/formatTime';
 
 const { status, currentTrack, queue, currentTime, duration, context, hasNext, hasPrevious, toggle, next, previous, seek, select, collapse } =
   usePlayer();
 
 const isPlaying = computed(() => status.value === 'playing');
+const isBusy = computed(() => status.value === 'loading' || status.value === 'buffering');
 const currentIndex = computed(() => queue.value.findIndex(track => track.key === currentTrack.value?.key));
-
-const onSeek = (event: Event): void => {
-  seek(Number((event.target as HTMLInputElement).value));
-};
 
 const trackLabel = (track: AudioTrack): string => (track.artist ? `${track.artist} — ${track.title}` : track.title);
 
@@ -88,63 +86,23 @@ onBeforeUnmount(() => {
       </p>
     </div>
 
-    <div class="player-screen__seek">
-      <span class="player-screen__time">{{ formatTime(currentTime) }}</span>
-      <input
-        class="player-screen__slider"
-        type="range"
-        min="0"
-        :max="duration || 0"
-        step="1"
-        :value="currentTime"
-        aria-label="Seek"
-        :aria-valuetext="`${formatTime(currentTime)} of ${formatTime(duration)}`"
-        @input="onSeek"
-      >
-      <span class="player-screen__time">{{ formatTime(duration) }}</span>
-    </div>
+    <PlayerSeek
+      :current-time="currentTime"
+      :duration="duration"
+      label="Seek"
+      @seek="seek"
+    />
 
-    <div class="player-screen__controls">
-      <button
-        type="button"
-        class="player-screen__button"
-        :disabled="!hasPrevious && currentTime < 3"
-        aria-label="Previous track"
-        @click="previous"
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6 6h2v12H6zm3.5 6 8.5 6V6z" /></svg>
-      </button>
-
-      <button
-        type="button"
-        class="player-screen__button player-screen__button--primary"
-        :aria-label="isPlaying ? 'Pause' : 'Play'"
-        @click="toggle"
-      >
-        <svg
-          v-if="isPlaying"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        ><path fill="currentColor" d="M6 5h4v14H6zm8 0h4v14h-4z" /></svg>
-        <svg
-          v-else
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        ><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
-      </button>
-
-      <button
-        type="button"
-        class="player-screen__button"
-        :disabled="!hasNext"
-        aria-label="Next track"
-        @click="next"
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M16 6h2v12h-2zM6 18l8.5-6L6 6z" /></svg>
-      </button>
-    </div>
+    <TransportControls
+      :playing="isPlaying"
+      :busy="isBusy"
+      :has-previous="hasPrevious"
+      :has-next="hasNext"
+      :current-time="currentTime"
+      @previous="previous"
+      @toggle="toggle"
+      @next="next"
+    />
 
     <ol
       v-if="queue.length > 1"

--- a/src/components/PlayerSeek.test.ts
+++ b/src/components/PlayerSeek.test.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import PlayerSeek from './PlayerSeek.vue';
+
+const props = {
+  currentTime: 50,
+  duration: 100,
+  label: 'Seek within One',
+};
+
+describe('PlayerSeek', () => {
+  it('renders the elapsed and total time', () => {
+    const wrapper = mount(PlayerSeek, { props });
+    const times = wrapper.findAll('.player-seek__time');
+
+    expect(times[0].text()).toBe('0:50');
+    expect(times[1].text()).toBe('1:40');
+  });
+
+  it('wires the slider to the current time and duration', () => {
+    const slider = mount(PlayerSeek, { props }).find('input[type="range"]');
+
+    expect(slider.attributes('max')).toBe('100');
+    expect((slider.element as HTMLInputElement).value).toBe('50');
+    expect(slider.attributes('aria-label')).toBe('Seek within One');
+    expect(slider.attributes('aria-valuetext')).toBe('0:50 of 1:40');
+  });
+
+  it('falls back to a zero range before the duration is known', () => {
+    const slider = mount(PlayerSeek, { props: { ...props, currentTime: 0, duration: 0 } }).find('input[type="range"]');
+
+    expect(slider.attributes('max')).toBe('0');
+    expect(slider.attributes('aria-valuetext')).toBe('0:00 of 0:00');
+  });
+
+  it('emits the numeric seek value on input', async () => {
+    const wrapper = mount(PlayerSeek, { props });
+
+    await wrapper.find('input[type="range"]').setValue(75);
+
+    expect(wrapper.emitted('seek')).toEqual([[75]]);
+  });
+});

--- a/src/components/PlayerSeek.vue
+++ b/src/components/PlayerSeek.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { formatTime } from '@/utils/formatTime';
+
+defineProps<{
+  currentTime: number;
+  duration: number;
+  label: string;
+}>();
+
+const emit = defineEmits<{
+  seek: [value: number];
+}>();
+
+const onInput = (event: Event): void => {
+  emit('seek', Number((event.target as HTMLInputElement).value));
+};
+</script>
+
+<template>
+  <div class="player-seek">
+    <span class="player-seek__time">{{ formatTime(currentTime) }}</span>
+    <input
+      class="player-seek__slider"
+      type="range"
+      min="0"
+      :max="duration || 0"
+      step="1"
+      :value="currentTime"
+      :aria-label="label"
+      :aria-valuetext="`${formatTime(currentTime)} of ${formatTime(duration)}`"
+      @input="onInput"
+    >
+    <span class="player-seek__time">{{ formatTime(duration) }}</span>
+  </div>
+</template>

--- a/src/components/TransportControls.test.ts
+++ b/src/components/TransportControls.test.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import TransportControls from './TransportControls.vue';
+
+const props = {
+  playing: false,
+  hasPrevious: true,
+  hasNext: true,
+  currentTime: 0,
+};
+
+describe('TransportControls', () => {
+  it('renders previous, primary, and next controls', () => {
+    const wrapper = mount(TransportControls, { props });
+    const buttons = wrapper.findAll('.transport-controls__button');
+
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0].attributes('aria-label')).toBe('Previous track');
+    expect(buttons[1].attributes('aria-label')).toBe('Play');
+    expect(buttons[2].attributes('aria-label')).toBe('Next track');
+  });
+
+  it('labels the primary control Pause while playing', () => {
+    const wrapper = mount(TransportControls, { props: { ...props, playing: true } });
+    expect(wrapper.findAll('.transport-controls__button')[1].attributes('aria-label')).toBe('Pause');
+  });
+
+  it('shows only the spinner while busy', () => {
+    const wrapper = mount(TransportControls, { props: { ...props, busy: true } });
+    expect(wrapper.find('.transport-controls__spinner').exists()).toBe(true);
+    expect(wrapper.findAll('.transport-controls__button')[1].findAll('path')).toHaveLength(0);
+  });
+
+  it('disables previous only at the queue head within the first three seconds', () => {
+    const head = mount(TransportControls, { props: { ...props, hasPrevious: false, currentTime: 0 } });
+    expect(head.findAll('.transport-controls__button')[0].attributes('disabled')).toBeDefined();
+
+    const restart = mount(TransportControls, { props: { ...props, hasPrevious: false, currentTime: 5 } });
+    expect(restart.findAll('.transport-controls__button')[0].attributes('disabled')).toBeUndefined();
+  });
+
+  it('disables next at the queue tail', () => {
+    const wrapper = mount(TransportControls, { props: { ...props, hasNext: false } });
+    expect(wrapper.findAll('.transport-controls__button')[2].attributes('disabled')).toBeDefined();
+  });
+
+  it('emits previous, toggle, and next on click', async () => {
+    const wrapper = mount(TransportControls, { props });
+    const buttons = wrapper.findAll('.transport-controls__button');
+
+    await buttons[0].trigger('click');
+    await buttons[1].trigger('click');
+    await buttons[2].trigger('click');
+
+    expect(wrapper.emitted('previous')).toHaveLength(1);
+    expect(wrapper.emitted('toggle')).toHaveLength(1);
+    expect(wrapper.emitted('next')).toHaveLength(1);
+  });
+});

--- a/src/components/TransportControls.vue
+++ b/src/components/TransportControls.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+  playing: boolean;
+  hasPrevious: boolean;
+  hasNext: boolean;
+  currentTime: number;
+  busy?: boolean;
+}>(), { busy: false });
+
+defineEmits<{
+  previous: [];
+  toggle: [];
+  next: [];
+}>();
+</script>
+
+<template>
+  <div class="transport-controls">
+    <button
+      type="button"
+      class="transport-controls__button"
+      :disabled="!hasPrevious && currentTime < 3"
+      aria-label="Previous track"
+      @click="$emit('previous')"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6 6h2v12H6zm3.5 6 8.5 6V6z" /></svg>
+    </button>
+
+    <button
+      type="button"
+      class="transport-controls__button transport-controls__button--primary"
+      :aria-label="playing ? 'Pause' : 'Play'"
+      @click="$emit('toggle')"
+    >
+      <svg
+        v-if="busy"
+        class="transport-controls__spinner"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        focusable="false"
+      ><circle
+        cx="12"
+        cy="12"
+        r="9"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-dasharray="44 20"
+        stroke-linecap="round"
+      /></svg>
+      <svg
+        v-else-if="playing"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        focusable="false"
+      ><path fill="currentColor" d="M6 5h4v14H6zm8 0h4v14h-4z" /></svg>
+      <svg
+        v-else
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        focusable="false"
+      ><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
+    </button>
+
+    <button
+      type="button"
+      class="transport-controls__button"
+      :disabled="!hasNext"
+      aria-label="Next track"
+      @click="$emit('next')"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M16 6h2v12h-2zM6 18l8.5-6L6 6z" /></svg>
+    </button>
+  </div>
+</template>

--- a/src/styles/_player.scss
+++ b/src/styles/_player.scss
@@ -57,67 +57,8 @@
     }
   }
 
-  &__controls {
-    display: flex;
+  .transport-controls {
     flex: 0 0 auto;
-    gap: $spacing-2;
-    align-items: center;
-    justify-content: center;
-  }
-
-  &__button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2.25rem;
-    height: 2.25rem;
-    padding: 0;
-    color: var(--color-text);
-    cursor: pointer;
-    background: none;
-    border: none;
-    border-radius: 50%;
-    transition: color $transition-fast, background-color $transition-fast;
-
-    svg {
-      width: 1.5rem;
-      height: 1.5rem;
-    }
-
-    &:hover:not(:disabled) {
-      background-color: var(--color-border);
-    }
-
-    &:disabled {
-      color: var(--color-text-muted);
-      cursor: default;
-      opacity: 0.5;
-    }
-  }
-
-  &__spinner {
-    animation: player-spin 0.8s linear infinite;
-  }
-
-  &__seek {
-    display: flex;
-    width: 100%;
-    gap: $spacing-3;
-    align-items: center;
-  }
-
-  &__time {
-    flex: 0 0 auto;
-    font-size: 0.85rem;
-    color: var(--color-text-muted);
-    font-variant-numeric: tabular-nums;
-  }
-
-  &__slider {
-    flex: 1 1 auto;
-    width: 100%;
-    cursor: pointer;
-    accent-color: var(--color-text);
   }
 
   // Visually hidden — a polite live region announcing playback state to screen readers.
@@ -141,7 +82,7 @@
       text-align: left;
     }
 
-    &__seek {
+    .player-seek {
       flex: 1 1 auto;
       width: auto;
     }
@@ -212,6 +153,74 @@
   }
 }
 
+.transport-controls {
+  display: flex;
+  gap: var(--transport-gap, #{$spacing-2});
+  align-items: center;
+  justify-content: center;
+
+  &__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--transport-button-size, 2.25rem);
+    height: var(--transport-button-size, 2.25rem);
+    padding: 0;
+    color: var(--color-text);
+    cursor: pointer;
+    background: none;
+    border: none;
+    border-radius: 50%;
+    transition: color $transition-fast, background-color $transition-fast;
+
+    svg {
+      width: var(--transport-icon-size, 1.5rem);
+      height: var(--transport-icon-size, 1.5rem);
+    }
+
+    &--primary svg {
+      width: var(--transport-primary-icon-size, var(--transport-icon-size, 1.5rem));
+      height: var(--transport-primary-icon-size, var(--transport-icon-size, 1.5rem));
+    }
+
+    &:hover:not(:disabled) {
+      background-color: var(--color-border);
+    }
+
+    &:disabled {
+      color: var(--color-text-muted);
+      cursor: default;
+      opacity: 0.5;
+    }
+  }
+
+  &__spinner {
+    animation: player-spin 0.8s linear infinite;
+  }
+}
+
+.player-seek {
+  display: flex;
+  gap: $spacing-3;
+  align-items: center;
+  width: 100%;
+  max-width: var(--player-seek-max-width, none);
+
+  &__time {
+    flex: 0 0 auto;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__slider {
+    flex: 1 1 auto;
+    width: 100%;
+    cursor: pointer;
+    accent-color: var(--color-text);
+  }
+}
+
 @keyframes player-spin {
   to {
     transform: rotate(360deg);
@@ -219,7 +228,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .player-bar__spinner,
+  .transport-controls__spinner,
   .release-cover__spinner {
     animation: none;
   }
@@ -253,6 +262,12 @@
   overflow-y: auto;
   color: var(--color-text);
   background-color: var(--color-bg);
+
+  --transport-gap: #{$spacing-6};
+  --transport-button-size: 3rem;
+  --transport-icon-size: 2rem;
+  --transport-primary-icon-size: 2.75rem;
+  --player-seek-max-width: 30rem;
 
   &__collapse {
     display: inline-flex;
@@ -312,70 +327,6 @@
     color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: $letter-spacing-wide;
-  }
-
-  &__seek {
-    display: flex;
-    gap: $spacing-3;
-    align-items: center;
-    width: 100%;
-    max-width: 30rem;
-  }
-
-  &__time {
-    flex: 0 0 auto;
-    font-size: 0.85rem;
-    color: var(--color-text-muted);
-    font-variant-numeric: tabular-nums;
-  }
-
-  &__slider {
-    flex: 1 1 auto;
-    width: 100%;
-    cursor: pointer;
-    accent-color: var(--color-text);
-  }
-
-  &__controls {
-    display: flex;
-    gap: $spacing-6;
-    align-items: center;
-    justify-content: center;
-  }
-
-  &__button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 3rem;
-    height: 3rem;
-    padding: 0;
-    color: var(--color-text);
-    cursor: pointer;
-    background: none;
-    border: none;
-    border-radius: 50%;
-    transition: background-color $transition-fast;
-
-    svg {
-      width: 2rem;
-      height: 2rem;
-    }
-
-    &--primary svg {
-      width: 2.75rem;
-      height: 2.75rem;
-    }
-
-    &:hover:not(:disabled) {
-      background-color: var(--color-border);
-    }
-
-    &:disabled {
-      color: var(--color-text-muted);
-      cursor: default;
-      opacity: 0.5;
-    }
   }
 
   &__queue {


### PR DESCRIPTION
## Description
Finding 2 from the A+ refactor audit (surfaced in #242). `PlayerBar` (docked) and `PlayerScreen` (expanded) are two views of the one `usePlayer` singleton, and they duplicated a cluster of markup and state. This extracts two shared child components.

> Held for your review — it carries one **deliberate visual change** (see below).

## Changes
- New **`TransportControls.vue`** — prev / play-pause / next, the four transport SVG paths, the busy-spinner state, and the `!hasPrevious && currentTime < 3` prev-disabled logic (previously duplicated verbatim in both files).
- New **`PlayerSeek.vue`** — the range input + elapsed/total `formatTime` labels + `aria-valuetext`, emitting a numeric `seek`.
- `PlayerBar.vue` / `PlayerScreen.vue` now render both; each drops its duplicated markup, its `onSeek` handler, and its `formatTime` import.
- **Sizing via CSS custom properties, not variant props** — `.transport-controls` / `.player-seek` read `--transport-*` / `--player-seek-max-width`; the compact bar uses the base fallbacks, `.player-screen` sets the larger values. The components stay context-agnostic (no `variant` prop).

### The one deliberate visual change
The bar's play button had a third **loading-spinner** state that the expanded screen lacked. The shared `TransportControls` renders it whenever `busy`, so **the expanded screen now shows the spinner too** — a small consistency fix, not a pure refactor. It only appears mid-load of the expanded view, so it isn't in any visual-regression snapshot (VR covers static routes, not a busy expanded player) — VR should stay green.

## Testing
- `npm run lint` / `type-check` — clean
- `npx vitest run` — **645/645** (9 new tests across `TransportControls` + `PlayerSeek`; the two player suites updated for the moved selectors and still green)
- coverage — above all thresholds
- `npm run build` — OK

### Manual smoke (please verify the spinner change)
1. Play a release, expand the player → transport + seek look and behave exactly as before.
2. On a slow connection (or DevTools throttling), open the expanded view while a track is still loading → the play button shows the **loading spinner** (new — matches the docked bar).

## Note on sequencing
Independent of #244 (`useFocusReturn`), but both touch `PlayerScreen.vue` in different regions (that PR the focus lifecycle, this one the template + `isBusy`) — they auto-merge; whichever lands second may need a trivial rebase.