### PR TITLE
Swipe down to collapse the expanded player (mobile)

### DIFF
--- a/src/components/PlayerScreen.test.ts
+++ b/src/components/PlayerScreen.test.ts
@@ -6,6 +6,14 @@ const TRACKS = [
   { key: 'x/2.m4a', title: 'Two', duration: 200 },
 ];
 
+const swipeTouch = (type: 'touchstart' | 'touchend', clientX: number, clientY: number): TouchEvent => {
+  const event = new Event(type) as TouchEvent;
+  Object.defineProperty(event, type === 'touchstart' ? 'touches' : 'changedTouches', {
+    value: [{ clientX, clientY, identifier: 0 } as Touch],
+  });
+  return event;
+};
+
 type PlayerModule = typeof import('@/composables/usePlayer');
 
 describe('PlayerScreen', () => {
@@ -97,6 +105,39 @@ describe('PlayerScreen', () => {
     player.expand();
     await wrapper.trigger('keydown', { key: 'Escape' });
     expect(player.usePlayer().expanded.value).toBe(false);
+  });
+
+  it('collapses on a fast downward swipe from the top of the sheet', async () => {
+    await player.play(TRACKS);
+    player.expand();
+    const wrapper = await mounted();
+    const root = wrapper.get('.player-screen').element;
+
+    const dateNow = vi.spyOn(Date, 'now');
+    dateNow.mockReturnValueOnce(1000);
+    root.dispatchEvent(swipeTouch('touchstart', 200, 100));
+    dateNow.mockReturnValueOnce(1200);
+    root.dispatchEvent(swipeTouch('touchend', 200, 220));
+    dateNow.mockRestore();
+
+    expect(player.usePlayer().expanded.value).toBe(false);
+  });
+
+  it('ignores the swipe when the sheet is scrolled down', async () => {
+    await player.play(TRACKS);
+    player.expand();
+    const wrapper = await mounted();
+    const root = wrapper.get('.player-screen').element;
+    Object.defineProperty(root, 'scrollTop', { configurable: true, value: 120 });
+
+    const dateNow = vi.spyOn(Date, 'now');
+    dateNow.mockReturnValueOnce(1000);
+    root.dispatchEvent(swipeTouch('touchstart', 200, 100));
+    dateNow.mockReturnValueOnce(1200);
+    root.dispatchEvent(swipeTouch('touchend', 200, 220));
+    dateNow.mockRestore();
+
+    expect(player.usePlayer().expanded.value).toBe(true);
   });
 
   it('restores focus to the trigger when it closes', async () => {

--- a/src/components/PlayerScreen.vue
+++ b/src/components/PlayerScreen.vue
@@ -7,6 +7,7 @@ import { useFocusReturn } from '@/composables/useFocusReturn';
 import { useFocusTrap } from '@/composables/useFocusTrap';
 import { usePlayer } from '@/composables/usePlayer';
 import { useScrollLock } from '@/composables/useScrollLock';
+import { useSwipeDismiss } from '@/composables/useSwipeDismiss';
 import type { AudioTrack } from '@/types/audio';
 
 const { status, currentTrack, queue, currentTime, duration, context, hasNext, hasPrevious, toggle, next, previous, seek, select, collapse } =
@@ -22,6 +23,7 @@ const dialog = ref<HTMLElement | null>(null);
 const { onKeydown: trapTab } = useFocusTrap(dialog);
 const { lock, unlock } = useScrollLock();
 const { capture, restore } = useFocusReturn();
+const { handleTouchStart, handleTouchEnd } = useSwipeDismiss(collapse, () => (dialog.value?.scrollTop ?? 0) <= 0);
 
 const onKeydown = (event: KeyboardEvent): void => {
   if (event.key === 'Escape') {
@@ -53,6 +55,8 @@ onBeforeUnmount(() => {
     aria-label="Now playing"
     tabindex="-1"
     @keydown="onKeydown"
+    @touchstart.passive="handleTouchStart"
+    @touchend.passive="handleTouchEnd"
   >
     <button
       type="button"

--- a/src/composables/useSwipeDismiss.test.ts
+++ b/src/composables/useSwipeDismiss.test.ts
@@ -1,0 +1,104 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Component, defineComponent } from 'vue';
+
+import { useSwipeDismiss } from './useSwipeDismiss';
+
+function createTestComponent(onDismiss: () => void, isAtTop: () => boolean): Component {
+  return defineComponent({
+    setup() {
+      return { ...useSwipeDismiss(onDismiss, isAtTop) };
+    },
+    template: '<div></div>',
+  });
+}
+
+function createTouchEvent(type: 'touchstart' | 'touchend', clientX: number, clientY: number): TouchEvent {
+  const touch = { clientX, clientY, identifier: 0 };
+  const touchList = [touch as Touch];
+
+  const event = new Event(type) as TouchEvent;
+  Object.defineProperty(event, type === 'touchstart' ? 'touches' : 'changedTouches', {
+    value: touchList,
+    writable: false,
+  });
+
+  return event;
+}
+
+describe('useSwipeDismiss', () => {
+  let onDismiss: ReturnType<typeof vi.fn>;
+  let dateNowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    onDismiss = vi.fn();
+    dateNowSpy = vi.spyOn(Date, 'now');
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+  });
+
+  const swipe = (
+    isAtTop: () => boolean,
+    from: [number, number],
+    to: [number, number],
+    elapsed = 200,
+  ): void => {
+    const wrapper = mount(createTestComponent(onDismiss, isAtTop));
+
+    dateNowSpy.mockReturnValueOnce(1000);
+    wrapper.vm.handleTouchStart(createTouchEvent('touchstart', from[0], from[1]));
+
+    dateNowSpy.mockReturnValueOnce(1000 + elapsed);
+    wrapper.vm.handleTouchEnd(createTouchEvent('touchend', to[0], to[1]));
+  };
+
+  it('dismisses on a fast downward swipe that starts at the top', () => {
+    swipe(() => true, [200, 100], [200, 200]);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('ignores the swipe when the sheet is not scrolled to the top', () => {
+    swipe(() => false, [200, 100], [200, 200]);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('ignores upward swipes', () => {
+    swipe(() => true, [200, 200], [200, 100]);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('ignores horizontal-dominant swipes', () => {
+    swipe(() => true, [100, 100], [220, 190]);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('ignores swipes shorter than the dismiss threshold', () => {
+    swipe(() => true, [200, 100], [200, 170]);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('ignores a swipe exactly at the threshold (not greater)', () => {
+    swipe(() => true, [200, 100], [200, 180]);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('ignores slow swipes', () => {
+    swipe(() => true, [200, 100], [200, 200], 350);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when a touch is missing', () => {
+    const wrapper = mount(createTestComponent(onDismiss, () => true));
+
+    const start = new Event('touchstart') as TouchEvent;
+    Object.defineProperty(start, 'touches', { value: [], writable: false });
+    const end = new Event('touchend') as TouchEvent;
+    Object.defineProperty(end, 'changedTouches', { value: [], writable: false });
+
+    expect(() => wrapper.vm.handleTouchStart(start)).not.toThrow();
+    expect(() => wrapper.vm.handleTouchEnd(end)).not.toThrow();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/useSwipeDismiss.ts
+++ b/src/composables/useSwipeDismiss.ts
@@ -1,0 +1,51 @@
+import { TOUCH } from '@/utils/constants';
+
+export interface UseSwipeDismissReturn {
+  handleTouchStart: (event: TouchEvent) => void;
+  handleTouchEnd: (event: TouchEvent) => void;
+}
+
+interface TouchOrigin {
+  x: number;
+  y: number;
+  time: number;
+  atTop: boolean;
+}
+
+export const useSwipeDismiss = (
+  onDismiss: () => void,
+  isAtTop: () => boolean,
+): UseSwipeDismissReturn => {
+  let origin: TouchOrigin = { x: 0, y: 0, time: 0, atTop: false };
+
+  const handleTouchStart = (event: TouchEvent): void => {
+    const touch = event.touches[0];
+    if (!touch) return;
+
+    origin = {
+      x: touch.clientX,
+      y: touch.clientY,
+      time: Date.now(),
+      atTop: isAtTop(),
+    };
+  };
+
+  const handleTouchEnd = (event: TouchEvent): void => {
+    const touch = event.changedTouches[0];
+    if (!touch) return;
+
+    const deltaX = touch.clientX - origin.x;
+    const deltaY = touch.clientY - origin.y;
+    const deltaTime = Date.now() - origin.time;
+
+    const isVerticalSwipe = Math.abs(deltaY) > Math.abs(deltaX);
+    const isDownwardPastThreshold = deltaY > TOUCH.MIN_DISMISS_DISTANCE;
+    const isValidSpeed = deltaTime < TOUCH.MAX_SWIPE_TIME;
+
+    if (origin.atTop && isVerticalSwipe && isDownwardPastThreshold && isValidSpeed) {
+      onDismiss();
+    }
+  };
+
+  return { handleTouchStart, handleTouchEnd };
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,6 +20,7 @@ export const ID_PREFIX = {
 
 export const TOUCH = {
   MIN_SWIPE_DISTANCE: 50,
+  MIN_DISMISS_DISTANCE: 80,
   MAX_SWIPE_TIME: 300,
 } as const;
 


### PR DESCRIPTION
## Description
Adds a swipe-down-to-collapse gesture to the expanded now-playing screen, the mobile-native way to dismiss a bottom sheet. v1 = threshold flick (chosen over the interactive drag-follow for scope/risk).

## How it works
- New **`useSwipeDismiss(onDismiss, isAtTop)`** — mirrors the existing `useSwipeNavigation` shape (`handleTouchStart`/`handleTouchEnd`, reuses `TOUCH.*`). It fires `onDismiss` only when **all** hold: the gesture started with the sheet **scrolled to the top**, the swipe is **downward**, **vertical-dominant** (`|Δy| > |Δx|`), past the **`MIN_DISMISS_DISTANCE` (80px)** threshold, and within `MAX_SWIPE_TIME` (300ms).
- Wired into `PlayerScreen` on its root (which is both the scroll container and the `dialog` ref): `@touchstart.passive` / `@touchend.passive` → `collapse()`. The existing `player-slide` leave transition animates the dismissal — no new animation code.

## Why the scroll-top guard
`.player-screen` is `overflow-y: auto` (art + meta + seek + controls + queue can exceed the viewport). Dismissing only when `scrollTop === 0` at gesture start is the iOS bottom-sheet convention — mid-scroll flicks scroll the content, they don't dismiss. `isAtTop` is read at `touchstart`.

## No regressions
- The chevron button and Escape still collapse (desktop/keyboard untouched).
- Handlers are **passive** (we never `preventDefault`), so native scrolling is unaffected.
- Touch events only fire on touch devices — inherently mobile, no desktop behaviour change.
- `prefers-reduced-motion` still collapses (the transition already no-ops under it).

## Testing
- `npm run lint` / `type-check` — clean
- `npx vitest run` — **659/659**. New: 8 `useSwipeDismiss` unit tests (at-top dismiss, not-at-top guard, upward / horizontal / below-threshold / slow rejections, missing-touch safety) + 2 `PlayerScreen` integration tests (swipe-from-top collapses; scrolled sheet does not).
- coverage — above all thresholds · `npm run build` — OK

### Manual mobile smoke (please verify on a device — the feel can't be unit-tested)
1. Play a release, expand the player. At the top of the sheet, **flick down** → it collapses to the docked bar with the slide animation.
2. Scroll the queue down, then flick down → it **scrolls**, does not dismiss. Only a flick from the very top dismisses.
3. A slow drag down, or a short nudge (<80px), does nothing. Dragging the seek slider (horizontal) never dismisses.

## Note
Chosen v1 (threshold flick). If you want the premium **drag-follow** feel later (sheet tracks the finger, springs back below threshold), that's a self-contained follow-up on top of this.