### PR TITLE
Refcount useScrollLock + make it iOS-safe

### DIFF
--- a/src/composables/useLightbox.test.ts
+++ b/src/composables/useLightbox.test.ts
@@ -1,5 +1,5 @@
-import { mount } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { enableAutoUnmount, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type Component, defineComponent } from 'vue';
 
 import type { LightboxItem } from '@/types/lightbox';
@@ -38,6 +38,8 @@ const mockVideos: LightboxItem[] = [
 ];
 
 describe('useLightbox', () => {
+  enableAutoUnmount(afterEach);
+
   beforeEach(() => {
     document.body.style.overflow = OVERFLOW_DEFAULT;
     vi.clearAllMocks();

--- a/src/composables/useScrollLock.test.ts
+++ b/src/composables/useScrollLock.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent } from 'vue';
 
 import { useScrollLock } from './useScrollLock';
@@ -20,31 +20,76 @@ const mountWithScrollLock = () => {
 
 describe('useScrollLock', () => {
   afterEach(() => {
-    document.body.style.overflow = '';
+    const { style } = document.body;
+    style.position = '';
+    style.top = '';
+    style.left = '';
+    style.right = '';
+    style.overflow = '';
   });
 
   it('starts with body scroll unlocked', () => {
     mountWithScrollLock();
+    expect(document.body.style.position).toBe('');
     expect(document.body.style.overflow).toBe('');
   });
 
-  it('locks and unlocks body scroll', () => {
+  it('locks with a fixed body and releases it on unlock', () => {
     const { api } = mountWithScrollLock();
 
     api.lock();
+    expect(document.body.style.position).toBe('fixed');
     expect(document.body.style.overflow).toBe('hidden');
 
     api.unlock();
+    expect(document.body.style.position).toBe('');
     expect(document.body.style.overflow).toBe('');
+  });
+
+  it('is idempotent — a second unlock without a lock is a no-op', () => {
+    const { api } = mountWithScrollLock();
+
+    expect(() => api.unlock()).not.toThrow();
+    expect(document.body.style.position).toBe('');
+  });
+
+  it('refcounts across consumers — stays locked until the last releases', () => {
+    const first = mountWithScrollLock();
+    const second = mountWithScrollLock();
+
+    first.api.lock();
+    second.api.lock();
+    expect(document.body.style.position).toBe('fixed');
+
+    first.api.unlock();
+    expect(document.body.style.position).toBe('fixed');
+
+    second.api.unlock();
+    expect(document.body.style.position).toBe('');
+  });
+
+  it('preserves and restores the scroll position', () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 240 });
+    const { api } = mountWithScrollLock();
+
+    api.lock();
+    expect(document.body.style.top).toBe('-240px');
+
+    api.unlock();
+    expect(scrollTo).toHaveBeenCalledWith(0, 240);
+
+    scrollTo.mockRestore();
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 });
   });
 
   it('releases the lock automatically on unmount', () => {
     const { wrapper, api } = mountWithScrollLock();
 
     api.lock();
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
 
     wrapper.unmount();
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
   });
 });

--- a/src/composables/useScrollLock.ts
+++ b/src/composables/useScrollLock.ts
@@ -5,13 +5,49 @@ interface UseScrollLockReturn {
   unlock: () => void;
 }
 
+let lockCount = 0;
+let savedScrollY = 0;
+
+const applyLock = (): void => {
+  savedScrollY = window.scrollY;
+
+  const { style } = document.body;
+  // position: fixed (not overflow: hidden alone) so iOS Safari actually holds still.
+  style.position = 'fixed';
+  style.top = `-${savedScrollY}px`;
+  style.left = '0';
+  style.right = '0';
+  style.overflow = 'hidden';
+};
+
+const releaseLock = (): void => {
+  const { style } = document.body;
+  style.position = '';
+  style.top = '';
+  style.left = '';
+  style.right = '';
+  style.overflow = '';
+
+  window.scrollTo(0, savedScrollY);
+};
+
 export const useScrollLock = (): UseScrollLockReturn => {
+  let isLocked = false;
+
   const lock = (): void => {
-    document.body.style.overflow = 'hidden';
+    if (isLocked) return;
+
+    isLocked = true;
+    if (lockCount === 0) applyLock();
+    lockCount += 1;
   };
 
   const unlock = (): void => {
-    document.body.style.overflow = '';
+    if (!isLocked) return;
+
+    isLocked = false;
+    lockCount -= 1;
+    if (lockCount === 0) releaseLock();
   };
 
   onUnmounted(unlock);


### PR DESCRIPTION
## Description
Fixes finding #1 from the objective audit — two real defects in `useScrollLock`, flagged independently by the architecture and accessibility reviews.

## The bugs
1. **No refcount.** Three overlays lock body scroll independently — `useOverlay` (command palette + help), `useLightbox`, `PlayerScreen`. The palette is a global ⌘K hotkey that opens *over* an already-expanded player; both call `lock()`, and closing the palette called `unlock()`, clearing the lock while the player was still open (last-writer-wins).
2. **iOS Safari ignores `overflow: hidden` on `body`.** The page behind every overlay still scrolled and rubber-banded on iPhone.

## Fix
- Each `useScrollLock()` instance is now **idempotent** (holds at most one lock), with a **module-level refcount**: the body is locked when the first consumer locks and released only when the last unlocks. This also makes the existing double-`unlock()` (on close *and* on unmount) safe.
- The lock uses **`position: fixed` + captured scroll offset**, restoring scroll on release — the standard iOS-safe pattern — instead of `overflow: hidden` alone.

## Testing
- `useScrollLock.test.ts` rewritten: fixed-body lock, idempotent unlock, **refcount across two consumers** (stays locked until the last releases), scroll capture/restore, auto-release on unmount.
- `useLightbox.test.ts`: added `enableAutoUnmount` so its wrappers unmount between tests — required now that the refcount is module-global (was leaking state); no assertions changed.
- `npm run lint` / `type-check` — clean · `npx vitest run` — **662/662** · `npm run build` — OK
- Not in any VR snapshot (overlays aren't captured on static routes), so CI VR stays green.

### Manual smoke (iOS especially)
1. iPhone: open the expanded player, then the ⌘K palette isn't reachable without a keyboard — instead open the **lightbox** (Live → Photos) and confirm the page behind it does **not** scroll/rubber-band, and that scroll position is preserved after closing.
2. Desktop: expand the player, open ⌘K over it, close the palette → the player is still open and the page is still scroll-locked (previously it unlocked).