### PR TITLE
Harden the contact Worker + credit-link rendering

### DIFF
--- a/src/utils/renderCredits.test.ts
+++ b/src/utils/renderCredits.test.ts
@@ -38,4 +38,25 @@ describe('renderCredits', () => {
   it('strips markers for indexing', () => {
     expect(plainCredits('Art by [[Lia]] and Dextro.')).toBe('Art by Lia and Dextro.');
   });
+
+  it('drops a non-http(s)/mailto url and renders the name plain', () => {
+    const credits = renderCredits('Art by [[X]].', [{ name: 'X', url: 'javascript:alert(1)' }]);
+
+    expect(credits).toBe('Art by X.');
+    expect(credits).not.toContain('<a');
+  });
+
+  it('escapes an attribute-breaking url so it cannot inject markup', () => {
+    const credits = renderCredits('Art by [[X]].', [{ name: 'X', url: 'https://x.test/"><img src=x onerror=alert(1)>' }]);
+
+    // No attribute breakout — the quote/brackets are escaped, so the payload stays inert text inside href.
+    expect(credits).not.toContain('"><img');
+    expect(credits).toContain('&quot;&gt;&lt;img');
+  });
+
+  it('escapes markup in the marker name', () => {
+    const credits = renderCredits('Art by [[<script>]].', [{ name: '<script>', url: 'https://x.test/' }]);
+
+    expect(credits).toBe('Art by <a href="https://x.test/">&lt;script&gt;</a>.');
+  });
 });

--- a/src/utils/renderCredits.ts
+++ b/src/utils/renderCredits.ts
@@ -1,6 +1,25 @@
 import type { Contributor } from '@/types/common';
 
 const MARKER = /\[\[([^\]]+)\]\]/g;
+const SAFE_SCHEME = /^(?:https?:|mailto:)/i;
+
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, character => HTML_ESCAPES[character] ?? character);
+
+// The data is author-controlled, but escape + scheme-allowlist so a stray
+// javascript:/attribute-breaking url can never render as a live link.
+const safeHref = (url: string): string | null => {
+  const trimmed = url.trim();
+  return SAFE_SCHEME.test(trimmed) ? escapeHtml(trimmed) : null;
+};
 
 export const renderCredits = (credits: string, contributors: Contributor[] = []): string => {
   const linked = new Map<string, string>();
@@ -10,8 +29,9 @@ export const renderCredits = (credits: string, contributors: Contributor[] = [])
   }
 
   return credits.replace(MARKER, (_match, name: string) => {
-    const url = linked.get(name);
-    return url ? `<a href="${url}">${name}</a>` : name;
+    const href = linked.has(name) ? safeHref(linked.get(name) as string) : null;
+    const safeName = escapeHtml(name);
+    return href ? `<a href="${href}">${safeName}</a>` : safeName;
   });
 };
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vitest/config';
-import vue from '@vitejs/plugin-vue';
 import { fileURLToPath } from 'node:url';
+
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [vue()],
@@ -12,6 +13,8 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       '**/e2e/**',
+      // The Worker targets the Cloudflare Workers runtime, not happy-dom — it has its own vitest.
+      '**/worker/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,playwright}.config.*',
     ],

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -84,6 +84,28 @@ describe('contact worker', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects a request from a disallowed origin before doing anything', async () => {
+    const response = await worker.fetch(postRequest(VALID_BODY, 'https://evil.example'), ENV);
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long message before verifying', async () => {
+    const response = await worker.fetch(postRequest({ ...VALID_BODY, message: 'x'.repeat(5001) }), ENV);
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects too many extra fields', async () => {
+    const fields = Array.from({ length: 21 }, (_unused, index) => ({ label: `L${index}`, value: 'v' }));
+    const response = await worker.fetch(postRequest({ ...VALID_BODY, fields }), ENV);
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('rejects a failed Turnstile verification without sending', async () => {
     fetchMock.mockResolvedValueOnce(turnstileResult(false));
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -23,6 +23,16 @@ interface ContactPayload {
 
 const REQUIRED_KEYS = ['token', 'inquiry', 'name', 'email', 'message'] as const;
 
+const MAX_LENGTHS = {
+  name: 200,
+  email: 254,
+  inquiry: 100,
+  message: 5000,
+  fieldValue: 1000,
+} as const;
+
+const MAX_FIELDS = 20;
+
 const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 const RESEND_SEND_URL = 'https://api.resend.com/emails';
 
@@ -37,8 +47,7 @@ const HTML_ENTITIES: Record<string, string> = {
 const escapeHtml = (value: string): string =>
   value.replace(/[&<>"']/g, character => HTML_ENTITIES[character] ?? character);
 
-const corsHeaders = (origin: string | null, env: Env): Record<string, string> => {
-  const allowed = env.ALLOWED_ORIGINS.split(',').map(entry => entry.trim());
+const corsHeaders = (origin: string | null, allowed: string[]): Record<string, string> => {
   const allowOrigin = origin && allowed.includes(origin) ? origin : (allowed[0] ?? '');
 
   return {
@@ -57,6 +66,16 @@ const jsonResponse = (body: unknown, status: number, headers: Record<string, str
 
 const firstMissingKey = (payload: ContactPayload): string | null =>
   REQUIRED_KEYS.find(key => String(payload[key] ?? '').trim() === '') ?? null;
+
+const firstOversizedKey = (payload: ContactPayload): string | null => {
+  if (payload.name.length > MAX_LENGTHS.name) return 'name';
+  if (payload.email.length > MAX_LENGTHS.email) return 'email';
+  if (payload.inquiry.length > MAX_LENGTHS.inquiry) return 'inquiry';
+  if (payload.message.length > MAX_LENGTHS.message) return 'message';
+  if ((payload.fields?.length ?? 0) > MAX_FIELDS) return 'fields';
+  if (payload.fields?.some(field => (field.value?.length ?? 0) > MAX_LENGTHS.fieldValue)) return 'fields';
+  return null;
+};
 
 const detailRows = (payload: ContactPayload): [string, string][] => [
   ['Inquiry', payload.inquiry],
@@ -121,7 +140,9 @@ const sendEmail = async (payload: ContactPayload, env: Env): Promise<boolean> =>
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const cors = corsHeaders(request.headers.get('Origin'), env);
+    const origin = request.headers.get('Origin');
+    const allowedOrigins = env.ALLOWED_ORIGINS.split(',').map(entry => entry.trim()).filter(Boolean);
+    const cors = corsHeaders(origin, allowedOrigins);
 
     if (request.method === 'OPTIONS') {
       return new Response(null, { status: 204, headers: cors });
@@ -129,6 +150,12 @@ export default {
 
     if (request.method !== 'POST') {
       return jsonResponse({ error: 'Method not allowed' }, 405, cors);
+    }
+
+    // A browser that sends a disallowed Origin is rejected outright; CORS headers alone
+    // don't stop the request reaching here. Origin-less (script) clients still face Turnstile.
+    if (origin !== null && !allowedOrigins.includes(origin)) {
+      return jsonResponse({ error: 'Origin not allowed' }, 403, cors);
     }
 
     let payload: ContactPayload;
@@ -145,6 +172,11 @@ export default {
     const missing = firstMissingKey(payload);
     if (missing) {
       return jsonResponse({ error: `Missing required field: ${missing}` }, 400, cors);
+    }
+
+    const oversized = firstOversizedKey(payload);
+    if (oversized) {
+      return jsonResponse({ error: `Field too long: ${oversized}` }, 400, cors);
     }
 
     try {


### PR DESCRIPTION
## Description
Fixes the security findings from the audit — converting two "trust me" assumptions into enforced boundaries. Defense-in-depth; nothing here is currently exploitable, but each closes a latent hole.

## Changes
### Contact Worker (`worker/src/index.ts`)
- **Origin rejection.** A POST whose `Origin` isn't in `ALLOWED_ORIGINS` now gets a `403` before any work. Previously `corsHeaders` silently normalized a disallowed origin to `allowed[0]`, so CORS gave a false sense of access control (it never stops the request reaching the handler). Origin-less/script clients still face Turnstile.
- **Length caps.** `name` (200), `email` (254), `inquiry` (100), `message` (5000), each field value (1000), and the field count (20) are enforced with a `400`. Prevents one solved Turnstile from relaying a multi-megabyte email or hundreds of rows to the inbox.

### Credit rendering (`src/utils/renderCredits.ts`)
- Escape the marker **name** and the **href**, and **allowlist the URL scheme** (`http:`/`https:`/`mailto:`). A `contributor.url` of `javascript:…` now renders as plain text (no link), and an attribute-breaking url (`https://x/"><img onerror=…>`) is escaped inert — no attribute breakout. **No-op on all current data** (the credits golden test is unchanged), so it's pure future-proofing for the day this content becomes semi-external.

### Test config
- Excluded `worker/**` from the **root** vitest. The Worker targets the Cloudflare Workers runtime, not happy-dom (which strips the `Origin` header) — it was being run in both, coincidentally passing until the new origin test. It runs under its own `worker/` vitest + the CI Worker job.

## Testing
- Root: **651** pass, coverage above thresholds. Worker: **14** pass under its own runner (added: disallowed-origin `403`, over-long message `400`, too-many-fields `400`). renderCredits: added `javascript:`-drop, attribute-breakout-escape, and name-escaping tests.
- `npm run lint` / `type-check` (app + worker) — clean · `npm run build` — OK

## NOT included — rate limiting (needs your Cloudflare account)
The audit also flagged "no rate limit." A per-IP throttle needs a Cloudflare resource I can't provision — either a KV namespace or the native Workers rate-limit binding — and a `wrangler.toml` binding. Length caps + origin rejection shrink the blast radius a lot; a rate limit is the remaining throttle. I can wire the binding + code once you decide which and create it. Also note: the Worker deploys separately (`cd worker && npm run deploy`) — merging this doesn't push it live.